### PR TITLE
Version and top-level functions

### DIFF
--- a/build.ocp2
+++ b/build.ocp2
@@ -1,3 +1,7 @@
+(* Version of the Liquidity compiler *)
+
+version = "1.0";
+
 (* Disable to compile without the sources of Tezos.
    The following features with be disabled:
    * Decompilation of Michelson files

--- a/tests/test11.liq
+++ b/tests/test11.liq
@@ -1,7 +1,7 @@
 
 (* strings *)
 
-(* let version = "1.0" *)
+let version = 1.0
 
 let contract
       (parameter : string)

--- a/tests/test16_ext.liq
+++ b/tests/test16_ext.liq
@@ -1,0 +1,11 @@
+let version = 1.0
+
+let f = fun ( arg : unit * int ) ->
+  arg.(0)
+
+let contract
+      (parameter : int)
+      (storage : unit)
+      (return : unit) =
+  let storage = Lambda.pipe (storage, parameter) f in
+  ( (), storage )

--- a/tools/liquidity/build.ocp2
+++ b/tools/liquidity/build.ocp2
@@ -58,7 +58,9 @@ OCaml.library("ocplib-liquidity",
 
 OCaml.library("ocplib-liquidity-ocaml",
    ocaml + {
+     version = version;
      files = [
+       "version.ml", {ocp2ml=true};
        "liquidFromOCaml.ml";
        "liquidToOCaml.ml";
      ];


### PR DESCRIPTION
#### Ask for a specific version of the liquidity compiler:

```ocaml
let version = 1.0

let contract ....
```

#### Define top-level functions for use in contract:

```ocaml
let f = fun ( arg : unit * int ) -> arg.(0)

let g = fun (x:int) -> x + 1

let contract
      (parameter : int)
      (storage : unit)
      (return : unit) =
  let storage = Lambda.pipe (storage, Lambda.pipe parameter g) f in
  ( (), storage )
```

is equivalent to

```ocaml
let contract
      (parameter : int)
      (storage : unit)
      (return : unit) =
  let f = fun ( arg : unit * int ) -> arg.(0) in
  let g = fun (x:int) -> x + 1 in
  let storage = Lambda.pipe (storage, Lambda.pipe parameter g) f in
  ( (), storage )
```