### PR TITLE
Better support for timestamps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ NTESTS=18
 SIMPLE_TESTS= `seq -f 'test%.0f' 0 $(NTESTS)`
 MORE_TESTS=test_ifcons test_if test_loop test_option test_transfer test_left \
   test_extfun test_left_constr test_closure test_closure2 test_closure3 \
-  test_map test_rev test_reduce_closure
+  test_map test_rev test_reduce_closure test_map_closure
 OTHER_TESTS=others/broker others/demo others/auction
 REV_TESTS=`seq -f  'test%.0f' 0 5`
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ NTESTS=18
 SIMPLE_TESTS= `seq -f 'test%.0f' 0 $(NTESTS)`
 MORE_TESTS=test_ifcons test_if test_loop test_option test_transfer test_left \
   test_extfun test_left_constr test_closure test_closure2 test_closure3 \
-  test_map test_rev
+  test_map test_rev test_reduce_closure
 OTHER_TESTS=others/broker others/demo others/auction
 REV_TESTS=`seq -f  'test%.0f' 0 5`
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ NTESTS=18
 SIMPLE_TESTS= `seq -f 'test%.0f' 0 $(NTESTS)`
 MORE_TESTS=test_ifcons test_if test_loop test_option test_transfer test_left \
   test_extfun test_left_constr test_closure test_closure2 test_closure3 \
-  test_map test_rev test_reduce_closure test_map_closure
+  test_map test_rev test_reduce_closure test_map_closure test_mapreduce_closure \
+  test_mapmap_closure test_setreduce_closure
 OTHER_TESTS=others/broker others/demo others/auction
 REV_TESTS=`seq -f  'test%.0f' 0 5`
 

--- a/docs/liquidity.md
+++ b/docs/liquidity.md
@@ -173,6 +173,12 @@ As in Michelson, there are different types of integers:
     a `tz` suffix (`1.00tz`, etc.) or as a string with type coercion
     (`("1.00" : tez)`).
 
+Timestamps are written in ISO 8601 format or integer seconds since epoch, the
+following are equivalent:
+* `("2015-12-01T10:01:00+01:00" : timestamp)`
+* `("1448960460" : timestamp)`
+* `(1448960460 : timestamp)`
+
 There are also three types of collections: lists, sets and
 maps. Constants collections can be created directly:
 * Lists: `["x";"y"]`;

--- a/docs/liquidity.md
+++ b/docs/liquidity.md
@@ -303,8 +303,7 @@ Functions and Closures
 Unlike Michelson, functions in Liquidity can also be closures. They can take
 multiple arguments and are curryfied. Because closures are lambda-lifted, it is
 however recommended to use a single tuple argument when possible.  Arguments
-must be annotated with their (monomorphic) type. Primitive functions such as
-`List.map` do not accept closures as their first arguments at the moment.
+must be annotated with their (monomorphic) type.
 
 Function applications are often done using the `Lambda.pipe` function
 or the `|>` operator:

--- a/tests/build.ocp2
+++ b/tests/build.ocp2
@@ -39,13 +39,24 @@ OCaml.library("ocplib-liquidity-examples",
                   "test_option.liq";
                   "test_right_constr.liq";
                   "test_transfer.liq";
-          ];
+                  "test_closure.liq";
+                  "test_closure2.liq";
+                  "test_closure3.liq";
+                  "test_map.liq";
+                  "test_rev.liq";
+                  "test_reduce_closure.liq";
+                  "test_map_closure.liq";
+                  "test_mapreduce_closure.liq";
+                  "test_mapmap_closure.liq";
+                  "test_setreduce_closure.liq";
+         ];
        };
 
        "liquidTestOthers.ml", {
          file2string = [
                   "others/demo.liq";
                   "others/broker.liq";
+                  "others/auction.liq";
           ];
        };
 

--- a/tests/test_map_closure.liq
+++ b/tests/test_map_closure.liq
@@ -1,0 +1,11 @@
+(* List.map with closure *)
+
+let version = 1.0
+
+let%entry main
+      (parameter : int)
+      (storage : int list)
+      [%return : unit] =
+  let add_param (x : int) = x + parameter in
+  let l = List.map add_param storage in
+  ( (), l )

--- a/tests/test_mapmap_closure.liq
+++ b/tests/test_mapmap_closure.liq
@@ -1,0 +1,12 @@
+let%entry main
+  (parameter : string)
+  (storage : (string, tez) map)
+  [%return : (string, bool) map] =
+
+  let amount = Current.amount() in
+  let f (arg: (string * tez)) =
+    arg.(1) + amount > 5.0tz
+  in
+
+  let m = Map.map f storage in
+  (m, storage)

--- a/tests/test_mapreduce_closure.liq
+++ b/tests/test_mapreduce_closure.liq
@@ -1,0 +1,13 @@
+let%entry main
+  (parameter : string)
+  (storage : (string, tez) map)
+  [%return : bool] =
+
+  let amount = Current.amount() in
+  let f (arg: (string * tez) * bool) =
+    if arg.(0).(1) + amount > 5.0tz then true
+    else arg.(1)
+  in
+
+  let b = Map.reduce f storage false in
+  (b, storage)

--- a/tests/test_reduce_closure.liq
+++ b/tests/test_reduce_closure.liq
@@ -1,0 +1,16 @@
+(* loops *)
+
+let version = 1.0
+
+let%entry main
+    (parameter : int list)
+    (storage : int)
+    [%return : unit] =
+
+  let c = 1 in
+
+  let f (x: (int * int)) = x.(1) + c + x.(0) in
+
+  let storage = List.reduce f parameter 0 in
+
+  ( (), storage )

--- a/tests/test_setreduce_closure.liq
+++ b/tests/test_setreduce_closure.liq
@@ -1,0 +1,13 @@
+let%entry main
+  (parameter : string)
+  (storage : tez set)
+  [%return : bool] =
+
+  let amount = Current.amount() in
+  let f (arg: tez * bool) =
+    if arg.(0) + amount > 5.0tz then true
+    else arg.(1)
+  in
+
+  let b = Set.reduce f storage false in
+  (b, storage)

--- a/tools/liquidity/with-tezos/liquidToTezos.ml
+++ b/tools/liquidity/with-tezos/liquidToTezos.ml
@@ -61,6 +61,7 @@ let rec convert_const expr =
     |CKey _|
    | CSignature _|CLeft _|CRight _)
             *)
+  | CTimestamp s -> Script_repr.String (0, s)
   | _ ->
     LiquidLoc.raise_error "to-tezos: unimplemented const:\n%s%!"
       (LiquidPrinter.Michelson.string_of_const expr)


### PR DESCRIPTION
Timestamps can be written in ISO 8601 format or integer seconds since epoch, the
following are equivalent:
* `("2015-12-01T10:01:00+01:00" : timestamp)`
* `("1448960460" : timestamp)`
* `(1448960460 : timestamp)`
