### PR TITLE
Return type like in OCaml

### DIFF
--- a/docs/liquidity.md
+++ b/docs/liquidity.md
@@ -27,7 +27,7 @@ All the contracts have the following form:
 let%entry main
       (parameter : TYPE)
       (storage : TYPE)
-      [%return : TYPE] =
+      : TYPE =
       BODY
 ```
 
@@ -40,17 +40,17 @@ network.
 The `main` function is the default entry point for the contract.
 `let%entry` is the construct used to declare entry points (there is
 currently only one entry point, but there will be probably more in the
-future).  The declaration takes three parameters with names
-`parameter`, `storage` and `return`. The first two parameters,
-`parameter` and `storage` are arguments to the function, while the
-latest one, `return`, is only used to specified the return type of the
-function. The types of the three parameters must always be specified.
+future).  The declaration takes two parameters with names
+`parameter`, `storage`, the arguments to the function. Their types must
+always be specified. The return type of the function must also be
+specified by a type annotation.
 
 A contract always returns a pair `(return, storage)`, where `return`
 is the return value to the caller, and `storage` is the final state of
 the contract after the call. The type of the pair must match the type
-of a pair with the two parameters, `return` and `storage`, that were
-specified at the beginning of `main`.
+of a pair where the first component is the return type of the function
+specified in its signature and the second is the type of the argument
+`storage` of `main`.
 
 <... local declarations ...> is an optional set of optional type and
 function declarations. Type declarations can be used to define records

--- a/tests/others/auction.liq
+++ b/tests/others/auction.liq
@@ -11,7 +11,7 @@ type storage = {
 let%entry main
     (parameter : key)
     (storage : storage)
-    [%return : unit] =
+    : unit =
 
   (* Check if auction has ended *)
   if Current.time () > storage.auction_end then Current.fail ();

--- a/tests/others/broker.liq
+++ b/tests/others/broker.liq
@@ -13,7 +13,7 @@ type storage = {
 let%entry main
       (parameter : timestamp)
       (storage : storage)
-      [%return : unit] =
+      : unit =
 
   if storage.state <> "open" then Current.fail ()
   else

--- a/tests/others/demo.liq
+++ b/tests/others/demo.liq
@@ -4,7 +4,7 @@
 let%entry main
   (parameter : string)
   (storage : (string, int) map)
-  [%return : unit] =
+  : unit =
 
   let amount = Current.amount() in
 

--- a/tests/others/morpion.liq
+++ b/tests/others/morpion.liq
@@ -9,7 +9,7 @@ type parameter = { play : bool; x : int; y : int }
 let contract
       ( storage : storage )
       ( parameter : parameter )
-      [%return : (bool option) option ]
+      : (bool option) option
   =
   let s = "This is a Tic Tac Toe game. Still work in progress" in
 

--- a/tests/test0.liq
+++ b/tests/test0.liq
@@ -9,5 +9,5 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : unit] =
+      : unit =
    ( (), storage )

--- a/tests/test1.liq
+++ b/tests/test1.liq
@@ -9,7 +9,7 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : (timestamp * tez) * (tez * timestamp) ] =
+      : (timestamp * tez) * (tez * timestamp) =
    let amount = Current.amount () in
    let x = (parameter, amount) in
    let y = (amount, parameter) in

--- a/tests/test10.liq
+++ b/tests/test10.liq
@@ -10,7 +10,7 @@ let%entry main
         int option *
         (string,int) map
       )
-      [%return : unit] =
+      : unit =
       
 (* options *)
       let x = 3 in

--- a/tests/test11.liq
+++ b/tests/test11.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : string)
       (storage : string)
-      [%return : unit] =
+      : unit =
       
 (* options *)
       let storage = if parameter = "" then

--- a/tests/test12.liq
+++ b/tests/test12.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : string)
       (storage : string set)
-      [%return : unit] =
+      : unit =
       
       let set = (Set : string set) in
       let set = Set.update "a" true set in

--- a/tests/test13.liq
+++ b/tests/test13.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : string)
       (storage : string list)
-      [%return : unit] =
+      : unit =
       
       let set = ([] : string list) in
       let set = "a" :: set in

--- a/tests/test14.liq
+++ b/tests/test14.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : int)
       (storage : int set)
-      [%return : unit] =
+      : unit =
 
       let x =
         Loop.loop (fun x ->

--- a/tests/test15.liq
+++ b/tests/test15.liq
@@ -12,7 +12,7 @@ type storage = {
 let%entry main
       (parameter : int)
       (storage : storage)
-      [%return : unit] =
+      : unit =
 
       let storage = storage.v.dest.z <- parameter in
       let storage = storage.v.orig <- { x="0"; y=true; z = parameter } in

--- a/tests/test16.liq
+++ b/tests/test16.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : int)
       (storage : unit)
-      [%return : unit] =
+      : unit =
   let f = fun ( arg : unit * int ) ->
     arg.(0)
   in

--- a/tests/test17.liq
+++ b/tests/test17.liq
@@ -7,7 +7,7 @@ type storage =
 let%entry main
       (parameter : int)
       (storage : storage)
-      [%return : unit] =
+      : unit =
   let _a = Nothing in
   let b = Int 3 in
   let c = String ("toto",0) in

--- a/tests/test18.liq
+++ b/tests/test18.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : int)
       (storage : nat)
-      [%return : int] =
+      : int =
 
   match int storage / parameter with
   | None -> ( 0, 0p)

--- a/tests/test2.liq
+++ b/tests/test2.liq
@@ -9,7 +9,7 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : (tez * tez) * (unit,unit) contract ] =
+      : (tez * tez) * (unit,unit) contract =
    let x = storage.(2) in
    let y = storage.(3) in
    ( (x,y), storage )

--- a/tests/test3.liq
+++ b/tests/test3.liq
@@ -9,7 +9,7 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : unit ] =
+      : unit =
    let s = get storage 0 in
    let storage = set storage 0 s in
    ( (), storage )

--- a/tests/test4.liq
+++ b/tests/test4.liq
@@ -9,6 +9,6 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : unit ] =
+      : unit =
    let storage = set storage 1 parameter in
    ( (), storage )

--- a/tests/test5.liq
+++ b/tests/test5.liq
@@ -9,7 +9,7 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : unit ] =
+      : unit  =
    let pn = get storage 2 in
    let p = get pn 0 in
    let p = p + 1tz in

--- a/tests/test6.liq
+++ b/tests/test6.liq
@@ -9,7 +9,7 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : unit ] =
+      : unit  =
    let pn = get storage 2 in
    let storage = set storage 2 pn in
    ( (), storage )

--- a/tests/test7.liq
+++ b/tests/test7.liq
@@ -5,7 +5,7 @@ let%entry main
       (parameter : timestamp)
       (storage : (tez * tez)  (* 2: P N *)
       )
-      [%return : int list] =
+      : int list =
 
       let p = get storage 0 in
       let n = get storage 1 in

--- a/tests/test8.liq
+++ b/tests/test8.liq
@@ -5,7 +5,7 @@ let%entry main
       (parameter : timestamp)
       (storage : tez * tez  (* 2: P N *)
       )
-      [%return : unit] =
+      : unit =
       let p = get storage 1 in
       let storage  = set storage 1 p in
       ( (), storage )

--- a/tests/test9.liq
+++ b/tests/test9.liq
@@ -12,7 +12,7 @@ let%entry main
         int set *
         int list
       )
-      [%return : unit] =
+      : unit =
 
 (* booleans *)
       let bool =

--- a/tests/test_closure.liq
+++ b/tests/test_closure.liq
@@ -4,7 +4,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      [%return : unit] =
+      : unit =
   let x = parameter + 10 in
   let f = fun ( arg : int * int ) ->
     arg.(1) + x

--- a/tests/test_closure2.liq
+++ b/tests/test_closure2.liq
@@ -4,7 +4,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      [%return : unit] =
+      : unit =
   let x = parameter + 10 in
   let f ( arg : int * int ) (y : int) =
     arg.(0) + x + y

--- a/tests/test_closure3.liq
+++ b/tests/test_closure3.liq
@@ -4,7 +4,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      [%return : unit] =
+      : unit =
   let x = parameter + 10 in
   let f ( arg : int * int ) (y : int) =
     0

--- a/tests/test_extfun.liq
+++ b/tests/test_extfun.liq
@@ -6,6 +6,6 @@ let f ( arg : unit * int ) = arg.(0)
 let%entry main
       (parameter : int)
       (storage : unit)
-      [%return : unit] =
+      : unit =
   let storage = f (storage, parameter) in
   ( (), storage )

--- a/tests/test_if.liq
+++ b/tests/test_if.liq
@@ -12,7 +12,7 @@ let%entry main
         int set *
         int list
       )
-      [%return : unit] =
+      : unit =
 
 (* booleans *)
       let bool =

--- a/tests/test_ifcons.liq
+++ b/tests/test_ifcons.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : string)
       (storage : string list)
-      [%return : unit] =
+      : unit =
       
       let a = "1" in
       let set = ([] : string list) in

--- a/tests/test_left.liq
+++ b/tests/test_left.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      [%return : unit] =
+      : unit =
   let a = (Left 3 : (_, string) variant) in
   let b = (Right a : (int, _) variant) in
 

--- a/tests/test_left_constr.liq
+++ b/tests/test_left_constr.liq
@@ -2,6 +2,6 @@
 let%entry main
       (parameter : int)
       (storage : (int, string) variant)
-      [%return : unit] =
+      : unit =
   let a = (Left parameter : (_, string) variant) in
   ( (), a )

--- a/tests/test_left_match.liq
+++ b/tests/test_left_match.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : (int, string) variant)
       (storage : int)
-      [%return : string] =
+      : string =
       
   match parameter with
   | Left left -> ("", left)

--- a/tests/test_loop.liq
+++ b/tests/test_loop.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      [%return : unit] =
+      : unit =
 
       let storage =
         Loop.loop (fun x ->

--- a/tests/test_map.liq
+++ b/tests/test_map.liq
@@ -7,7 +7,7 @@ let succ (x : int) = x + 1
 let%entry main
       (parameter : int)
       (storage : int list)
-      [%return : unit] =
+      : unit =
   let l = List.map succ storage in
   ( (), l)
 

--- a/tests/test_map_closure.liq
+++ b/tests/test_map_closure.liq
@@ -5,7 +5,7 @@
 let%entry main
       (parameter : int)
       (storage : int list)
-      [%return : unit] =
+      : unit =
   let add_param (x : int) = x + parameter in
   let l = List.map add_param storage in
   ( (), l )

--- a/tests/test_mapmap_closure.liq
+++ b/tests/test_mapmap_closure.liq
@@ -1,7 +1,8 @@
+[%%version 0.1]
 let%entry main
   (parameter : string)
   (storage : (string, tez) map)
-  [%return : (string, bool) map] =
+  : (string, bool) map =
 
   let amount = Current.amount() in
   let f (arg: (string * tez)) =

--- a/tests/test_mapreduce_closure.liq
+++ b/tests/test_mapreduce_closure.liq
@@ -1,7 +1,7 @@
 let%entry main
   (parameter : string)
   (storage : (string, tez) map)
-  [%return : bool] =
+  : bool =
 
   let amount = Current.amount() in
   let f (arg: (string * tez) * bool) =

--- a/tests/test_option.liq
+++ b/tests/test_option.liq
@@ -1,7 +1,7 @@
 let%entry main
   (parameter : int option)
   (storage : unit)
-  [%return : int] =
+  : int =
 
   let x = match parameter with
     | None -> 1

--- a/tests/test_reduce_closure.liq
+++ b/tests/test_reduce_closure.liq
@@ -5,7 +5,7 @@
 let%entry main
     (parameter : int list)
     (storage : int)
-    [%return : unit] =
+    : unit =
 
   let c = 1 in
 

--- a/tests/test_rev.liq
+++ b/tests/test_rev.liq
@@ -5,6 +5,6 @@
 let%entry main
       (parameter : int)
       (storage : int list)
-      [%return : unit] =
+      : unit =
   let l = List.rev storage in
   ( (), l )

--- a/tests/test_right_constr.liq
+++ b/tests/test_right_constr.liq
@@ -2,6 +2,6 @@
 let%entry main
       (parameter : string)
       (storage : (int, string) variant)
-      [%return : unit] =
+      : unit =
   let a = (Right parameter : (int, _) variant) in
   ( (), a )

--- a/tests/test_setreduce_closure.liq
+++ b/tests/test_setreduce_closure.liq
@@ -1,7 +1,7 @@
 let%entry main
   (parameter : string)
   (storage : tez set)
-  [%return : bool] =
+  : bool =
 
   let amount = Current.amount() in
   let f (arg: tez * bool) =

--- a/tests/test_transfer.liq
+++ b/tests/test_transfer.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : (unit,unit) contract)
       (storage : tez)
-      [%return : unit] =
+      : unit =
 
       let amount = Current.amount () in
       let storage = storage + amount in

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -721,17 +721,11 @@ let rec translate_head env ext_funs head_exp args =
             },
             head_exp) } ->
      translate_head env ext_funs head_exp
-                    ((arg, translate_type env arg_type) :: args)
+       ((arg, translate_type env arg_type) :: args)
 
-  | { pexp_desc =
-        Pexp_fun (
-            Nolabel, None,
-            { ppat_desc =
-                Ppat_extension ({ txt = "return"}, PTyp arg_type)
-            },
-            head_exp) } ->
-     translate_head env ext_funs head_exp
-                    (("return", translate_type env arg_type) :: args)
+  | { pexp_desc = Pexp_constraint (head_exp, return_type) } ->
+    translate_head env ext_funs head_exp
+      (("return", translate_type env return_type) :: args)
 
   | { pexp_desc =
         Pexp_fun (

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -319,12 +319,10 @@ let structure_of_contract contract =
                                    (Pat.var (loc "storage"))
                                    (convert_type contract.storage)
                                 )
-                      (Exp.fun_ Nolabel None
-                                (Pat.extension
-                                   (loc "return",
-                                   PTyp (convert_type contract.return))
-                                )
-                                code)))
+                      (Exp.constraint_
+                         code
+                         (convert_type contract.return))
+                      ))
               ]
   ])]
 

--- a/tools/liquidity/ocaml/liquidOCamlPrinter.ml
+++ b/tools/liquidity/ocaml/liquidOCamlPrinter.ml
@@ -1145,6 +1145,18 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; _} =
   let rec pp_print_pexp_function f x =
     if x.pexp_attributes <> [] then pp f "=@;%a" (expression ctxt) x
     else match x.pexp_desc with
+      | Pexp_fun (label, eo, p,
+                  { pexp_desc = Pexp_constraint (e, rty) }) ->
+          if label=Nolabel then
+            pp f "%a@ : %a@ %a"
+              (simple_pattern ctxt) p
+              (core_type ctxt) rty
+              pp_print_pexp_function e
+          else
+            pp f "%a@ : %a@ %a"
+              (label_exp ctxt) (label,eo,p)
+              (core_type ctxt) rty
+              pp_print_pexp_function e
       | Pexp_fun (label, eo, p, e) ->
           if label=Nolabel then
             pp f "%a@ %a" (simple_pattern ctxt) p pp_print_pexp_function e


### PR DESCRIPTION
Now:
```ocaml
let%entry main
    (storage : st)
    (parameter: p)
    : return_ty = ...
```
Used to be:
```ocaml
let%entry main
    (storage : st)
    (parameter: p)
    [%return : return_ty] = ...
```