### PR TITLE
Return type like in OCaml

### DIFF
--- a/build.ocp2
+++ b/build.ocp2
@@ -1,7 +1,3 @@
-(* Version of the Liquidity compiler *)
-
-version = "1.0";
-
 (* Disable to compile without the sources of Tezos.
    The following features with be disabled:
    * Decompilation of Michelson files

--- a/docs/liquidity.md
+++ b/docs/liquidity.md
@@ -27,7 +27,7 @@ All the contracts have the following form:
 let%entry main
       (parameter : TYPE)
       (storage : TYPE)
-      [%return : TYPE] =
+      : TYPE =
       BODY
 ```
 
@@ -40,17 +40,17 @@ network.
 The `main` function is the default entry point for the contract.
 `let%entry` is the construct used to declare entry points (there is
 currently only one entry point, but there will be probably more in the
-future).  The declaration takes three parameters with names
-`parameter`, `storage` and `return`. The first two parameters,
-`parameter` and `storage` are arguments to the function, while the
-latest one, `return`, is only used to specified the return type of the
-function. The types of the three parameters must always be specified.
+future).  The declaration takes two parameters with names
+`parameter`, `storage`, the arguments to the function. Their types must
+always be specified. The return type of the function must also be
+specified by a type annotation.
 
 A contract always returns a pair `(return, storage)`, where `return`
 is the return value to the caller, and `storage` is the final state of
 the contract after the call. The type of the pair must match the type
-of a pair with the two parameters, `return` and `storage`, that were
-specified at the beginning of `main`.
+of a pair where the first component is the return type of the function
+specified in its signature and the second is the type of the argument
+`storage` of `main`.
 
 <... local declarations ...> is an optional set of optional type and
 function declarations. Type declarations can be used to define records

--- a/docs/liquidity.md
+++ b/docs/liquidity.md
@@ -175,11 +175,11 @@ As in Michelson, there are different types of integers:
     a `tz` suffix (`1.00tz`, etc.) or as a string with type coercion
     (`("1.00" : tez)`).
 
-Timestamps are written in ISO 8601 format or integer seconds since epoch, the
-following are equivalent:
+Timestamps are written in ISO 8601 format, like in Michelson:
 * `("2015-12-01T10:01:00+01:00" : timestamp)`
-* `("1448960460" : timestamp)`
-* `(1448960460 : timestamp)`
+
+Keys and signatures constants are the same as the ones in Michelson:
+* `("tz1hxLtJnSYCVabeGio3M87Yp8ChLF9LFmCM" : key)`
 
 There are also three types of collections: lists, sets and
 maps. Constants collections can be created directly:

--- a/tests/others/auction.liq
+++ b/tests/others/auction.liq
@@ -11,7 +11,7 @@ type storage = {
 let%entry main
     (parameter : key)
     (storage : storage)
-    : unit =
+    : unit * storage =
 
   (* Check if auction has ended *)
   if Current.time () > storage.auction_end then Current.fail ();

--- a/tests/others/auction.liq
+++ b/tests/others/auction.liq
@@ -11,7 +11,7 @@ type storage = {
 let%entry main
     (parameter : key)
     (storage : storage)
-    [%return : unit] =
+    : unit =
 
   (* Check if auction has ended *)
   if Current.time () > storage.auction_end then Current.fail ();

--- a/tests/others/auction.liq
+++ b/tests/others/auction.liq
@@ -1,6 +1,6 @@
 (* Auction contract from https://www.michelson-lang.com/contract-a-day.html *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 type storage = {
   auction_end : timestamp;

--- a/tests/others/broker.liq
+++ b/tests/others/broker.liq
@@ -13,7 +13,7 @@ type storage = {
 let%entry main
       (parameter : timestamp)
       (storage : storage)
-      [%return : unit] =
+      : unit =
 
   if storage.state <> "open" then Current.fail ()
   else

--- a/tests/others/broker.liq
+++ b/tests/others/broker.liq
@@ -13,7 +13,7 @@ type storage = {
 let%entry main
       (parameter : timestamp)
       (storage : storage)
-      : unit =
+      : unit * storage =
 
   if storage.state <> "open" then Current.fail ()
   else

--- a/tests/others/broker.liq
+++ b/tests/others/broker.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 type storage = {
   state : string;

--- a/tests/others/demo.liq
+++ b/tests/others/demo.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
   (parameter : string)

--- a/tests/others/demo.liq
+++ b/tests/others/demo.liq
@@ -4,7 +4,7 @@
 let%entry main
   (parameter : string)
   (storage : (string, int) map)
-  [%return : unit] =
+  : unit =
 
   let amount = Current.amount() in
 

--- a/tests/others/demo.liq
+++ b/tests/others/demo.liq
@@ -4,7 +4,7 @@
 let%entry main
   (parameter : string)
   (storage : (string, int) map)
-  : unit =
+  : unit * (string, int) map =
 
   let amount = Current.amount() in
 

--- a/tests/others/morpion.liq
+++ b/tests/others/morpion.liq
@@ -9,7 +9,7 @@ type parameter = { play : bool; x : int; y : int }
 let contract
       ( storage : storage )
       ( parameter : parameter )
-      [%return : (bool option) option ]
+      : (bool option) option
   =
   let s = "This is a Tic Tac Toe game. Still work in progress" in
 

--- a/tests/test0.liq
+++ b/tests/test0.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 type storage = string * (* 0: S *)
                timestamp * (* 1: T *)

--- a/tests/test0.liq
+++ b/tests/test0.liq
@@ -9,5 +9,5 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : unit] =
+      : unit =
    ( (), storage )

--- a/tests/test0.liq
+++ b/tests/test0.liq
@@ -1,13 +1,14 @@
 
 [%%version 0.1]
 
+type storage = string * (* 0: S *)
+               timestamp * (* 1: T *)
+               (tez * tez) * (* 2: P N *)
+               (unit,unit) contract * (* 3: X *)
+               (unit,unit) contract * (* 4: A *)
+               (unit,unit) contract  (* 5: B *)
 let%entry main
       (parameter : timestamp)
-      (storage : string * (* 0: S *)
-                   timestamp * (* 1: T *)
-                     (tez * tez) * (* 2: P N *)
-                       (unit,unit) contract * (* 3: X *)
-                         (unit,unit) contract * (* 4: A *)
-                           (unit,unit) contract)  (* 5: B *)
-      : unit =
+      (storage : storage)
+      : (unit * storage) =
    ( (), storage )

--- a/tests/test1.liq
+++ b/tests/test1.liq
@@ -9,7 +9,7 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : (timestamp * tez) * (tez * timestamp) ] =
+      : (timestamp * tez) * (tez * timestamp) =
    let amount = Current.amount () in
    let x = (parameter, amount) in
    let y = (amount, parameter) in

--- a/tests/test1.liq
+++ b/tests/test1.liq
@@ -1,15 +1,17 @@
 
 [%%version 0.1]
 
+type storage =  string * (* 0: S *)
+                timestamp * (* 1: T *)
+                (tez * tez) * (* 2: P N *)
+                (unit,unit) contract * (* 3: X *)
+                (unit,unit) contract * (* 4: A *)
+                (unit,unit) contract  (* 5: B *)
+
 let%entry main
       (parameter : timestamp)
-      (storage : string * (* 0: S *)
-                   timestamp * (* 1: T *)
-                     (tez * tez) * (* 2: P N *)
-                       (unit,unit) contract * (* 3: X *)
-                         (unit,unit) contract * (* 4: A *)
-                           (unit,unit) contract)  (* 5: B *)
-      : (timestamp * tez) * (tez * timestamp) =
+      (storage : storage)
+      : ((timestamp * tez) * (tez * timestamp)) * storage =
    let amount = Current.amount () in
    let x = (parameter, amount) in
    let y = (amount, parameter) in

--- a/tests/test1.liq
+++ b/tests/test1.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test10.liq
+++ b/tests/test10.liq
@@ -3,15 +3,16 @@
 
 [%%version 0.1]
 
-let%entry main
-      (parameter : bool)
-      (storage :
+type s =
         bool *
         int option *
         (string,int) map
-      )
-      : unit =
-      
+
+let%entry main
+      (parameter : bool)
+      (storage : s)
+      : unit * s =
+
 (* options *)
       let x = 3 in
       let option = Some x in

--- a/tests/test10.liq
+++ b/tests/test10.liq
@@ -10,7 +10,7 @@ let%entry main
         int option *
         (string,int) map
       )
-      [%return : unit] =
+      : unit =
       
 (* options *)
       let x = 3 in

--- a/tests/test10.liq
+++ b/tests/test10.liq
@@ -1,7 +1,7 @@
 
 (* constructors *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 type s =
         bool *

--- a/tests/test11.liq
+++ b/tests/test11.liq
@@ -6,13 +6,13 @@
 let%entry main
       (parameter : string)
       (storage : string)
-      : unit =
-      
+      : unit * string =
+
 (* options *)
       let storage = if parameter = "" then
            storage
         else
            storage @ parameter
-       in   
+       in
 
       ( (), storage )

--- a/tests/test11.liq
+++ b/tests/test11.liq
@@ -1,7 +1,7 @@
 
 (* strings *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : string)

--- a/tests/test11.liq
+++ b/tests/test11.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : string)
       (storage : string)
-      [%return : unit] =
+      : unit =
       
 (* options *)
       let storage = if parameter = "" then

--- a/tests/test12.liq
+++ b/tests/test12.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : string)
       (storage : string set)
-      [%return : unit] =
+      : unit =
       
       let set = (Set : string set) in
       let set = Set.update "a" true set in

--- a/tests/test12.liq
+++ b/tests/test12.liq
@@ -1,7 +1,7 @@
 
 (* sets *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : string)

--- a/tests/test12.liq
+++ b/tests/test12.liq
@@ -6,8 +6,8 @@
 let%entry main
       (parameter : string)
       (storage : string set)
-      : unit =
-      
+      : unit * string set =
+
       let set = (Set : string set) in
       let set = Set.update "a" true set in
       let set = Set.update "b" true set in

--- a/tests/test13.liq
+++ b/tests/test13.liq
@@ -1,7 +1,7 @@
 
 (* lists *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : string)

--- a/tests/test13.liq
+++ b/tests/test13.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : string)
       (storage : string list)
-      : unit =
+      : unit * string list =
       
       let set = ([] : string list) in
       let set = "a" :: set in

--- a/tests/test13.liq
+++ b/tests/test13.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : string)
       (storage : string list)
-      [%return : unit] =
+      : unit =
       
       let set = ([] : string list) in
       let set = "a" :: set in

--- a/tests/test14.liq
+++ b/tests/test14.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : int)
       (storage : int set)
-      : unit =
+      : unit * int set =
 
       let x =
         Loop.loop (fun x ->

--- a/tests/test14.liq
+++ b/tests/test14.liq
@@ -1,7 +1,7 @@
 
 (* loops *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : int)

--- a/tests/test14.liq
+++ b/tests/test14.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : int)
       (storage : int set)
-      [%return : unit] =
+      : unit =
 
       let x =
         Loop.loop (fun x ->

--- a/tests/test15.liq
+++ b/tests/test15.liq
@@ -12,7 +12,7 @@ type storage = {
 let%entry main
       (parameter : int)
       (storage : storage)
-      : unit =
+      : unit * storage =
 
       let storage = storage.v.dest.z <- parameter in
       let storage = storage.v.orig <- { x="0"; y=true; z = parameter } in

--- a/tests/test15.liq
+++ b/tests/test15.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 type point = { x : string; y : bool; z : int }
 type vector = { orig : point; dest : point }

--- a/tests/test15.liq
+++ b/tests/test15.liq
@@ -12,7 +12,7 @@ type storage = {
 let%entry main
       (parameter : int)
       (storage : storage)
-      [%return : unit] =
+      : unit =
 
       let storage = storage.v.dest.z <- parameter in
       let storage = storage.v.orig <- { x="0"; y=true; z = parameter } in

--- a/tests/test16.liq
+++ b/tests/test16.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : int)
       (storage : unit)
-      : unit =
+      : unit * unit =
   let f = fun ( arg : unit * int ) ->
     arg.(0)
   in

--- a/tests/test16.liq
+++ b/tests/test16.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : int)
       (storage : unit)
-      [%return : unit] =
+      : unit =
   let f = fun ( arg : unit * int ) ->
     arg.(0)
   in

--- a/tests/test17.liq
+++ b/tests/test17.liq
@@ -7,7 +7,7 @@ type storage =
 let%entry main
       (parameter : int)
       (storage : storage)
-      : unit =
+      : unit * storage =
   let _a = Nothing in
   let b = Int 3 in
   let c = String ("toto",0) in

--- a/tests/test17.liq
+++ b/tests/test17.liq
@@ -7,7 +7,7 @@ type storage =
 let%entry main
       (parameter : int)
       (storage : storage)
-      [%return : unit] =
+      : unit =
   let _a = Nothing in
   let b = Int 3 in
   let c = String ("toto",0) in

--- a/tests/test18.liq
+++ b/tests/test18.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : int)
       (storage : nat)
-      : int =
+      : int * nat =
 
   match int storage / parameter with
   | None -> ( 0, 0p)

--- a/tests/test18.liq
+++ b/tests/test18.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : int)
       (storage : nat)
-      [%return : int] =
+      : int =
 
   match int storage / parameter with
   | None -> ( 0, 0p)

--- a/tests/test2.liq
+++ b/tests/test2.liq
@@ -9,7 +9,7 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : (tez * tez) * (unit,unit) contract ] =
+      : (tez * tez) * (unit,unit) contract =
    let x = storage.(2) in
    let y = storage.(3) in
    ( (x,y), storage )

--- a/tests/test2.liq
+++ b/tests/test2.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test2.liq
+++ b/tests/test2.liq
@@ -1,15 +1,17 @@
 
 [%%version 0.1]
 
+type storage =  string * (* 0: S *)
+                timestamp * (* 1: T *)
+                (tez * tez) * (* 2: P N *)
+                (unit,unit) contract * (* 3: X *)
+                (unit,unit) contract * (* 4: A *)
+                (unit,unit) contract  (* 5: B *)
+
 let%entry main
       (parameter : timestamp)
-      (storage : string * (* 0: S *)
-                   timestamp * (* 1: T *)
-                     (tez * tez) * (* 2: P N *)
-                       (unit,unit) contract * (* 3: X *)
-                         (unit,unit) contract * (* 4: A *)
-                           (unit,unit) contract)  (* 5: B *)
-      : (tez * tez) * (unit,unit) contract =
+      (storage : storage)
+      : ((tez * tez) * (unit,unit) contract) * storage =
    let x = storage.(2) in
    let y = storage.(3) in
    ( (x,y), storage )

--- a/tests/test3.liq
+++ b/tests/test3.liq
@@ -1,15 +1,17 @@
 
 [%%version 0.1]
 
+type storage =  string * (* 0: S *)
+                timestamp * (* 1: T *)
+                (tez * tez) * (* 2: P N *)
+                (unit,unit) contract * (* 3: X *)
+                (unit,unit) contract * (* 4: A *)
+                (unit,unit) contract  (* 5: B *)
+
 let%entry main
       (parameter : timestamp)
-      (storage : string * (* 0: S *)
-                   timestamp * (* 1: T *)
-                     (tez * tez) * (* 2: P N *)
-                       (unit,unit) contract * (* 3: X *)
-                         (unit,unit) contract * (* 4: A *)
-                           (unit,unit) contract)  (* 5: B *)
-      : unit =
+      (storage : storage)
+      : (unit * storage) =
    let s = get storage 0 in
    let storage = set storage 0 s in
    ( (), storage )

--- a/tests/test3.liq
+++ b/tests/test3.liq
@@ -9,7 +9,7 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : unit ] =
+      : unit =
    let s = get storage 0 in
    let storage = set storage 0 s in
    ( (), storage )

--- a/tests/test3.liq
+++ b/tests/test3.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test4.liq
+++ b/tests/test4.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)
                 (tez * tez) * (* 2: P N *)

--- a/tests/test4.liq
+++ b/tests/test4.liq
@@ -1,14 +1,15 @@
 
 [%%version 0.1]
+type storage =  string * (* 0: S *)
+                timestamp * (* 1: T *)
+                (tez * tez) * (* 2: P N *)
+                (unit,unit) contract * (* 3: X *)
+                (unit,unit) contract * (* 4: A *)
+                (unit,unit) contract  (* 5: B *)
 
 let%entry main
       (parameter : timestamp)
-      (storage : string * (* 0: S *)
-                   timestamp * (* 1: T *)
-                     (tez * tez) * (* 2: P N *)
-                       (unit,unit) contract * (* 3: X *)
-                         (unit,unit) contract * (* 4: A *)
-                           (unit,unit) contract)  (* 5: B *)
-      : unit =
+      (storage : storage)
+      : (unit * storage) =
    let storage = set storage 1 parameter in
    ( (), storage )

--- a/tests/test4.liq
+++ b/tests/test4.liq
@@ -9,6 +9,6 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : unit ] =
+      : unit =
    let storage = set storage 1 parameter in
    ( (), storage )

--- a/tests/test5.liq
+++ b/tests/test5.liq
@@ -1,15 +1,17 @@
 
 [%%version 0.1]
 
+type storage =  string * (* 0: S *)
+                timestamp * (* 1: T *)
+                (tez * tez) * (* 2: P N *)
+                (unit,unit) contract * (* 3: X *)
+                (unit,unit) contract * (* 4: A *)
+                (unit,unit) contract  (* 5: B *)
+
 let%entry main
       (parameter : timestamp)
-      (storage : string * (* 0: S *)
-                   timestamp * (* 1: T *)
-                     (tez * tez) * (* 2: P N *)
-                       (unit,unit) contract * (* 3: X *)
-                         (unit,unit) contract * (* 4: A *)
-                           (unit,unit) contract)  (* 5: B *)
-      : unit  =
+      (storage : storage)
+      : (unit * storage) =
    let pn = get storage 2 in
    let p = get pn 0 in
    let p = p + 1tz in

--- a/tests/test5.liq
+++ b/tests/test5.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test5.liq
+++ b/tests/test5.liq
@@ -9,7 +9,7 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : unit ] =
+      : unit  =
    let pn = get storage 2 in
    let p = get pn 0 in
    let p = p + 1tz in

--- a/tests/test6.liq
+++ b/tests/test6.liq
@@ -9,7 +9,7 @@ let%entry main
                        (unit,unit) contract * (* 3: X *)
                          (unit,unit) contract * (* 4: A *)
                            (unit,unit) contract)  (* 5: B *)
-      [%return : unit ] =
+      : unit  =
    let pn = get storage 2 in
    let storage = set storage 2 pn in
    ( (), storage )

--- a/tests/test6.liq
+++ b/tests/test6.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test6.liq
+++ b/tests/test6.liq
@@ -1,15 +1,17 @@
 
 [%%version 0.1]
 
+type storage =  string * (* 0: S *)
+                timestamp * (* 1: T *)
+                (tez * tez) * (* 2: P N *)
+                (unit,unit) contract * (* 3: X *)
+                (unit,unit) contract * (* 4: A *)
+                (unit,unit) contract  (* 5: B *)
+
 let%entry main
       (parameter : timestamp)
-      (storage : string * (* 0: S *)
-                   timestamp * (* 1: T *)
-                     (tez * tez) * (* 2: P N *)
-                       (unit,unit) contract * (* 3: X *)
-                         (unit,unit) contract * (* 4: A *)
-                           (unit,unit) contract)  (* 5: B *)
-      : unit  =
+      (storage : storage)
+      : (unit * storage) =
    let pn = get storage 2 in
    let storage = set storage 2 pn in
    ( (), storage )

--- a/tests/test7.liq
+++ b/tests/test7.liq
@@ -5,7 +5,7 @@ let%entry main
       (parameter : timestamp)
       (storage : (tez * tez)  (* 2: P N *)
       )
-      [%return : int list] =
+      : int list =
 
       let p = get storage 0 in
       let n = get storage 1 in

--- a/tests/test7.liq
+++ b/tests/test7.liq
@@ -1,11 +1,13 @@
 
 [%%version 0.1]
 
+type t = tez
+type s = (t * tez)
+
 let%entry main
       (parameter : timestamp)
-      (storage : (tez * tez)  (* 2: P N *)
-      )
-      : int list =
+      (storage : s)
+      : (int list * (tez * t)) =
 
       let p = get storage 0 in
       let n = get storage 1 in

--- a/tests/test7.liq
+++ b/tests/test7.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 type t = tez
 type s = (t * tez)

--- a/tests/test8.liq
+++ b/tests/test8.liq
@@ -5,7 +5,7 @@ let%entry main
       (parameter : timestamp)
       (storage : tez * tez  (* 2: P N *)
       )
-      [%return : unit] =
+      : unit =
       let p = get storage 1 in
       let storage  = set storage 1 p in
       ( (), storage )

--- a/tests/test8.liq
+++ b/tests/test8.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : timestamp)

--- a/tests/test8.liq
+++ b/tests/test8.liq
@@ -5,7 +5,7 @@ let%entry main
       (parameter : timestamp)
       (storage : tez * tez  (* 2: P N *)
       )
-      : unit =
+      : unit * (tez * tez) =
       let p = get storage 1 in
       let storage  = set storage 1 p in
       ( (), storage )

--- a/tests/test9.liq
+++ b/tests/test9.liq
@@ -1,7 +1,7 @@
 
 (* constants *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 type storage = bool *
                int option *

--- a/tests/test9.liq
+++ b/tests/test9.liq
@@ -12,7 +12,7 @@ let%entry main
         int set *
         int list
       )
-      [%return : unit] =
+      : unit =
 
 (* booleans *)
       let bool =

--- a/tests/test9.liq
+++ b/tests/test9.liq
@@ -3,16 +3,16 @@
 
 [%%version 0.1]
 
+type storage = bool *
+               int option *
+               (string,int) map *
+               int set *
+               int list
+
 let%entry main
       (parameter : bool)
-      (storage :
-        bool *
-        int option *
-        (string,int) map *
-        int set *
-        int list
-      )
-      : unit =
+      (storage : storage)
+      : unit * storage =
 
 (* booleans *)
       let bool =

--- a/tests/test_closure.liq
+++ b/tests/test_closure.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : int)

--- a/tests/test_closure.liq
+++ b/tests/test_closure.liq
@@ -4,7 +4,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      : unit =
+      : unit * int =
   let x = parameter + 10 in
   let f = fun ( arg : int * int ) ->
     arg.(1) + x

--- a/tests/test_closure.liq
+++ b/tests/test_closure.liq
@@ -4,7 +4,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      [%return : unit] =
+      : unit =
   let x = parameter + 10 in
   let f = fun ( arg : int * int ) ->
     arg.(1) + x

--- a/tests/test_closure2.liq
+++ b/tests/test_closure2.liq
@@ -4,7 +4,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      [%return : unit] =
+      : unit =
   let x = parameter + 10 in
   let f ( arg : int * int ) (y : int) =
     arg.(0) + x + y

--- a/tests/test_closure2.liq
+++ b/tests/test_closure2.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : int)

--- a/tests/test_closure2.liq
+++ b/tests/test_closure2.liq
@@ -4,7 +4,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      : unit =
+      : unit * int =
   let x = parameter + 10 in
   let f ( arg : int * int ) (y : int) =
     arg.(0) + x + y

--- a/tests/test_closure3.liq
+++ b/tests/test_closure3.liq
@@ -4,7 +4,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      [%return : unit] =
+      : unit =
   let x = parameter + 10 in
   let f ( arg : int * int ) (y : int) =
     0

--- a/tests/test_closure3.liq
+++ b/tests/test_closure3.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : int)

--- a/tests/test_closure3.liq
+++ b/tests/test_closure3.liq
@@ -4,7 +4,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      : unit =
+      : unit * int =
   let x = parameter + 10 in
   let f ( arg : int * int ) (y : int) =
     0

--- a/tests/test_extfun.liq
+++ b/tests/test_extfun.liq
@@ -6,6 +6,6 @@ let f ( arg : unit * int ) = arg.(0)
 let%entry main
       (parameter : int)
       (storage : unit)
-      : unit =
+      : unit * unit =
   let storage = f (storage, parameter) in
   ( (), storage )

--- a/tests/test_extfun.liq
+++ b/tests/test_extfun.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.1]
+[%%version 0.11]
 
 let f ( arg : unit * int ) = arg.(0)
 

--- a/tests/test_extfun.liq
+++ b/tests/test_extfun.liq
@@ -6,6 +6,6 @@ let f ( arg : unit * int ) = arg.(0)
 let%entry main
       (parameter : int)
       (storage : unit)
-      [%return : unit] =
+      : unit =
   let storage = f (storage, parameter) in
   ( (), storage )

--- a/tests/test_if.liq
+++ b/tests/test_if.liq
@@ -1,7 +1,7 @@
 
 (* constants *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 type storage =
         bool *

--- a/tests/test_if.liq
+++ b/tests/test_if.liq
@@ -12,7 +12,7 @@ let%entry main
         int set *
         int list
       )
-      [%return : unit] =
+      : unit =
 
 (* booleans *)
       let bool =

--- a/tests/test_if.liq
+++ b/tests/test_if.liq
@@ -3,16 +3,17 @@
 
 [%%version 0.1]
 
-let%entry main
-      (parameter : bool)
-      (storage :
+type storage =
         bool *
         int option *
         (string,int) map *
         int set *
         int list
-      )
-      : unit =
+
+let%entry main
+      (parameter : bool)
+      (storage : storage)
+      : unit * storage =
 
 (* booleans *)
       let bool =

--- a/tests/test_ifcons.liq
+++ b/tests/test_ifcons.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : string)
       (storage : string list)
-      [%return : unit] =
+      : unit =
       
       let a = "1" in
       let set = ([] : string list) in

--- a/tests/test_ifcons.liq
+++ b/tests/test_ifcons.liq
@@ -1,7 +1,7 @@
 
 (* lists *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : string)

--- a/tests/test_ifcons.liq
+++ b/tests/test_ifcons.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : string)
       (storage : string list)
-      : unit =
+      : unit * string list =
       
       let a = "1" in
       let set = ([] : string list) in

--- a/tests/test_left.liq
+++ b/tests/test_left.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      : unit =
+      : unit * int =
   let a = (Left 3 : (_, string) variant) in
   let b = (Right a : (int, _) variant) in
 

--- a/tests/test_left.liq
+++ b/tests/test_left.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      [%return : unit] =
+      : unit =
   let a = (Left 3 : (_, string) variant) in
   let b = (Right a : (int, _) variant) in
 

--- a/tests/test_left_constr.liq
+++ b/tests/test_left_constr.liq
@@ -2,6 +2,6 @@
 let%entry main
       (parameter : int)
       (storage : (int, string) variant)
-      : unit =
+      : unit * (int, string) variant =
   let a = (Left parameter : (_, string) variant) in
   ( (), a )

--- a/tests/test_left_constr.liq
+++ b/tests/test_left_constr.liq
@@ -2,6 +2,6 @@
 let%entry main
       (parameter : int)
       (storage : (int, string) variant)
-      [%return : unit] =
+      : unit =
   let a = (Left parameter : (_, string) variant) in
   ( (), a )

--- a/tests/test_left_match.liq
+++ b/tests/test_left_match.liq
@@ -2,7 +2,7 @@
 let%entry main
       (parameter : (int, string) variant)
       (storage : int)
-      [%return : string] =
+      : string =
       
   match parameter with
   | Left left -> ("", left)

--- a/tests/test_loop.liq
+++ b/tests/test_loop.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      : unit =
+      : unit * int =
 
       let storage =
         Loop.loop (fun x ->

--- a/tests/test_loop.liq
+++ b/tests/test_loop.liq
@@ -1,7 +1,7 @@
 
 (* loops *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : int)

--- a/tests/test_loop.liq
+++ b/tests/test_loop.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : int)
       (storage : int)
-      [%return : unit] =
+      : unit =
 
       let storage =
         Loop.loop (fun x ->

--- a/tests/test_map.liq
+++ b/tests/test_map.liq
@@ -7,7 +7,7 @@ let succ (x : int) = x + 1
 let%entry main
       (parameter : int)
       (storage : int list)
-      [%return : unit] =
+      : unit =
   let l = List.map succ storage in
   ( (), l)
 

--- a/tests/test_map.liq
+++ b/tests/test_map.liq
@@ -1,6 +1,6 @@
 (* List.map *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 let succ (x : int) = x + 1
 

--- a/tests/test_map.liq
+++ b/tests/test_map.liq
@@ -7,7 +7,7 @@ let succ (x : int) = x + 1
 let%entry main
       (parameter : int)
       (storage : int list)
-      : unit =
+      : unit * int list =
   let l = List.map succ storage in
   ( (), l)
 

--- a/tests/test_map_closure.liq
+++ b/tests/test_map_closure.liq
@@ -5,7 +5,7 @@
 let%entry main
       (parameter : int)
       (storage : int list)
-      [%return : unit] =
+      : unit =
   let add_param (x : int) = x + parameter in
   let l = List.map add_param storage in
   ( (), l )

--- a/tests/test_map_closure.liq
+++ b/tests/test_map_closure.liq
@@ -5,7 +5,7 @@
 let%entry main
       (parameter : int)
       (storage : int list)
-      : unit =
+      : unit * int list =
   let add_param (x : int) = x + parameter in
   let l = List.map add_param storage in
   ( (), l )

--- a/tests/test_mapmap_closure.liq
+++ b/tests/test_mapmap_closure.liq
@@ -2,7 +2,7 @@
 let%entry main
   (parameter : string)
   (storage : (string, tez) map)
-  : (string, bool) map =
+  : (string, bool) map * (string, tez) map =
 
   let amount = Current.amount() in
   let f (arg: (string * tez)) =

--- a/tests/test_mapmap_closure.liq
+++ b/tests/test_mapmap_closure.liq
@@ -1,4 +1,4 @@
-[%%version 0.1]
+[%%version 0.11]
 let%entry main
   (parameter : string)
   (storage : (string, tez) map)

--- a/tests/test_mapmap_closure.liq
+++ b/tests/test_mapmap_closure.liq
@@ -1,7 +1,8 @@
+[%%version 0.1]
 let%entry main
   (parameter : string)
   (storage : (string, tez) map)
-  [%return : (string, bool) map] =
+  : (string, bool) map =
 
   let amount = Current.amount() in
   let f (arg: (string * tez)) =

--- a/tests/test_mapreduce_closure.liq
+++ b/tests/test_mapreduce_closure.liq
@@ -1,7 +1,7 @@
 let%entry main
   (parameter : string)
   (storage : (string, tez) map)
-  : bool =
+  : bool * (string, tez) map =
 
   let amount = Current.amount() in
   let f (arg: (string * tez) * bool) =

--- a/tests/test_mapreduce_closure.liq
+++ b/tests/test_mapreduce_closure.liq
@@ -1,7 +1,7 @@
 let%entry main
   (parameter : string)
   (storage : (string, tez) map)
-  [%return : bool] =
+  : bool =
 
   let amount = Current.amount() in
   let f (arg: (string * tez) * bool) =

--- a/tests/test_option.liq
+++ b/tests/test_option.liq
@@ -1,7 +1,7 @@
 let%entry main
   (parameter : int option)
   (storage : unit)
-  [%return : int] =
+  : int =
 
   let x = match parameter with
     | None -> 1

--- a/tests/test_option.liq
+++ b/tests/test_option.liq
@@ -1,7 +1,7 @@
 let%entry main
   (parameter : int option)
   (storage : unit)
-  : int =
+  : int * unit =
 
   let x = match parameter with
     | None -> 1

--- a/tests/test_reduce_closure.liq
+++ b/tests/test_reduce_closure.liq
@@ -5,7 +5,7 @@
 let%entry main
     (parameter : int list)
     (storage : int)
-    : unit =
+    : unit * int =
 
   let c = 1 in
 

--- a/tests/test_reduce_closure.liq
+++ b/tests/test_reduce_closure.liq
@@ -5,7 +5,7 @@
 let%entry main
     (parameter : int list)
     (storage : int)
-    [%return : unit] =
+    : unit =
 
   let c = 1 in
 

--- a/tests/test_rev.liq
+++ b/tests/test_rev.liq
@@ -5,6 +5,6 @@
 let%entry main
       (parameter : int)
       (storage : int list)
-      : unit =
+      : unit * int list =
   let l = List.rev storage in
   ( (), l )

--- a/tests/test_rev.liq
+++ b/tests/test_rev.liq
@@ -5,6 +5,6 @@
 let%entry main
       (parameter : int)
       (storage : int list)
-      [%return : unit] =
+      : unit =
   let l = List.rev storage in
   ( (), l )

--- a/tests/test_rev.liq
+++ b/tests/test_rev.liq
@@ -1,6 +1,6 @@
 (* List.rev *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : int)

--- a/tests/test_right_constr.liq
+++ b/tests/test_right_constr.liq
@@ -2,6 +2,6 @@
 let%entry main
       (parameter : string)
       (storage : (int, string) variant)
-      [%return : unit] =
+      : unit =
   let a = (Right parameter : (int, _) variant) in
   ( (), a )

--- a/tests/test_setreduce_closure.liq
+++ b/tests/test_setreduce_closure.liq
@@ -1,7 +1,7 @@
 let%entry main
   (parameter : string)
   (storage : tez set)
-  : bool =
+  : bool * tez set =
 
   let amount = Current.amount() in
   let f (arg: tez * bool) =

--- a/tests/test_setreduce_closure.liq
+++ b/tests/test_setreduce_closure.liq
@@ -1,7 +1,7 @@
 let%entry main
   (parameter : string)
   (storage : tez set)
-  [%return : bool] =
+  : bool =
 
   let amount = Current.amount() in
   let f (arg: tez * bool) =

--- a/tests/test_transfer.liq
+++ b/tests/test_transfer.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : (unit,unit) contract)
       (storage : tez)
-      : unit =
+      : unit * tez =
 
       let amount = Current.amount () in
       let storage = storage + amount in

--- a/tests/test_transfer.liq
+++ b/tests/test_transfer.liq
@@ -6,7 +6,7 @@
 let%entry main
       (parameter : (unit,unit) contract)
       (storage : tez)
-      [%return : unit] =
+      : unit =
 
       let amount = Current.amount () in
       let storage = storage + amount in

--- a/tests/test_transfer.liq
+++ b/tests/test_transfer.liq
@@ -1,7 +1,7 @@
 
 (* transfers *)
 
-[%%version 0.1]
+[%%version 0.11]
 
 let%entry main
       (parameter : (unit,unit) contract)

--- a/tools/liquidity/build.ocp2
+++ b/tools/liquidity/build.ocp2
@@ -64,7 +64,6 @@ OCaml.library("ocplib-liquidity",
 
 OCaml.library("ocplib-liquidity-ocaml",
    ocaml + {
-     version = version;
      files = [
        "ocaml/liquidOCamlParser.mly";
        "ocaml/liquidOCamlLexer.mll";

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -791,7 +791,7 @@ let rec loc_exp env e = match e.desc with
        let record_ty, ty_kind = StringMap.find ty_name env.env.types in
        let len = List.length (match ty_kind with
                               | Type_record (tys,_labels) -> tys
-                              | Type_variant _ -> assert false) in
+                              | Type_variant _ | Type_alias -> assert false) in
        let t = Array.make len None in
        let record_can_fail = ref false in
        List.iteri (fun i (label, exp) ->
@@ -827,7 +827,7 @@ let rec loc_exp env e = match e.desc with
        let constr_ty, ty_kind = StringMap.find ty_name env.env.types in
        let exp =
          match ty_kind with
-         | Type_record _ -> assert false
+         | Type_record _ | Type_alias -> assert false
          | Type_variant constrs ->
             let rec iter constrs =
               match constrs with
@@ -918,7 +918,7 @@ let rec loc_exp env e = match e.desc with
                 let constr_ty, ty_kind = StringMap.find ty_name env.env.types in
                 match ty_kind with
                 | Type_variant constrs -> (ty_name, constrs)
-                | Type_record _ -> raise Not_found
+                | Type_record _ | Type_alias -> raise Not_found
               end
            | _ -> raise Not_found
          with Not_found ->
@@ -1330,10 +1330,10 @@ let typecheck_contract ~warnings env contract =
   (* "parameter/2" *)
   let (_, env, _) = new_binding env "parameter" contract.parameter in
 
-  let expected_ty = Ttuple [ contract.return; contract.storage ] in
+  let expected_ty = Ttuple [contract.return; contract.storage] in
 
   let code, _can_fail, _transfer =
-    typecheck_expected "final value" env expected_ty contract.code in
+    typecheck_expected "return value" env expected_ty contract.code in
   { contract with code }, ! (env.to_inline)
 
 let typecheck_code ~warnings env contract expected_ty code =

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -1371,16 +1371,11 @@ let check_const_type ~to_tez loc ty cst =
     | Ttez, CString s -> CTez (to_tez s)
 
     | Tkey, CKey s
-      | Tkey, CString s -> CKey s
-
-    | Ttimestamp, CInt { integer = s }
-    | Ttimestamp, CNat { integer = s } -> CTimestamp s
+    | Tkey, CString s -> CKey s
 
     | Ttimestamp, CString s
     | Ttimestamp, CTimestamp s ->
       begin (* approximation of correct tezos timestamp *)
-        try Scanf.sscanf s "%_d%!" ()
-        with _ ->
         try Scanf.sscanf s "%_d-%_d-%_dT%_d:%_d:%_dZ%!" ()
         with _ ->
         try Scanf.sscanf s "%_d-%_d-%_d %_d:%_d:%_dZ%!" ()

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -81,10 +81,6 @@ let () =
 
 (* The minimal version of liquidity files that are accepted by this compiler *)
 let minimal_version = 0.1
-
-(* The maximal version of liquidity files that are accepted by this compiler *)
-let maximal_version = 0.1
-
 (*
 let contract
       (parameter : timestamp)
@@ -95,6 +91,18 @@ let contract
       [%return : unit] =
        ...
  *)
+
+(* The maximal version of liquidity files that are accepted by this compiler *)
+let maximal_version = 0.11
+(*
+type storage = ...
+let contract
+      (parameter : timestamp)
+      (storage: storage )
+      : unit * storage =
+       ...
+ *)
+
 
 open Asttypes
 open Longident
@@ -737,6 +745,16 @@ let rec translate_head env ext_funs head_exp args =
           "return type must be a product of some type and the storage type"
     in
     translate_head env ext_funs head_exp (("return", return) :: args)
+
+  | { pexp_desc =
+        Pexp_fun (
+            Nolabel, None,
+            { ppat_desc =
+                Ppat_extension ({ txt = "return"}, PTyp arg_type)
+            },
+            head_exp) } ->
+     translate_head env ext_funs head_exp
+       (("return", translate_type env arg_type) :: args)
 
   | { pexp_desc =
         Pexp_fun (

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -118,7 +118,7 @@ let loc_of_loc loc =
 let ppf = Format.err_formatter
 
 let default_args = [
-    "return", Tunit;
+    "return_storage", Tunit;
     "storage", Tunit;
     "parameter", Tunit;
   ]
@@ -184,8 +184,9 @@ let rec translate_type env typ =
   | { ptyp_desc = Ptyp_constr ({ txt = Lident ty_name }, []) } ->
      begin
        try
-         let ty,_ = StringMap.find ty_name env.types in
-         Ttype (ty_name, ty)
+         match StringMap.find ty_name env.types with
+         | ty, Type_alias -> ty
+         | ty, _ -> Ttype (ty_name, ty)
        with Not_found ->
          unbound_type typ.ptyp_loc ty_name
      end
@@ -723,9 +724,19 @@ let rec translate_head env ext_funs head_exp args =
      translate_head env ext_funs head_exp
        ((arg, translate_type env arg_type) :: args)
 
-  | { pexp_desc = Pexp_constraint (head_exp, return_type) } ->
-    translate_head env ext_funs head_exp
-      (("return", translate_type env return_type) :: args)
+  | { pexp_desc = Pexp_constraint (head_exp, return_type); pexp_loc } ->
+    let return = match translate_type env return_type with
+      | Ttuple [ ret_ty; sto_ty ] ->
+        let storage = List.assoc "storage" args in
+        if sto_ty <> storage then
+          error_loc pexp_loc
+            "Second component of return type must be identical to storage type";
+        ret_ty
+      | _ ->
+        error_loc pexp_loc
+          "return type must be a product of some type and the storage type"
+    in
+    translate_head env ext_funs head_exp (("return", return) :: args)
 
   | { pexp_desc =
         Pexp_fun (
@@ -871,6 +882,23 @@ let rec translate_structure funs env ast =
         translate_variant ty_name constrs env;
      end;
      translate_structure funs env ast
+
+  (* type alias *)
+  | { pstr_desc = Pstr_type (Recursive,
+                             [
+                               { ptype_name = { txt = ty_name };
+                                 ptype_params = [];
+                                 ptype_cstrs = [];
+                                 ptype_private = Public;
+                                 ptype_manifest = Some ct;
+                                 ptype_attributes = [];
+                                 ptype_loc;
+                                 ptype_kind;
+                               }
+    ]) } :: ast ->
+    let ty = translate_type env ct in
+    env.types <- StringMap.add ty_name (ty, Type_alias) env.types;
+    translate_structure funs env ast
 
   | [] ->
     Location.raise_errorf "No entry point found in file %S%!" env.filename

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -721,17 +721,11 @@ let rec translate_head env ext_funs head_exp args =
             },
             head_exp) } ->
      translate_head env ext_funs head_exp
-                    ((arg, translate_type env arg_type) :: args)
+       ((arg, translate_type env arg_type) :: args)
 
-  | { pexp_desc =
-        Pexp_fun (
-            Nolabel, None,
-            { ppat_desc =
-                Ppat_extension ({ txt = "return"}, PTyp arg_type)
-            },
-            head_exp) } ->
-     translate_head env ext_funs head_exp
-                    (("return", translate_type env arg_type) :: args)
+  | { pexp_desc = Pexp_constraint (head_exp, return_type) } ->
+    translate_head env ext_funs head_exp
+      (("return", translate_type env return_type) :: args)
 
   | { pexp_desc =
         Pexp_fun (

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -320,8 +320,8 @@ let structure_of_contract contract =
                                    (convert_type contract.storage)
                                 )
                       (Exp.constraint_
-                         code
-                         (convert_type contract.return))
+                         code (convert_type
+                                 (Ttuple [contract.return; contract.storage])))
                       ))
               ]
   ])]

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -8,16 +8,14 @@
 (**************************************************************************)
 
 (* The version that will be required to compile the generated files. *)
-let output_version = "0.1"
+let output_version = "0.11"
 
 (*
+type storage = ...
 let contract
       (parameter : timestamp)
-      (storage: (string * timestamp * (tez * tez) *
-                   ( (unit,unit) contract *
-                       (unit, unit) contract *
-                         (unit, unit) contract)) )
-      [%return : unit] =
+      (storage: storage )
+      : unit * storage =
        ...
  *)
 

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -304,6 +304,12 @@ let structure_of_contract contract =
                 Str.eval
                       (Exp.constant (Const.float output_version))
               ]);
+
+    Str.type_ Recursive [
+      Type.mk ~manifest:(convert_type contract.storage)
+        { txt = "storage"; loc = !default_loc }
+    ];
+
     Str.extension ( { txt = "entry"; loc = !default_loc },
                PStr    [
                      Str.value Nonrecursive
@@ -317,11 +323,11 @@ let structure_of_contract contract =
                       (Exp.fun_ Nolabel None
                                 (Pat.constraint_
                                    (Pat.var (loc "storage"))
-                                   (convert_type contract.storage)
+                                   (typ_constr "storage" [])
                                 )
                       (Exp.constraint_
-                         code (convert_type
-                                 (Ttuple [contract.return; contract.storage])))
+                         code (Typ.tuple [convert_type contract.return;
+                                          typ_constr "storage" []]))
                       ))
               ]
   ])]

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -319,12 +319,10 @@ let structure_of_contract contract =
                                    (Pat.var (loc "storage"))
                                    (convert_type contract.storage)
                                 )
-                      (Exp.fun_ Nolabel None
-                                (Pat.extension
-                                   (loc "return",
-                                   PTyp (convert_type contract.return))
-                                )
-                                code)))
+                      (Exp.constraint_
+                         code
+                         (convert_type contract.return))
+                      ))
               ]
   ])]
 

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -424,6 +424,7 @@ type pre_michelson =
   | DIV
 
 type type_kind =
+  | Type_alias
   | Type_record of datatype list * int StringMap.t
   | Type_variant of
       (string

--- a/tools/liquidity/ocaml/liquidOCamlPrinter.ml
+++ b/tools/liquidity/ocaml/liquidOCamlPrinter.ml
@@ -1145,6 +1145,18 @@ and binding ctxt f {pvb_pat=p; pvb_expr=x; _} =
   let rec pp_print_pexp_function f x =
     if x.pexp_attributes <> [] then pp f "=@;%a" (expression ctxt) x
     else match x.pexp_desc with
+      | Pexp_fun (label, eo, p,
+                  { pexp_desc = Pexp_constraint (e, rty) }) ->
+          if label=Nolabel then
+            pp f "%a@ : %a@ %a"
+              (simple_pattern ctxt) p
+              (core_type ctxt) rty
+              pp_print_pexp_function e
+          else
+            pp f "%a@ : %a@ %a"
+              (label_exp ctxt) (label,eo,p)
+              (core_type ctxt) rty
+              pp_print_pexp_function e
       | Pexp_fun (label, eo, p, e) ->
           if label=Nolabel then
             pp f "%a@ %a" (simple_pattern ctxt) p pp_print_pexp_function e

--- a/tools/liquidity/with-tezos/liquidFromTezos.ml
+++ b/tools/liquidity/with-tezos/liquidFromTezos.ml
@@ -178,8 +178,7 @@ let convert_contract c =
   let parameter = convert_type c.Script_repr.arg_type in
   let storage = convert_type c.Script_repr.storage_type in
   let code = convert_code c.Script_repr.code in
-  { code;
-    storage; return; parameter }
+  { code; storage; return; parameter }
 
 let contract_of_string s =
   match Client_proto_programs.parse_program s with

--- a/tools/liquidity/with-tezos/liquidToTezos.ml
+++ b/tools/liquidity/with-tezos/liquidToTezos.ml
@@ -62,6 +62,9 @@ let rec convert_const expr =
    | CSignature _|CLeft _|CRight _)
             *)
   | CTimestamp s -> Script_repr.String (0, s)
+  | CKey s -> Script_repr.String (0, s)
+  | CSignature s -> Script_repr.String (0, s)
+
   | _ ->
     LiquidLoc.raise_error "to-tezos: unimplemented const:\n%s%!"
       (LiquidPrinter.Michelson.string_of_const expr)

--- a/tools/liquidity/without-tezos/liquidFromTezos.ml
+++ b/tools/liquidity/without-tezos/liquidFromTezos.ml
@@ -181,8 +181,7 @@ let convert_contract c =
   let parameter = convert_type c.Script_repr.arg_type in
   let storage = convert_type c.Script_repr.storage_type in
   let code = convert_code c.Script_repr.code in
-  { code;
-    storage; return; parameter }
+  { code; storage; return; parameter }
 
 let contract_of_string s =
   match Client_proto_programs.parse_program s with


### PR DESCRIPTION
Reopening #10, see discussion there also.

Now:
```ocaml
let%entry main
    (storage : st)
    (parameter: p)
    : return_ty = ...
```
Used to be:
```ocaml
let%entry main
    (storage : st)
    (parameter: p)
    [%return : return_ty] = ...
```