### PR TITLE
Deconstruct tuples in let bindings and lambda abstractions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ distclean: clean
 
 # All of these tests must be run with with_tezos=true
 
-NTESTS=19
+NTESTS=20
 SIMPLE_TESTS= `seq -f 'test%.0f' 0 $(NTESTS)`
 MORE_TESTS=test_ifcons test_if test_loop test_option test_transfer test_left \
   test_extfun test_left_constr test_closure test_closure2 test_closure3 \

--- a/tests/others/broker.liq
+++ b/tests/others/broker.liq
@@ -19,8 +19,8 @@ let%entry main
   else
     if Current.time () < storage.timeout then (* Before timeout *)
       (* We compute ((1 + P) + N) tez for keeping the contract alive *)
-      let pn = storage.pn in
-      let cost = 1.00tz + pn.(0) + pn.(1) in
+      let (pn0, pn1) = storage.pn in
+      let cost = 1.00tz + pn0 + pn1 in
       let b = Current.balance () in
       if cost < b then
         (* # Not enough cash, we just accept the transaction
@@ -30,15 +30,17 @@ let%entry main
         (* # Enough cash, successful ending
                    # We update the global*)
         let storage = storage.state <- "success" in
+        let (pn0, _) = storage.pn in
         let (_result, storage) =
-            Contract.call storage.x storage.pn.(0) storage () in
+          Contract.call storage.x pn0 storage () in
+        let (_, pn1) = storage.pn in
         let (_result, storage) =
-            Contract.call storage.a storage.pn.(1) storage () in
+            Contract.call storage.a pn1 storage () in
         ( (), storage )
     else
       (* # After timeout, we refund
            # We update the global *)
-      let p = storage.pn.(0) in
+      let (p, _) = storage.pn in
       let storage = storage.state <- "timeout" in
       (*  # We try to transfer the fee to the broker *)
       let bal = Current.balance () in

--- a/tests/test20.liq
+++ b/tests/test20.liq
@@ -1,0 +1,10 @@
+type storage = tez * int * ((nat * unit) * bool)
+
+let%entry main
+    (parameter : unit)
+    (storage : storage)
+  :  (nat * tez) * storage =
+
+  let x, y = 0p, 1p in
+  let amount, _, ((n, _), b) = storage in
+  ((n + x + y, amount), storage)

--- a/tests/test_extfun.liq
+++ b/tests/test_extfun.liq
@@ -1,7 +1,7 @@
 
 [%%version 0.11]
 
-let f ( arg : unit * int ) = arg.(0)
+let f ((x : unit), (_ : int) ) = x
 
 let%entry main
       (parameter : int)


### PR DESCRIPTION
One can write:
```ocaml
let x, (_, y) = storage in ...
```
The following two are equivalent:
```ocaml
let f ((x : int), (y : bool)) = if y then x else 0
let f ((x, y) : int * bool) = if y then x else 0
```

Fixes #13 