### PR TITLE
match%nat and abs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ distclean: clean
 
 # All of these tests must be run with with_tezos=true
 
-NTESTS=20
+NTESTS=21
 SIMPLE_TESTS= `seq -f 'test%.0f' 0 $(NTESTS)`
 MORE_TESTS=test_ifcons test_if test_loop test_option test_transfer test_left \
   test_extfun test_left_constr test_closure test_closure2 test_closure3 \

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ The Liquidity language provides the following features:
 * High-level types: types like sum-types and record-types can be defined
   and used in Liquidity programs.
 
+Branches
+--------
+
+The `master` branch contains the latest stable release. The `next`
+branch contains the upcoming version: the language on the `next`
+branch is for experimentation, and features may be modified before the
+next release.
+
+
 Documentation
 -------------
 

--- a/tests/others/auction.liq
+++ b/tests/others/auction.liq
@@ -1,6 +1,6 @@
 (* Auction contract from https://www.michelson-lang.com/contract-a-day.html *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 type storage = {
   auction_end : timestamp;

--- a/tests/others/broker.liq
+++ b/tests/others/broker.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 type storage = {
   state : string;

--- a/tests/others/demo.liq
+++ b/tests/others/demo.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
   (parameter : string)

--- a/tests/test0.liq
+++ b/tests/test0.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 type storage = string * (* 0: S *)
                timestamp * (* 1: T *)

--- a/tests/test1.liq
+++ b/tests/test1.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test10.liq
+++ b/tests/test10.liq
@@ -1,7 +1,7 @@
 
 (* constructors *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 type s =
         bool *

--- a/tests/test11.liq
+++ b/tests/test11.liq
@@ -1,7 +1,7 @@
 
 (* strings *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : string)

--- a/tests/test12.liq
+++ b/tests/test12.liq
@@ -1,7 +1,7 @@
 
 (* sets *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : string)

--- a/tests/test13.liq
+++ b/tests/test13.liq
@@ -1,7 +1,7 @@
 
 (* lists *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : string)

--- a/tests/test14.liq
+++ b/tests/test14.liq
@@ -1,7 +1,7 @@
 
 (* loops *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : int)

--- a/tests/test15.liq
+++ b/tests/test15.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 type point = { x : string; y : bool; z : int }
 type vector = { orig : point; dest : point }

--- a/tests/test2.liq
+++ b/tests/test2.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test21.liq
+++ b/tests/test21.liq
@@ -1,0 +1,13 @@
+[%%version 0.12]
+
+let%entry main
+    (parameter : int)
+    (storage : int)
+  : nat * int =
+
+  let r = match%abs (parameter + 1)  with
+    | Plus x -> x
+    | Minus y -> y
+  in
+
+  (r, storage)

--- a/tests/test21.liq
+++ b/tests/test21.liq
@@ -10,4 +10,5 @@ let%entry main
     | Minus y -> y + 3p
   in
   let x = r + 10p in
+  let storage = abs storage in
   (x, storage)

--- a/tests/test21.liq
+++ b/tests/test21.liq
@@ -5,7 +5,7 @@ let%entry main
     (storage : int)
   : nat * int =
 
-  let r = match%abs (parameter + 1)  with
+  let r = match%nat (parameter + 1)  with
     | Plus x -> x + 2p
     | Minus y -> y + 3p
   in

--- a/tests/test21.liq
+++ b/tests/test21.liq
@@ -6,8 +6,8 @@ let%entry main
   : nat * int =
 
   let r = match%abs (parameter + 1)  with
-    | Plus x -> x
-    | Minus y -> y
+    | Plus x -> x + 2p
+    | Minus y -> y + 3p
   in
-
-  (r, storage)
+  let x = r + 10p in
+  (x, storage)

--- a/tests/test3.liq
+++ b/tests/test3.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test4.liq
+++ b/tests/test4.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)
                 (tez * tez) * (* 2: P N *)

--- a/tests/test5.liq
+++ b/tests/test5.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test6.liq
+++ b/tests/test6.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test7.liq
+++ b/tests/test7.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 type t = tez
 type s = (t * tez)

--- a/tests/test8.liq
+++ b/tests/test8.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : timestamp)

--- a/tests/test9.liq
+++ b/tests/test9.liq
@@ -1,7 +1,7 @@
 
 (* constants *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 type storage = bool *
                int option *

--- a/tests/test_closure.liq
+++ b/tests/test_closure.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : int)

--- a/tests/test_closure2.liq
+++ b/tests/test_closure2.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : int)

--- a/tests/test_closure3.liq
+++ b/tests/test_closure3.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : int)

--- a/tests/test_extfun.liq
+++ b/tests/test_extfun.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.11]
+[%%version 0.12]
 
 let f ((x : unit), (_ : int) ) = x
 

--- a/tests/test_if.liq
+++ b/tests/test_if.liq
@@ -1,7 +1,7 @@
 
 (* constants *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 type storage =
         bool *

--- a/tests/test_ifcons.liq
+++ b/tests/test_ifcons.liq
@@ -1,7 +1,7 @@
 
 (* lists *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : string)

--- a/tests/test_loop.liq
+++ b/tests/test_loop.liq
@@ -1,7 +1,7 @@
 
 (* loops *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : int)

--- a/tests/test_map.liq
+++ b/tests/test_map.liq
@@ -1,6 +1,6 @@
 (* List.map *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 let succ (x : int) = x + 1
 

--- a/tests/test_map_closure.liq
+++ b/tests/test_map_closure.liq
@@ -1,6 +1,6 @@
 (* List.map with closure *)
 
-[%%version  0.1]
+[%%version 0.12]
 
 let%entry main
       (parameter : int)

--- a/tests/test_map_closure.liq
+++ b/tests/test_map_closure.liq
@@ -1,6 +1,6 @@
 (* List.map with closure *)
 
-let version = 1.0
+[%%version  0.1]
 
 let%entry main
       (parameter : int)

--- a/tests/test_mapmap_closure.liq
+++ b/tests/test_mapmap_closure.liq
@@ -1,4 +1,4 @@
-[%%version 0.11]
+[%%version 0.12]
 let%entry main
   (parameter : string)
   (storage : (string, tez) map)

--- a/tests/test_reduce_closure.liq
+++ b/tests/test_reduce_closure.liq
@@ -1,6 +1,6 @@
 (* loops *)
 
-[%%version  0.1]
+[%%version 0.12]
 
 let%entry main
     (parameter : int list)

--- a/tests/test_reduce_closure.liq
+++ b/tests/test_reduce_closure.liq
@@ -1,6 +1,6 @@
 (* loops *)
 
-let version = 1.0
+[%%version  0.1]
 
 let%entry main
     (parameter : int list)

--- a/tests/test_rev.liq
+++ b/tests/test_rev.liq
@@ -1,6 +1,6 @@
 (* List.rev *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : int)

--- a/tests/test_transfer.liq
+++ b/tests/test_transfer.liq
@@ -1,7 +1,7 @@
 
 (* transfers *)
 
-[%%version 0.11]
+[%%version 0.12]
 
 let%entry main
       (parameter : (unit,unit) contract)

--- a/tools/liquidity/env/liquidityEnv.ml
+++ b/tools/liquidity/env/liquidityEnv.ml
@@ -45,10 +45,14 @@ end
 module Int : sig
 
   val of_string : string -> integer
+  val abs : integer -> integer
 
 end = struct
 
   let of_string n = Z.of_string n, Int
+  let abs (n, t) = match t with
+    | Int -> Z.abs n, Int
+    | _ -> assert false
 
 end
 

--- a/tools/liquidity/env/liquidityEnv.ml
+++ b/tools/liquidity/env/liquidityEnv.ml
@@ -45,14 +45,10 @@ end
 module Int : sig
 
   val of_string : string -> integer
-  val abs : integer -> integer
 
 end = struct
 
   let of_string n = Z.of_string n, Int
-  let abs (n, t) = match t with
-    | Int -> Z.abs n, Int
-    | _ -> assert false
 
 end
 
@@ -240,6 +236,9 @@ let (+) (x,unit) (y,_) = Z.add x y, unit
 let (-) (x,unit) (y,_) = Z.sub x y, unit
 let (@) = (^)
 
+let abs = function
+  | x, Int -> Z.abs x, Int
+  | _ -> raise (Invalid_argument "abs")
 
 let ediv x y =
   try

--- a/tools/liquidity/liquidBoundVariables.ml
+++ b/tools/liquidity/liquidBoundVariables.ml
@@ -60,6 +60,12 @@ let rec bv code =
                      (StringSet.union (bv ifnone)
                                       (StringSet.remove some_pat (bv ifsome)))
 
+  | MatchAbs (exp, loc, p, ifplus, m, ifminus) ->
+     StringSet.union (bv exp)
+       (StringSet.union
+          (StringSet.remove m (bv ifminus))
+          (StringSet.remove p (bv ifplus)))
+
   | MatchList (exp, loc, head_pat, tail_pat, ifcons, ifnil) ->
      StringSet.union
        (bv exp)
@@ -207,6 +213,20 @@ let rec bound code =
      in
      let desc = MatchOption(exp,loc,ifnone, some_pat, ifsome) in
      mk desc code bv
+
+
+  | MatchAbs (exp, loc, p, ifplus, m, ifminus) ->
+    let exp = bound exp in
+    let ifplus = bound ifplus in
+    let ifminus = bound ifminus in
+    let bv =
+      StringSet.union exp.bv
+        (StringSet.union
+           (StringSet.remove m ifminus.bv)
+           (StringSet.remove p ifplus.bv))
+    in
+    let desc = MatchAbs (exp, loc, p, ifplus, m, ifminus) in
+    mk desc code bv
 
   | MatchList (exp, loc, head_pat, tail_pat, ifcons, ifnil) ->
      let exp = bound exp in

--- a/tools/liquidity/liquidBoundVariables.ml
+++ b/tools/liquidity/liquidBoundVariables.ml
@@ -60,7 +60,7 @@ let rec bv code =
                      (StringSet.union (bv ifnone)
                                       (StringSet.remove some_pat (bv ifsome)))
 
-  | MatchAbs (exp, loc, p, ifplus, m, ifminus) ->
+  | MatchNat (exp, loc, p, ifplus, m, ifminus) ->
      StringSet.union (bv exp)
        (StringSet.union
           (StringSet.remove m (bv ifminus))
@@ -215,7 +215,7 @@ let rec bound code =
      mk desc code bv
 
 
-  | MatchAbs (exp, loc, p, ifplus, m, ifminus) ->
+  | MatchNat (exp, loc, p, ifplus, m, ifminus) ->
     let exp = bound exp in
     let ifplus = bound ifplus in
     let ifminus = bound ifminus in
@@ -225,7 +225,7 @@ let rec bound code =
            (StringSet.remove m ifminus.bv)
            (StringSet.remove p ifplus.bv))
     in
-    let desc = MatchAbs (exp, loc, p, ifplus, m, ifminus) in
+    let desc = MatchNat (exp, loc, p, ifplus, m, ifminus) in
     mk desc code bv
 
   | MatchList (exp, loc, head_pat, tail_pat, ifcons, ifnil) ->

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -1143,7 +1143,7 @@ and typecheck_prim2 env prim loc args =
   | Prim_and, [ { ty = Tint|Tnat }; { ty = Tint|Tnat } ] -> Tint
   | Prim_not, [ { ty = Tint|Tnat } ] -> Tint
 
-  | Prim_abs, [ { ty = Tint } ] -> Tnat
+  | Prim_abs, [ { ty = Tint } ] -> Tint
   | Prim_int, [ { ty = Tnat } ] -> Tint
   | Prim_sub, [ { ty = Tint|Tnat } ] -> Tint
 

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -256,7 +256,7 @@ let rec loc_exp env e = match e.desc with
     | Apply (_, loc, _)
     | LetTransfer (_, _, loc, _, _, _, _, _)
     | MatchOption (_, loc, _, _, _)
-    | MatchAbs (_, loc, _, _, _, _)
+    | MatchNat (_, loc, _, _, _, _)
     | MatchList (_, loc, _, _, _, _)
     | Loop (_, loc, _, _)
     | Lambda (_, _, loc, _, _)
@@ -704,9 +704,9 @@ let rec typecheck env ( exp : LiquidTypes.syntax_exp ) =
      can_fail,
      transfer1 || transfer2 || transfer3
 
-  | MatchAbs (arg, loc, plus_name, ifplus, minus_name, ifminus) ->
+  | MatchNat (arg, loc, plus_name, ifplus, minus_name, ifminus) ->
      let arg, fail1, transfer1 =
-       typecheck_expected "match%abs" env Tint arg in
+       typecheck_expected "match%nat" env Tint arg in
      let env = maybe_reset_vars env transfer1 in
      let (plus_name, env2, count_p) = new_binding env plus_name Tnat in
      let ifplus, fail2, transfer2 = typecheck env2 ifplus in
@@ -714,13 +714,13 @@ let rec typecheck env ( exp : LiquidTypes.syntax_exp ) =
      let ifminus, fail3, transfer3 = typecheck env3 ifminus in
      check_used env plus_name loc count_p;
      check_used env minus_name loc count_m;
-     let desc = MatchAbs (arg, loc, plus_name, ifplus, minus_name, ifminus) in
+     let desc = MatchNat (arg, loc, plus_name, ifplus, minus_name, ifminus) in
      let ty =
        match ifplus.ty, ifminus.ty with
        | ty, Tfail | Tfail, ty -> ty
        | ty1, ty2 ->
          if ty1 <> ty2 then
-           type_error loc "branches of match%abs must have the same type"
+           type_error loc "branches of match%nat must have the same type"
              ty2 ty1;
          ty1
      in

--- a/tools/liquidity/liquidData.ml
+++ b/tools/liquidity/liquidData.ml
@@ -43,6 +43,7 @@ let rec translate_const_exp loc exp =
     | Seq (_, _)
     | LetTransfer (_, _, _, _, _, _, _, _)
     | MatchOption (_, _, _, _, _)
+    | MatchAbs (_, _, _, _, _, _)
     | MatchList (_, _, _, _, _, _)
     | Loop (_, _, _, _)
     | Lambda (_, _, _, _, _)

--- a/tools/liquidity/liquidData.ml
+++ b/tools/liquidity/liquidData.ml
@@ -43,7 +43,7 @@ let rec translate_const_exp loc exp =
     | Seq (_, _)
     | LetTransfer (_, _, _, _, _, _, _, _)
     | MatchOption (_, _, _, _, _)
-    | MatchAbs (_, _, _, _, _, _)
+    | MatchNat (_, _, _, _, _, _)
     | MatchList (_, _, _, _, _, _)
     | Loop (_, _, _, _)
     | Lambda (_, _, _, _, _)

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -136,6 +136,9 @@ let decompile contract =
                           mk(Apply(Prim_tuple_get,noloc,[
                                        mk(Var(var_of node,noloc,[]));
                                        int_zero]))))
+       (* ABS : int -> int *)
+       | N_ABS, [arg] ->
+         mklet node (Apply(Prim_abs, noloc, [arg_of arg]))
 
        (* ABS as match%nat *)
        | N_PRIM "ABS", [arg] ->
@@ -183,7 +186,6 @@ let decompile contract =
                  | "EDIV" -> Prim_ediv
                  | "EXEC" -> Prim_exec
                  | "INT" -> Prim_int
-                 | "ABS" -> Prim_abs
                  | "H" -> Prim_hash
                  | "HASH_KEY" -> Prim_hash_key
                  | "CHECK_SIGNATURE" -> Prim_check
@@ -306,7 +308,7 @@ let decompile contract =
 
        | (
          N_LAMBDA_END _
-         | N_LAMBDA _
+       | N_LAMBDA _
        | N_TRANSFER _
        | N_LOOP _
        | N_IF _
@@ -316,7 +318,7 @@ let decompile contract =
        | N_SOURCE _
        | N_LEFT _
        | N_RIGHT _
-
+       | N_ABS
        | N_START
        | N_LAMBDA_BEGIN
        | N_VAR _

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -47,6 +47,8 @@ let rec var_of node =
   | N_IF_CONS _ -> Printf.sprintf "if_cons%d" node.num
   | N_IF_LEFT _ -> Printf.sprintf "if_left%d" node.num
   | N_IF_RIGHT _ -> Printf.sprintf "if_right%d" node.num
+  | N_IF_PLUS _ -> Printf.sprintf "if_plus%d" node.num
+  | N_IF_MINUS _ -> Printf.sprintf "if_minus%d" node.num
   | N_LEFT _ -> Printf.sprintf "left%d" node.num
   | N_RIGHT _ -> Printf.sprintf "right%d" node.num
   | N_TRANSFER _ -> Printf.sprintf "transfer%d" node.num
@@ -241,6 +243,12 @@ let decompile contract =
                            decompile_next then_node,
                            var_of var0,
                            decompile_next else_node)
+            | N_IF_PLUS (_, var0), N_IF_MINUS (_,var1) ->
+               MatchAbs(arg_of arg, noloc,
+                        var_of var0,
+                        decompile_next then_node,
+                        var_of var1,
+                        decompile_next else_node)
             | N_IF_LEFT (_, var0), N_IF_RIGHT (_,var1) ->
                MatchVariant(arg_of arg, noloc,
                             [
@@ -322,6 +330,8 @@ let decompile contract =
        | N_IF_CONS (_, _, _)
        | N_IF_LEFT (_, _)
        | N_IF_RIGHT (_, _)
+       | N_IF_PLUS (_, _)
+       | N_IF_MINUS (_, _)
        | N_TRANSFER_RESULT _
        | N_LOOP_BEGIN _
        | N_LOOP_ARG (_, _)

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -135,6 +135,12 @@ let decompile contract =
                                        mk(Var(var_of node,noloc,[]));
                                        int_zero]))))
 
+       (* ABS as match%abs *)
+       | N_PRIM "ABS", [arg] ->
+         let x = var_of arg in
+         let vx = mk (Var (x, noloc, [])) in
+         mklet node (MatchAbs(arg_of arg, noloc, x, vx, x, vx))
+
        | N_PRIM prim, _ ->
           let prim, args =
             match prim, node.args with

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -137,11 +137,11 @@ let decompile contract =
                                        mk(Var(var_of node,noloc,[]));
                                        int_zero]))))
 
-       (* ABS as match%abs *)
+       (* ABS as match%nat *)
        | N_PRIM "ABS", [arg] ->
          let x = var_of arg in
          let vx = mk (Var (x, noloc, [])) in
-         mklet node (MatchAbs(arg_of arg, noloc, x, vx, x, vx))
+         mklet node (MatchNat(arg_of arg, noloc, x, vx, x, vx))
 
        | N_PRIM prim, _ ->
           let prim, args =
@@ -244,7 +244,7 @@ let decompile contract =
                            var_of var0,
                            decompile_next else_node)
             | N_IF_PLUS (_, var0), N_IF_MINUS (_,var1) ->
-               MatchAbs(arg_of arg, noloc,
+               MatchNat(arg_of arg, noloc,
                         var_of var0,
                         decompile_next then_node,
                         var_of var1,

--- a/tools/liquidity/liquidDot.ml
+++ b/tools/liquidity/liquidDot.ml
@@ -68,7 +68,7 @@ let to_string contract =
           | N_LEFT _
           | N_RIGHT _
           | N_TRANSFER_RESULT _
-
+          | N_ABS
             -> []
 
           | N_LOOP_END (x,y,z)

--- a/tools/liquidity/liquidDot.ml
+++ b/tools/liquidity/liquidDot.ml
@@ -57,44 +57,46 @@ let to_string contract =
         let deps =
           match node.kind with
           | N_UNKNOWN _
-            | N_START
-            | N_FAIL
-            | N_LAMBDA_BEGIN
-            | N_END
-            | N_VAR _
-            | N_CONST (_, _)
-            | N_PRIM _
-            | N_SOURCE _
-            | N_LEFT _
-            | N_RIGHT _
-            | N_TRANSFER_RESULT _
+          | N_START
+          | N_FAIL
+          | N_LAMBDA_BEGIN
+          | N_END
+          | N_VAR _
+          | N_CONST (_, _)
+          | N_PRIM _
+          | N_SOURCE _
+          | N_LEFT _
+          | N_RIGHT _
+          | N_TRANSFER_RESULT _
 
             -> []
 
           | N_LOOP_END (x,y,z)
-            | N_IF_CONS (x, y, z)-> [x;y;z]
+          | N_IF_CONS (x, y, z)-> [x;y;z]
 
 
-            | N_TRANSFER (x,y)
-            | N_LOOP_RESULT (x,y,_)
-            | N_IF_SOME (x,y)
-            | N_IF_LEFT (x,y)
-            | N_IF_RIGHT (x,y)
-            | N_IF_END_RESULT (x,Some y,_)
+          | N_TRANSFER (x,y)
+          | N_LOOP_RESULT (x,y,_)
+          | N_IF_SOME (x,y)
+          | N_IF_LEFT (x,y)
+          | N_IF_RIGHT (x,y)
+          | N_IF_PLUS (x,y)
+          | N_IF_MINUS (x,y)
+          | N_IF_END_RESULT (x,Some y,_)
           | N_IF_END (x,y)
           | N_IF (x,y)
-            | N_LOOP (x,y)
-            | N_LAMBDA (x,y,_,_) -> [x;y]
+          | N_LOOP (x,y)
+          | N_LAMBDA (x,y,_,_) -> [x;y]
 
-            | N_IF_END_RESULT (x,None,_)
-              | N_IF_RESULT (x,_)
-            | N_IF_THEN x
-            | N_IF_ELSE x
-            | N_IF_NONE x
-            | N_IF_NIL x
-            | N_LOOP_BEGIN x
-            | N_LOOP_ARG (x,_)
-            | N_LAMBDA_END x -> [x]
+          | N_IF_END_RESULT (x,None,_)
+          | N_IF_RESULT (x,_)
+          | N_IF_THEN x
+          | N_IF_ELSE x
+          | N_IF_NONE x
+          | N_IF_NIL x
+          | N_LOOP_BEGIN x
+          | N_LOOP_ARG (x,_)
+          | N_LAMBDA_END x -> [x]
         in
         List.iter (fun arg ->
             add_edge node arg [ ]
@@ -105,7 +107,7 @@ let to_string contract =
         List.iter iter deps;
         List.iter iter node.args;
         iter_next node
-      end
+    end
   in
   iter begin_node;
   Ocamldot.to_string g

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -80,28 +80,10 @@ let () =
 
 
 (* The minimal version of liquidity files that are accepted by this compiler *)
-let minimal_version = 0.1
-(*
-let contract
-      (parameter : timestamp)
-      (storage: (string * timestamp * (tez * tez) *
-                   ( (unit,unit) contract *
-                       (unit, unit) contract *
-                         (unit, unit) contract)) )
-      [%return : unit] =
-       ...
- *)
+let minimal_version = 0.12
 
 (* The maximal version of liquidity files that are accepted by this compiler *)
 let maximal_version = 0.12
-(*
-type storage = ...
-let contract
-      (parameter : timestamp)
-      (storage: storage )
-      : unit * storage =
-       ...
- *)
 
 
 open Asttypes

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -553,7 +553,7 @@ let rec translate_code env exp =
                                        ) args)
 
     | { pexp_desc = Pexp_extension (
-        { txt = "abs" },
+        { txt = "nat" },
         PStr [{ pstr_desc = Pstr_eval (
             { pexp_desc = Pexp_match (e, cases); pexp_loc },
             [])
@@ -565,12 +565,12 @@ let rec translate_code env exp =
         match cases with
         | [ CConstr ("Plus", [p]), ifplus; CConstr ("Minus", [m]), ifminus ]
         | [ CConstr ("Minus", [m]), ifminus; CConstr ("Plus", [p]), ifplus ] ->
-          MatchAbs(e, loc_of_loc pexp_loc, p, ifplus, m, ifminus)
+          MatchNat(e, loc_of_loc pexp_loc, p, ifplus, m, ifminus)
         | [ CConstr ("Plus", [p]), ifplus; CAny, ifminus ] ->
-          MatchAbs(e, loc_of_loc pexp_loc, p, ifplus, "_", ifminus)
+          MatchNat(e, loc_of_loc pexp_loc, p, ifplus, "_", ifminus)
         | [ CConstr ("Minus", [m]), ifminus; CAny, ifplus ] ->
-          MatchAbs(e, loc_of_loc pexp_loc, "_", ifplus, m, ifminus)
-        | _ -> error_loc pexp_loc "match%abs patterns are Plus _, Minus _"
+          MatchNat(e, loc_of_loc pexp_loc, "_", ifplus, m, ifminus)
+        | _ -> error_loc pexp_loc "match%nat patterns are Plus _, Minus _"
       end
 
     | { pexp_desc = Pexp_match (e, cases); pexp_loc } ->

--- a/tools/liquidity/liquidInterp.ml
+++ b/tools/liquidity/liquidInterp.ml
@@ -113,7 +113,13 @@ let interp contract =
     match code, stack with
     | [], _ -> (stack, seq)
 
-    (* Special case for match%abs *)
+    (* Special case for abs *)
+    | {ins=ABS; loc} :: {ins=INT} :: code, x :: stack ->
+      let n = node loc N_ABS [x] [seq] in
+      let stack, seq = n :: stack, n in
+      decompile_seq stack seq code
+
+    (* Special case for match%nat *)
     | {ins=DUP 1; loc} ::
       {ins=ABS} ::
       {ins=SWAP} ::

--- a/tools/liquidity/liquidMichelson.ml
+++ b/tools/liquidity/liquidMichelson.ml
@@ -165,7 +165,7 @@ let translate_code code =
                           seq (ifsome @ ifsome_end) )}],
        transfer1 || transfer2 || transfer3
 
-    | MatchAbs(arg, loc, plus_name, ifplus, minus_name, ifminus) ->
+    | MatchNat(arg, loc, plus_name, ifplus, minus_name, ifminus) ->
        let arg, transfer1 = compile depth env arg in
        let (depth, env) =
          if transfer1 then (0, StringMap.empty) else (depth, env)

--- a/tools/liquidity/liquidMichelson.ml
+++ b/tools/liquidity/liquidMichelson.ml
@@ -393,7 +393,7 @@ the ending NIL is not annotated with a type *)
          | Prim_and, 2 -> [ ii AND ]
          | Prim_xor, 2 -> [ ii XOR ]
          | Prim_not, 1 -> [ ii NOT ]
-         | Prim_abs, 1 -> [ ii ABS ]
+         | Prim_abs, 1 -> [ ii ABS; ii INT ]
          | Prim_int, 1 -> [ ii INT ]
          | Prim_neg, 1 -> [ ii NEG ]
          | Prim_lsr, 2 -> [ ii LSR ]

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -560,10 +560,10 @@ module Liquid = struct
        Printf.bprintf b "\n%s| Some %s ->\n" indent2 var;
        bprint_code ~debug b indent4 ifsome;
        ()
-    | MatchAbs (arg, _loc, p, ifplus, m, ifminus) ->
+    | MatchNat (arg, _loc, p, ifplus, m, ifminus) ->
        let indent2 = indent ^ "  " in
        let indent4 = indent2 ^ "  " in
-       Printf.bprintf b "\n%smatch%%abs " indent;
+       Printf.bprintf b "\n%smatch%%nat " indent;
        bprint_code ~debug b indent2 arg;
        Printf.bprintf b " with\n";
        Printf.bprintf b "\n%s| Plus %s ->\n" indent2 p;

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -713,3 +713,4 @@ let string_of_node node =
   | N_SOURCE _ -> "N_SOURCE"
   | N_LEFT _ -> "N_LEFT"
   | N_RIGHT _ -> "N_RIGHT"
+  | N_ABS -> "N_ABS"

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -692,6 +692,8 @@ let string_of_node node =
   | N_IF_CONS _ -> "N_IF_CONS"
   | N_IF_LEFT _ -> "N_IF_LEFT"
   | N_IF_RIGHT _ -> "N_IF_RIGHT"
+  | N_IF_PLUS _ -> "N_IF_PLUS"
+  | N_IF_MINUS _ -> "N_IF_MINUS"
   | N_TRANSFER _ -> "N_TRANSFER"
   | N_TRANSFER_RESULT int -> Printf.sprintf "N_TRANSFER_RESULT %d" int
   | N_CONST (ty, cst) -> "N_CONST " ^ Michelson.string_of_const cst

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -560,6 +560,17 @@ module Liquid = struct
        Printf.bprintf b "\n%s| Some %s ->\n" indent2 var;
        bprint_code ~debug b indent4 ifsome;
        ()
+    | MatchAbs (arg, _loc, p, ifplus, m, ifminus) ->
+       let indent2 = indent ^ "  " in
+       let indent4 = indent2 ^ "  " in
+       Printf.bprintf b "\n%smatch%%abs " indent;
+       bprint_code ~debug b indent2 arg;
+       Printf.bprintf b " with\n";
+       Printf.bprintf b "\n%s| Plus %s ->\n" indent2 p;
+       bprint_code ~debug b indent4 ifplus;
+       Printf.bprintf b "\n%s| Minus %s ->\n" indent2 m;
+       bprint_code ~debug b indent4 ifminus;
+       ()
     | MatchList (arg, _loc, head_name, tail_name, ifcons, ifnil) ->
        let indent2 = indent ^ "  " in
        let indent4 = indent2 ^ "  " in

--- a/tools/liquidity/liquidSimplify.ml
+++ b/tools/liquidity/liquidSimplify.ml
@@ -50,6 +50,12 @@ let compute code to_inline =
        let ifsome = iter ifsome in
        { exp with desc = MatchOption(arg,loc,ifnone,name,ifsome) }
 
+    | MatchAbs(arg, loc, p, ifplus, m, ifminus) ->
+       let arg = iter arg in
+       let ifplus = iter ifplus in
+       let ifminus = iter ifminus in
+       { exp with desc = MatchAbs(arg, loc, p, ifplus, m, ifminus) }
+
     | MatchList(arg, loc, head_name, tail_name, ifcons, ifnil) ->
        let arg = iter arg in
        let ifcons = iter ifcons in

--- a/tools/liquidity/liquidSimplify.ml
+++ b/tools/liquidity/liquidSimplify.ml
@@ -50,11 +50,11 @@ let compute code to_inline =
        let ifsome = iter ifsome in
        { exp with desc = MatchOption(arg,loc,ifnone,name,ifsome) }
 
-    | MatchAbs(arg, loc, p, ifplus, m, ifminus) ->
+    | MatchNat(arg, loc, p, ifplus, m, ifminus) ->
        let arg = iter arg in
        let ifplus = iter ifplus in
        let ifminus = iter ifminus in
-       { exp with desc = MatchAbs(arg, loc, p, ifplus, m, ifminus) }
+       { exp with desc = MatchNat(arg, loc, p, ifplus, m, ifminus) }
 
     | MatchList(arg, loc, head_name, tail_name, ifcons, ifnil) ->
        let arg = iter arg in

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -203,8 +203,8 @@ let rec convert_code expr =
                            (convert_code ifsome);
                 ]
 
-  | MatchAbs (exp, _loc, p, ifplus, m, ifminus) ->
-    Exp.extension (loc "abs", PStr [
+  | MatchNat (exp, _loc, p, ifplus, m, ifminus) ->
+    Exp.extension (loc "nat", PStr [
         Str.eval (
           Exp.match_ (convert_code exp)
                 [

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -8,7 +8,7 @@
 (**************************************************************************)
 
 (* The version that will be required to compile the generated files. *)
-let output_version = "0.11"
+let output_version = "0.12"
 
 (*
 type storage = ...
@@ -202,6 +202,20 @@ let rec convert_code expr =
                                           (Some (Pat.var (loc some_pat))))
                            (convert_code ifsome);
                 ]
+
+  | MatchAbs (exp, _loc, p, ifplus, m, ifminus) ->
+    Exp.extension (loc "abs", PStr [
+        Str.eval (
+          Exp.match_ (convert_code exp)
+                [
+                  Exp.case (Pat.construct (lid "Plus")
+                              (Some (Pat.var (loc p))))
+                    (convert_code ifplus);
+                  Exp.case (Pat.construct (lid "Minus")
+                              (Some (Pat.var (loc m))))
+                    (convert_code ifminus);
+                ])
+      ])
 
   | MatchList (exp, _loc, head_pat, tail_pat, ifcons, ifnil) ->
      Exp.match_ (convert_code exp)

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -360,6 +360,11 @@ type 'ty exp = {
                     * location
                     * (pattern * 'ty exp) list
 
+  | MatchAbs of 'ty exp  (* argument *)
+                * location
+                * string * 'ty exp (* ifplus *)
+                * string * 'ty exp (* ifminus *)
+
 type syntax_exp = unit exp
 type typed_exp = datatype exp
 type live_exp = (datatype * datatype StringMap.t) exp

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -538,6 +538,8 @@ type node = {
    | N_IF_CONS of node * node * node
    | N_IF_LEFT of node * node
    | N_IF_RIGHT of node * node
+   | N_IF_PLUS of node * node
+   | N_IF_MINUS of node * node
    | N_TRANSFER of node * node
    | N_TRANSFER_RESULT of int
    | N_CONST of datatype * const

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -560,6 +560,7 @@ type node = {
    | N_LEFT of datatype
    | N_RIGHT of datatype
    | N_SOURCE of datatype * datatype
+   | N_ABS
 
 type node_exp = node * node
 

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -360,7 +360,7 @@ type 'ty exp = {
                     * location
                     * (pattern * 'ty exp) list
 
-  | MatchAbs of 'ty exp  (* argument *)
+  | MatchNat of 'ty exp  (* argument *)
                 * location
                 * string * 'ty exp (* ifplus *)
                 * string * 'ty exp (* ifminus *)

--- a/tools/liquidity/liquidUntype.ml
+++ b/tools/liquidity/liquidUntype.ml
@@ -135,10 +135,10 @@ let rec untype (env : env) (code : typed_exp) =
                     untype env ifnone,
                     some_pat', untype env' ifsome)
 
-    | MatchAbs (exp, loc, p, ifplus, m, ifminus) ->
+    | MatchNat (exp, loc, p, ifplus, m, ifminus) ->
        let (p, env') = find_free env p ifplus.bv in
        let (m, env'') = find_free env m ifminus.bv in
-       MatchAbs (untype env exp, loc,
+       MatchNat (untype env exp, loc,
                  p, untype env' ifplus,
                  m, untype env'' ifminus)
 

--- a/tools/liquidity/liquidUntype.ml
+++ b/tools/liquidity/liquidUntype.ml
@@ -135,6 +135,13 @@ let rec untype (env : env) (code : typed_exp) =
                     untype env ifnone,
                     some_pat', untype env' ifsome)
 
+    | MatchAbs (exp, loc, p, ifplus, m, ifminus) ->
+       let (p, env') = find_free env p ifplus.bv in
+       let (m, env'') = find_free env m ifminus.bv in
+       MatchAbs (untype env exp, loc,
+                 p, untype env' ifplus,
+                 m, untype env'' ifminus)
+
     | MatchList (exp, loc, head_pat, tail_pat, ifcons, ifnil) ->
        let bv = ifcons.bv in
        let (head_pat, env') = find_free env head_pat bv in

--- a/tools/liquidity/ocaml/liquidOCamlTranslate.ml
+++ b/tools/liquidity/ocaml/liquidOCamlTranslate.ml
@@ -159,13 +159,13 @@ let clean_ast =
              (Exp.let_ ~loc Nonrecursive
                 [ Vb.mk (Pat.var { txt = p; loc })
                     (Exp.apply ~loc:ifplus.pexp_loc
-                       (exp_ident ~loc "Int.abs")
+                       (exp_ident ~loc "abs")
                        [Nolabel, exp_ident ~loc id])]
                 ifplus)
              (Some (Exp.let_ ~loc Nonrecursive
                       [ Vb.mk (Pat.var { txt = m; loc })
                           (Exp.apply ~loc:ifminus.pexp_loc
-                             (exp_ident ~loc "Int.abs")
+                             (exp_ident ~loc "abs")
                              [Nolabel, exp_ident ~loc id])]
                       ifminus)))
 


### PR DESCRIPTION
Function `abs` now has type:
```ocaml
abs : int -> int
```

Coercion from `int` to `nat` has to be performed through a match construct. This forces users to explicitly handle the case where their integer is negative.
```ocaml
match%nat x with
| Plus y -> (* y is of type nat, and x = y *)
| Minus w -> (* w is of type nat and x = -w *)
```

**Missing**: documentation