### PR TITLE
Bug fixes in pattern matching with contract calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ distclean: clean
 
 # All of these tests must be run with with_tezos=true
 
-NTESTS=21
+NTESTS=31
 SIMPLE_TESTS= `seq -f 'test%.0f' 0 $(NTESTS)`
 MORE_TESTS=test_ifcons test_if test_loop test_option test_transfer test_left \
   test_extfun test_left_constr test_closure test_closure2 test_closure3 \

--- a/tests/test22.liq
+++ b/tests/test22.liq
@@ -1,0 +1,19 @@
+[%%version 0.12]
+
+type t = A of int | B | C of (int * nat)
+
+let%entry main
+    (parameter : (unit, unit) contract * t)
+    (storage : int)
+  : int * int =
+
+  let (c, m) = parameter in
+  match m with
+  | A i ->
+    (i, storage)
+  | B ->
+    let (_, storage) = Contract.call c 0tz storage () in
+    (0, storage)
+  | C _ ->
+    let (_, storage) = Contract.call c 1tz storage () in
+    (1, storage)

--- a/tests/test23.liq
+++ b/tests/test23.liq
@@ -1,0 +1,16 @@
+[%%version 0.12]
+
+let%entry main
+    (parameter : (nat, nat) contract)
+    (storage : int)
+  : nat * int =
+
+  let r, storage = match%nat (storage + 1)  with
+    | Plus x -> (x + 2p, storage)
+    | Minus y ->
+      let (w, storage) = Contract.call parameter 0tz storage y in
+      (w, storage)
+  in
+  let x = r + 10p in
+  let storage = abs storage in
+  (x, storage)

--- a/tests/test24.liq
+++ b/tests/test24.liq
@@ -1,0 +1,20 @@
+[%%version 0.12]
+
+type t = A of int | B | C of (int * nat)
+
+let%entry main
+    (parameter : (unit, unit) contract * t)
+    (storage : int)
+  : int * int =
+
+  let (c, m) = parameter in
+  match m with
+  | A _ ->
+    let (_, storage) = Contract.call c 0tz storage () in
+    (0, storage)
+  | B ->
+    let (_, storage) = Contract.call c 0tz storage () in
+    (0, storage)
+  | C _ ->
+    let (_, storage) = Contract.call c 1tz storage () in
+    (1, storage)

--- a/tests/test25.liq
+++ b/tests/test25.liq
@@ -1,0 +1,18 @@
+[%%version 0.12]
+
+let%entry main
+    (parameter : (nat, nat) contract)
+    (storage : int)
+  : nat * int =
+
+  let r, storage = match%nat (storage + 1)  with
+    | Plus x ->
+      let (w, storage) = Contract.call parameter 0tz storage x in
+      (w + 2p, storage)
+    | Minus y ->
+      let (w, storage) = Contract.call parameter 0tz storage y in
+      (w, storage)
+  in
+  let x = r + 10p in
+  let storage = abs storage in
+  (x, storage)

--- a/tests/test26.liq
+++ b/tests/test26.liq
@@ -1,0 +1,14 @@
+[%%version 0.12]
+
+let%entry main
+    (parameter : (nat, bool) contract)
+    (storage : bool)
+  : bool * bool =
+
+  if
+    let (b, _) = Contract.call parameter 0tz storage 1p in
+    b
+  then
+    false, false
+  else
+    true, false

--- a/tests/test27.liq
+++ b/tests/test27.liq
@@ -1,0 +1,13 @@
+[%%version 0.12]
+
+let%entry main
+    (parameter : (nat, bool) contract)
+    (storage : bool * (nat, bool) contract)
+  : bool * (bool * (nat, bool) contract) =
+
+  let (b, c) = storage in
+  if b then
+    false, storage
+  else
+    let (b, storage) = Contract.call c 0tz storage 0p in
+    b, storage

--- a/tests/test28.liq
+++ b/tests/test28.liq
@@ -1,0 +1,13 @@
+[%%version 0.12]
+
+let%entry main
+    (parameter : (nat, bool) contract)
+    (storage : bool * (nat, bool) contract)
+  : bool * (bool * (nat, bool) contract) =
+
+  let (b, c) = storage in
+  if b then
+    let (b, storage) = Contract.call c 0tz storage 0p in
+    b, storage
+  else
+    false, storage

--- a/tests/test29.liq
+++ b/tests/test29.liq
@@ -1,0 +1,14 @@
+[%%version 0.12]
+
+let%entry main
+    (parameter : (int, unit) contract * int list)
+    (storage : int)
+  : unit * int =
+
+  let (c, l) = parameter in
+  match l with
+  | [] ->
+    ((), storage)
+  | x :: _ ->
+    let (result, storage) = Contract.call c 0tz storage x in
+    (result, storage)

--- a/tests/test30.liq
+++ b/tests/test30.liq
@@ -1,0 +1,14 @@
+[%%version 0.12]
+
+let%entry main
+    (parameter : (int, unit) contract * int list)
+    (storage : int)
+  : unit * int =
+
+  let (c, l) = parameter in
+  match l with
+  | [] ->
+    let (result, storage) = Contract.call c 0tz storage (-1) in
+    (result, storage)
+  | _ :: _ ->
+    ((), storage)

--- a/tests/test31.liq
+++ b/tests/test31.liq
@@ -1,0 +1,14 @@
+[%%version 0.12]
+
+let%entry main
+    (parameter : (int, unit) contract * int option)
+    (storage : int)
+  : unit * int =
+
+  let (c, l) = parameter in
+  match l with
+  | None ->
+    ((), storage)
+  | Some x  ->
+    let (result, storage) = Contract.call c 0tz storage x in
+    (result, storage)

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -468,6 +468,19 @@ let rec typecheck env ( exp : LiquidTypes.syntax_exp ) =
      typecheck env { exp with
                      desc = Apply(Prim_exec, loc, [x;f]) }
 
+
+  | Apply (Prim_unknown, loc,
+           ({ desc = Var ("Contract.call", varloc, [])} :: args)) ->
+    let nb_args = List.length args in
+    if nb_args <> 4 then
+      error loc
+        "Contract.call expects 4 arguments, it was given %d arguments."
+        nb_args
+    else
+      error loc
+        "The result of Contract.call must be bound under a \
+         \"let (result, storage) =\" directly."
+
   | Apply (Prim_unknown, loc,
            ({ desc = Var (name, varloc, [])} ::args)) ->
      let prim =

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -452,11 +452,9 @@ let rec translate_code env exp =
                     {
                       ppat_desc =
                         Ppat_tuple [
-                            { ppat_desc = Ppat_var { txt = result } };
-                            { ppat_desc = Ppat_var { txt =
-                                                       ("storage" | "_storage")as storage_name
-                            } };
-                          ]
+                          { ppat_desc = (Ppat_any | Ppat_var _) as res};
+                          { ppat_desc = (Ppat_any | Ppat_var _) as sto};
+                        ]
                     };
                   pvb_expr =
                     { pexp_desc =
@@ -473,6 +471,16 @@ let rec translate_code env exp =
                     ]) }
                 }
               ], body) } ->
+       let result = match res with
+         | Ppat_any -> "_"
+         | Ppat_var { txt = result } -> result
+         | _ -> assert false
+       in
+       let storage_name = match sto with
+         | Ppat_any -> "_"
+         | Ppat_var { txt = storage_name } -> storage_name
+         | _ -> assert false
+       in
        LetTransfer (storage_name, result,
                     loc_of_loc exp.pexp_loc,
                     translate_code env contract_exp,

--- a/tools/liquidity/liquidInterp.ml
+++ b/tools/liquidity/liquidInterp.ml
@@ -100,7 +100,8 @@ let rec merge_stacks if_stack end_node1 end_node2 stack1 stack2 =
         | Some node -> node.args <- List.rev node.args);
        stack
      with Exit ->
-       LiquidLoc.raise_error "interp error merging stacks:\n%a%a"
+       LiquidLoc.raise_error ~loc:end_node1.loc
+         "interp error merging stacks:\n%a%a"
          (fprint_stack "stack1 ") stack1
          (fprint_stack "stack2 ") stack2
 

--- a/tools/liquidity/liquidMichelson.ml
+++ b/tools/liquidity/liquidMichelson.ml
@@ -174,12 +174,13 @@ let translate_code code =
        let ifplus, transfer2 = compile (depth + 1) env' ifplus in
        let env'' = StringMap.add minus_name depth env in
        let ifminus, transfer3 = compile (depth + 1) env'' ifminus in
+       let depth = depth + 1 in
        let (ifplus_end, ifminus_end) =
          match transfer2, transfer3 with
          | false, false -> [ {i=DIP_DROP(1,1)} ], [ {i=DIP_DROP(1,1)} ]
          | true, true -> [], []
-         | true, false -> [], drop_stack 1 (depth - 1)
-         | false, true -> drop_stack 1 (depth - 1), []
+         | true, false -> [], drop_stack 1 depth
+         | false, true -> drop_stack 1 depth, []
        in
        arg @ [
          dup 1; ii ABS; ii SWAP; ii GE;
@@ -232,7 +233,7 @@ let translate_code code =
               | true, true -> []
               | false, false -> [ {i=DIP_DROP(1,1)} ]
               | false, true -> assert false
-              | true, false -> drop_stack 1 (depth-1)
+              | true, false -> drop_stack 1 depth
             in
             let left = left @ left_end in
             match cases with


### PR DESCRIPTION
- Fix bug in compilation of pattern matching with contract calls
-  More flexible `Contract.call`
   One can write `let (_, _) = Contract.call ...`
   Errors in Contract.call are reported more accurately