### PR TITLE
Split type checking and encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ MORE_TESTS=test_ifcons test_if test_loop test_option test_transfer test_left \
   test_extfun test_left_constr test_closure test_closure2 test_closure3 \
   test_map test_rev test_reduce_closure test_map_closure test_mapreduce_closure \
   test_mapmap_closure test_setreduce_closure test_left_match
-OTHER_TESTS=others/broker others/demo others/auction
+OTHER_TESTS=others/broker others/demo others/auction others/multisig
 REV_TESTS=`seq -f  'test%.0f' 0 $(NREVTESTS)`
 
 NEW_TEZOS_TESTS= fail weather_insurance

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ distclean: clean
 # All of these tests must be run with with_tezos=true
 
 NTESTS=32
-NTESTS=21
 NREVTESTS=6
 SIMPLE_TESTS= `seq -f 'test%.0f' 0 $(NTESTS)`
 MORE_TESTS=test_ifcons test_if test_loop test_option test_transfer test_left \

--- a/tests/build.ocp2
+++ b/tests/build.ocp2
@@ -2,7 +2,7 @@
 OCaml.library("ocplib-liquidity-examples",
   ocaml + {
     files = [
-    
+
        "liquidTestSimple.ml", {
          file2string = [
                      "test0.liq";
@@ -23,7 +23,20 @@ OCaml.library("ocplib-liquidity-examples",
                      "test15.liq";
                      "test16.liq";
                      "test17.liq";
-                     "test18.liq";
+                     "test19.liq";
+                     "test20.liq";
+                     "test21.liq";
+                     "test22.liq";
+                     "test23.liq";
+                     "test24.liq";
+                     "test25.liq";
+                     "test26.liq";
+                     "test27.liq";
+                     "test28.liq";
+                     "test29.liq";
+                     "test30.liq";
+                     "test31.liq";
+                     "test32.liq";
                      ];
        };
 
@@ -57,6 +70,7 @@ OCaml.library("ocplib-liquidity-examples",
                   "others/demo.liq";
                   "others/broker.liq";
                   "others/auction.liq";
+                  "others/multisig.liq";
           ];
        };
 

--- a/tests/others/auction.liq
+++ b/tests/others/auction.liq
@@ -1,6 +1,6 @@
 (* Auction contract from https://www.michelson-lang.com/contract-a-day.html *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 type storage = {
   auction_end : timestamp;

--- a/tests/others/broker.liq
+++ b/tests/others/broker.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 type storage = {
   state : string;

--- a/tests/others/demo.liq
+++ b/tests/others/demo.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
   (parameter : string)

--- a/tests/others/multisig.liq
+++ b/tests/others/multisig.liq
@@ -1,0 +1,90 @@
+[%%version 0.13]
+
+(* A proposition of transfer to a destination, the address of (unit, unit)
+   contract *)
+type proposition = {
+  destination : key_hash;
+  amount : tez;
+}
+
+(* An owner can submit a proposition or remove a previously submitted
+   proposition *)
+type action = proposition option
+
+(* The multisig contract can be payed to, simply transfering tokens to it,
+   or an owner can submit an action *)
+type parameter =
+  | Pay
+  | Manage of action
+
+type storage = {
+  owners : key_hash set;                 (* set of owners *)
+  actions : (key_hash, proposition) map; (* map of owner to proposition *)
+  owners_length : nat;                   (* total number of owners *)
+  min_agree : nat;                       (* minimum number of required
+                                            agreements before proposition is
+                                            executed *)
+}
+
+(* fails if the proposition is not a valid one *)
+let check_proposition (p:proposition) =
+  if p.amount > Current.balance () then Current.fail () else ()
+
+
+(* returns the address of the current caller of this multisig contract *)
+let get_caller (_ : unit) =
+  let c = (Source : (unit, unit) contract) in
+  Contract.manager c
+
+(* returns true if two proositions are identical *)
+let equal_props ((p1:proposition), (p2:proposition)) =
+  p1.destination = p2.destination &&
+  p1.amount = p2.amount
+
+(* returns true if a proposition p should be executed immediately *)
+let should_execute ((p : proposition), (storage : storage)) =
+  let nb_agree =
+    Map.reduce (fun (((_:key_hash), (p':proposition)), (cpt:nat)) ->
+        if equal_props (p, p') then cpt + 1p else cpt
+      ) storage.actions 0p
+  in
+  nb_agree >= storage.min_agree
+
+
+let%entry main
+    (parameter : parameter)
+    (storage : storage)
+  : unit * storage
+  =
+  match parameter with
+  | Pay ->
+    (* Simple payment, nothing to do *)
+    (), storage
+  | Manage action ->
+    (* Owner wants to perform an action *)
+    let owner_kh = get_caller () in
+    (* the caller must be an owner*)
+    if not (Set.mem owner_kh storage.owners) then Current.fail ();
+    (* Don't send money while managing multisig *)
+    if Current.amount () <> 0tz then Current.fail ();
+    (* Register the desired action in the storage *)
+    let storage =
+      storage.actions <- Map.update owner_kh action storage.actions in
+    let storage =
+      match action with
+      | None ->
+        (* action is to remove previous proposition: nothing to do *)
+        storage
+      | Some p ->
+        (* The action is new proposition *)
+        check_proposition p; (* it must be a valid one *)
+        if should_execute (p, storage) then
+          (* execute proposition, i.e. transfer tokens *)
+          let c_dest = Account.default p.destination in
+          let _, storage = Contract.call c_dest p.amount storage () in
+          (* reset the map of actions *)
+          storage.actions <- (Map [] : (key_hash, proposition) map)
+        else
+          storage
+    in
+    (), storage

--- a/tests/test0.liq
+++ b/tests/test0.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 type storage = string * (* 0: S *)
                timestamp * (* 1: T *)

--- a/tests/test1.liq
+++ b/tests/test1.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test10.liq
+++ b/tests/test10.liq
@@ -1,7 +1,7 @@
 
 (* constructors *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 type s =
         bool *

--- a/tests/test11.liq
+++ b/tests/test11.liq
@@ -1,7 +1,7 @@
 
 (* strings *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : string)

--- a/tests/test12.liq
+++ b/tests/test12.liq
@@ -1,7 +1,7 @@
 
 (* sets *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : string)

--- a/tests/test13.liq
+++ b/tests/test13.liq
@@ -1,7 +1,7 @@
 
 (* lists *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : string)

--- a/tests/test14.liq
+++ b/tests/test14.liq
@@ -1,7 +1,7 @@
 
 (* loops *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : int)

--- a/tests/test15.liq
+++ b/tests/test15.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 type point = { x : string; y : bool; z : int }
 type vector = { orig : point; dest : point }

--- a/tests/test2.liq
+++ b/tests/test2.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test21.liq
+++ b/tests/test21.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
     (parameter : int)

--- a/tests/test22.liq
+++ b/tests/test22.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 type t = A of int | B | C of (int * nat)
 

--- a/tests/test23.liq
+++ b/tests/test23.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
     (parameter : (nat, nat) contract)

--- a/tests/test24.liq
+++ b/tests/test24.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 type t = A of int | B | C of (int * nat)
 

--- a/tests/test25.liq
+++ b/tests/test25.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
     (parameter : (nat, nat) contract)

--- a/tests/test26.liq
+++ b/tests/test26.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
     (parameter : (nat, bool) contract)

--- a/tests/test27.liq
+++ b/tests/test27.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
     (parameter : (nat, bool) contract)

--- a/tests/test28.liq
+++ b/tests/test28.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
     (parameter : (nat, bool) contract)

--- a/tests/test29.liq
+++ b/tests/test29.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
     (parameter : (int, unit) contract * int list)

--- a/tests/test3.liq
+++ b/tests/test3.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test30.liq
+++ b/tests/test30.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
     (parameter : (int, unit) contract * int list)

--- a/tests/test31.liq
+++ b/tests/test31.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
     (parameter : (int, unit) contract * int option)

--- a/tests/test32.liq
+++ b/tests/test32.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 
 type t = A of int | B of (int * ((bool * unit) * nat))
 

--- a/tests/test4.liq
+++ b/tests/test4.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)
                 (tez * tez) * (* 2: P N *)

--- a/tests/test5.liq
+++ b/tests/test5.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test6.liq
+++ b/tests/test6.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 type storage =  string * (* 0: S *)
                 timestamp * (* 1: T *)

--- a/tests/test7.liq
+++ b/tests/test7.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 type t = tez
 type s = (t * tez)

--- a/tests/test8.liq
+++ b/tests/test8.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : timestamp)

--- a/tests/test9.liq
+++ b/tests/test9.liq
@@ -1,7 +1,7 @@
 
 (* constants *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 type storage = bool *
                int option *

--- a/tests/test_closure.liq
+++ b/tests/test_closure.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : int)

--- a/tests/test_closure2.liq
+++ b/tests/test_closure2.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : int)

--- a/tests/test_closure3.liq
+++ b/tests/test_closure3.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : int)

--- a/tests/test_extfun.liq
+++ b/tests/test_extfun.liq
@@ -1,5 +1,5 @@
 
-[%%version 0.12]
+[%%version 0.13]
 
 let f ((x : unit), (_ : int) ) = x
 

--- a/tests/test_if.liq
+++ b/tests/test_if.liq
@@ -1,7 +1,7 @@
 
 (* constants *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 type storage =
         bool *

--- a/tests/test_ifcons.liq
+++ b/tests/test_ifcons.liq
@@ -1,7 +1,7 @@
 
 (* lists *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : string)

--- a/tests/test_loop.liq
+++ b/tests/test_loop.liq
@@ -1,7 +1,7 @@
 
 (* loops *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : int)

--- a/tests/test_map.liq
+++ b/tests/test_map.liq
@@ -1,6 +1,6 @@
 (* List.map *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let succ (x : int) = x + 1
 

--- a/tests/test_map_closure.liq
+++ b/tests/test_map_closure.liq
@@ -1,6 +1,6 @@
 (* List.map with closure *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : int)

--- a/tests/test_mapmap_closure.liq
+++ b/tests/test_mapmap_closure.liq
@@ -1,4 +1,4 @@
-[%%version 0.12]
+[%%version 0.13]
 let%entry main
   (parameter : string)
   (storage : (string, tez) map)

--- a/tests/test_reduce_closure.liq
+++ b/tests/test_reduce_closure.liq
@@ -1,6 +1,6 @@
 (* loops *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
     (parameter : int list)

--- a/tests/test_rev.liq
+++ b/tests/test_rev.liq
@@ -1,6 +1,6 @@
 (* List.rev *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : int)

--- a/tests/test_transfer.liq
+++ b/tests/test_transfer.liq
@@ -1,7 +1,7 @@
 
 (* transfers *)
 
-[%%version 0.12]
+[%%version 0.13]
 
 let%entry main
       (parameter : (unit,unit) contract)

--- a/tools/liquidity/build.ocp2
+++ b/tools/liquidity/build.ocp2
@@ -55,9 +55,9 @@ OCaml.library("ocplib-liquidity",
 
        "liquidEmit.ml";
        "liquidPeephole.ml";
+       "liquidCheck.ml";
        "liquidMichelson.ml";
        "liquidSimplify.ml";
-       "liquidCheck.ml";
 
        "liquidClean.ml";
        "liquidInterp.ml";

--- a/tools/liquidity/build.ocp2
+++ b/tools/liquidity/build.ocp2
@@ -56,6 +56,7 @@ OCaml.library("ocplib-liquidity",
        "liquidEmit.ml";
        "liquidPeephole.ml";
        "liquidCheck.ml";
+       "liquidEncode.ml";
        "liquidMichelson.ml";
        "liquidSimplify.ml";
 

--- a/tools/liquidity/liquidBoundVariables.ml
+++ b/tools/liquidity/liquidBoundVariables.ml
@@ -115,7 +115,7 @@ let rec bv code =
            StringSet.union set bv_case
          ) StringSet.empty args)
 
-let mk desc exp bv = { desc; ty = exp.ty; bv; fail = exp.fail }
+let mk desc exp bv = { exp with desc; bv }
 
 let rec bound code =
   match code.desc with

--- a/tools/liquidity/liquidBoundVariables.mli
+++ b/tools/liquidity/liquidBoundVariables.mli
@@ -10,6 +10,6 @@
 open LiquidTypes
 
 (* Compute free variables of an expression *)
-val bound_contract : 'a exp contract -> 'a exp contract
-val bound : 'a exp -> 'a exp
-val bv : 'a exp -> StringSet.t
+val bound_contract : ('a, 'b) exp contract -> ('a, 'b) exp contract
+val bound : ('a, 'b) exp -> ('a, 'b) exp
+val bv : ('a, 'b) exp -> StringSet.t

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -87,18 +87,7 @@ let find_var ?(count_used=true) env loc name =
     if count_used then incr count;
     mk (Var (name, loc, [])) ty
   with Not_found ->
-  match env.clos_env with
-  | None -> error loc "unbound variable %S" name
-  | Some ce ->
-    try
-      let v, (cpt_in, cpt_out) = StringMap.find name ce.env_bindings in
-      if count_used then begin
-        incr cpt_in;
-        incr cpt_out;
-      end;
-      v
-    with Not_found ->
-      error loc "unbound variable %S" name
+    error loc "unbound variable %S" name
 
 let maybe_reset_vars env transfer =
   if transfer then
@@ -170,7 +159,7 @@ let rec loc_exp env e = match e.desc with
    * whether the expression can fail
    * whether the expression performs a TRANSFER_TOKENS
    *)
-let rec typecheck env ( exp : LiquidTypes.syntax_exp ) =
+let rec typecheck env ( exp : syntax_exp ) : typed_exp =
   match exp.desc with
 
   | Const (ty, cst) ->

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -596,15 +596,7 @@ and typecheck_prim1 env prim loc args =
      in
      let n = LiquidPrinter.int_of_integer n in
      let size = List.length tuple in
-     let prim =
-       if size <= n then
-         error loc "get outside tuple"
-       else
-         if size = n + 1 then
-           Prim_tuple_get_last
-         else
-           Prim_tuple_get
-     in
+     if size <= n then error loc "get outside tuple";
      let ty = List.nth tuple n in
      prim, ty
 
@@ -620,15 +612,7 @@ and typecheck_prim1 env prim loc args =
      let n = LiquidPrinter.int_of_integer n in
      let expected_ty = List.nth tuple n in
      let size = List.length tuple in
-     let prim =
-       if size <= n then
-         error loc "set outside tuple"
-       else
-         if size = n + 1 then
-           Prim_tuple_set_last
-         else
-           Prim_tuple_set
-     in
+     if size <= n then error loc "set outside tuple";
      let ty = if not (eq_types ty expected_ty || eq_types ty Tfail) then
                 error loc "prim set bad type"
               else tuple_ty

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -347,7 +347,7 @@ let rec typecheck env ( exp : syntax_exp ) : typed_exp =
      check_used env name loc count;
      let desc = MatchOption (arg, loc, ifnone, name, ifsome ) in
      let ty =
-       match ifnone.ty, ifsome.ty with
+       match get_type ifnone.ty, get_type ifsome.ty with
        | ty, Tfail | Tfail, ty -> ty
        | ty1, ty2 ->
           if ty1 <> ty2 then type_error loc "Bad option type in match" ty2 ty1;
@@ -366,7 +366,7 @@ let rec typecheck env ( exp : syntax_exp ) : typed_exp =
      check_used env minus_name loc count_m;
      let desc = MatchNat (arg, loc, plus_name, ifplus, minus_name, ifminus) in
      let ty =
-       match ifplus.ty, ifminus.ty with
+       match get_type ifplus.ty, get_type ifminus.ty with
        | ty, Tfail | Tfail, ty -> ty
        | ty1, ty2 ->
          if ty1 <> ty2 then
@@ -378,7 +378,7 @@ let rec typecheck env ( exp : syntax_exp ) : typed_exp =
 
   | Loop (name, loc, body, arg) ->
      let arg = typecheck env arg in
-     if arg.ty = Tfail then error loc "loop arg is a failure";
+     if get_type arg.ty = Tfail then error loc "loop arg is a failure";
      let env = maybe_reset_vars env arg.transfer in
      let (env, count) = new_binding env name arg.ty in
      let body =
@@ -388,7 +388,7 @@ let rec typecheck env ( exp : syntax_exp ) : typed_exp =
 
   | MatchList (arg, loc, head_name, tail_name, ifcons, ifnil) ->
      let arg  = typecheck env arg in
-     let arg_ty = match arg.ty with
+     let arg_ty = match get_type arg.ty with
        | Tfail -> error loc "cannot match failure"
        | Tlist ty -> ty
        | _ -> error loc "not a list type"
@@ -402,7 +402,7 @@ let rec typecheck env ( exp : syntax_exp ) : typed_exp =
      check_used env tail_name loc count;
      let desc = MatchList (arg, loc, head_name, tail_name, ifcons, ifnil) in
      let ty =
-       match ifnil.ty, ifcons.ty with
+       match get_type ifnil.ty, get_type ifcons.ty with
        | ty, Tfail | Tfail, ty -> ty
        | ty1, ty2 ->
           if ty1 <> ty2 then

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -957,7 +957,7 @@ let check_const_type ?(from_mic=false) ~to_tez loc ty cst =
     | Tbool, CBool b -> CBool b
 
     | Tint, CInt s
-      | Tint, CNat s -> CInt s
+    | Tint, CNat s -> CInt s
 
     | Tnat, CInt s
     | Tnat, CNat s -> CNat s
@@ -981,6 +981,12 @@ let check_const_type ?(from_mic=false) ~to_tez loc ty cst =
 
     | Toption _, CNone -> CNone
     | Toption ty, CSome cst -> CSome (check_const_type ty cst)
+
+    | Tor (left_ty, _), CLeft cst ->
+      CLeft (check_const_type left_ty cst)
+
+    | Tor (_, right_ty), CRight cst ->
+      CRight (check_const_type right_ty cst)
 
     | Tmap (ty1, ty2), CMap csts ->
        CMap (List.map (fun (cst1, cst2) ->

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -177,7 +177,7 @@ let rec typecheck env ( exp : syntax_exp ) : typed_exp =
 
   | Var (name, loc, (_::_ as labels)) ->
     begin match find_var env loc name with
-      | { desc = Var (name, _, []); ty = (Ttype _) as ty } ->
+      | { desc = Var (name, _, []); ty } ->
         let ty =
           List.fold_left (fun ty label ->
               match get_type ty with
@@ -190,7 +190,8 @@ let rec typecheck env ( exp : syntax_exp ) : typed_exp =
                     ty'
                   with Not_found -> error loc "bad label"
                 end
-              | _ -> error loc "not a record"
+              | _ -> error loc "not a record : %s"
+                       (LiquidPrinter.Liquid.string_of_type_expl ty)
             ) ty labels
         in
         mk (Var (name, loc, labels)) ty
@@ -335,7 +336,7 @@ let rec typecheck env ( exp : syntax_exp ) : typed_exp =
 
   | MatchOption (arg, loc, ifnone, name, ifsome) ->
      let arg = typecheck env arg in
-     let arg_ty = match arg.ty with
+     let arg_ty = match get_type arg.ty with
        | Tfail -> error loc "cannot match failure"
        | Toption ty -> ty
        | _ -> error loc "not an option type"

--- a/tools/liquidity/liquidCheck.mli
+++ b/tools/liquidity/liquidCheck.mli
@@ -13,17 +13,16 @@ val error :
   location ->
   ('a, Format.formatter, unit, unit, unit, 'b) format6 -> 'a
 
-val typecheck_contract : warnings:bool -> env ->
+val typecheck_contract : only_typecheck:bool -> warnings:bool -> env ->
                          syntax_exp contract ->
-                         typed_exp contract
-                         * datatype exp StringMap.t
+                         typed_exp contract * datatype exp StringMap.t
 
                        (*
 val uniq_ident : string -> string
                         *)
 
 val typecheck_code :
-  warnings:bool -> env ->
+  only_typecheck:bool -> warnings:bool -> env ->
   syntax_exp contract ->
   LiquidTypes.datatype ->
   syntax_exp ->

--- a/tools/liquidity/liquidCheck.mli
+++ b/tools/liquidity/liquidCheck.mli
@@ -14,7 +14,7 @@ val error :
   ('a, Format.formatter, unit, unit, unit, 'b) format6 -> 'a
 
 val typecheck_contract :
-  warnings:bool -> env -> syntax_exp contract -> typed_exp contract
+  warnings:bool -> env -> syntax_contract -> typed_contract
 
                        (*
 val uniq_ident : string -> string
@@ -22,7 +22,7 @@ val uniq_ident : string -> string
 
 val typecheck_code :
   warnings:bool -> env ->
-  syntax_exp contract ->
+  syntax_contract ->
   LiquidTypes.datatype ->
   syntax_exp ->
   typed_exp

--- a/tools/liquidity/liquidCheck.mli
+++ b/tools/liquidity/liquidCheck.mli
@@ -13,6 +13,8 @@ val error :
   location ->
   ('a, Format.formatter, unit, unit, unit, 'b) format6 -> 'a
 
+val encode_type : ?keepalias:bool -> datatype -> datatype
+
 val typecheck_contract : only_typecheck:bool -> warnings:bool -> env ->
                          syntax_exp contract ->
                          typed_exp contract * datatype exp StringMap.t

--- a/tools/liquidity/liquidData.ml
+++ b/tools/liquidity/liquidData.ml
@@ -14,7 +14,7 @@
 
 open LiquidTypes
 
-let rec translate_const_exp loc exp =
+let rec translate_const_exp loc (exp : encoded_exp) =
   match exp.desc with
   | Let (_, loc, _, _) ->
      LiquidLoc.raise_error ~loc "'let' forbidden in constant"
@@ -22,7 +22,7 @@ let rec translate_const_exp loc exp =
 
   (* removed during typechecking *)
   | Record (_, _)
-    | Constructor (_, _, _) -> assert false
+  | Constructor (_, _, _) -> assert false
 
   | Apply (Prim_Left, _, [x; _ty]) -> CLeft (translate_const_exp loc x)
   | Apply (Prim_Right, _, [x; _ty]) -> CRight (translate_const_exp loc x)
@@ -38,19 +38,19 @@ let rec translate_const_exp loc exp =
                              (LiquidTypes.string_of_primitive prim)
                              (List.length args)
   | Var (_, _, _)
-    | SetVar (_, _, _, _)
-    | If (_, _, _)
-    | Seq (_, _)
-    | LetTransfer (_, _, _, _, _, _, _, _)
-    | MatchOption (_, _, _, _, _)
-    | MatchNat (_, _, _, _, _, _)
-    | MatchList (_, _, _, _, _, _)
-    | Loop (_, _, _, _)
-    | Lambda (_, _, _, _, _)
-    | Closure (_, _, _, _, _, _)
-    | MatchVariant (_, _, _)
+  | SetVar (_, _, _, _)
+  | If (_, _, _)
+  | Seq (_, _)
+  | LetTransfer (_, _, _, _, _, _, _, _)
+  | MatchOption (_, _, _, _, _)
+  | MatchNat (_, _, _, _, _, _)
+  | MatchList (_, _, _, _, _, _)
+  | Loop (_, _, _, _)
+  | Lambda (_, _, _, _, _)
+  | Closure (_, _, _, _, _, _)
+  | MatchVariant (_, _, _)
     ->
-     LiquidLoc.raise_error ~loc "non-constant expression"
+    LiquidLoc.raise_error ~loc "non-constant expression"
 
 let data_of_liq ~filename ~contract ~parameter ~storage =
   (* first, extract the types *)
@@ -66,9 +66,11 @@ let data_of_liq ~filename ~contract ~parameter ~storage =
       let sy_exp = LiquidFromOCaml.translate_expression env ml_exp in
       let ty_exp = LiquidCheck.typecheck_code
           ~warnings:true env contract ty sy_exp in
+      let enc_exp = LiquidEncode.encode_code
+          ~warnings:true env contract ty_exp in
       let loc = LiquidLoc.loc_in_file filename in
-      let ty_exp = translate_const_exp loc ty_exp in
-      let s = LiquidPrinter.Michelson.line_of_const ty_exp in
+      let c = translate_const_exp loc enc_exp in
+      let s = LiquidPrinter.Michelson.line_of_const c in
       Ok s
     with LiquidError error ->
       Error error

--- a/tools/liquidity/liquidData.ml
+++ b/tools/liquidity/liquidData.ml
@@ -57,8 +57,7 @@ let data_of_liq ~filename ~contract ~parameter ~storage =
   let ocaml_ast = LiquidFromOCaml.structure_of_string
                     ~filename contract in
   let contract, env = LiquidFromOCaml.translate ~filename ocaml_ast in
-  let _, _ = LiquidCheck.typecheck_contract
-               ~only_typecheck:false
+  let _ = LiquidCheck.typecheck_contract
                ~warnings:true env contract in
 
   let translate filename s ty =
@@ -66,7 +65,7 @@ let data_of_liq ~filename ~contract ~parameter ~storage =
       let ml_exp = LiquidFromOCaml.expression_of_string ~filename s in
       let sy_exp = LiquidFromOCaml.translate_expression env ml_exp in
       let ty_exp = LiquidCheck.typecheck_code
-          ~only_typecheck:false ~warnings:true env contract ty sy_exp in
+          ~warnings:true env contract ty sy_exp in
       let loc = LiquidLoc.loc_in_file filename in
       let ty_exp = translate_const_exp loc ty_exp in
       let s = LiquidPrinter.Michelson.line_of_const ty_exp in

--- a/tools/liquidity/liquidData.ml
+++ b/tools/liquidity/liquidData.ml
@@ -58,14 +58,15 @@ let data_of_liq ~filename ~contract ~parameter ~storage =
                     ~filename contract in
   let contract, env = LiquidFromOCaml.translate ~filename ocaml_ast in
   let _, _ = LiquidCheck.typecheck_contract
+               ~only_typecheck:false
                ~warnings:true env contract in
 
   let translate filename s ty =
     try
       let ml_exp = LiquidFromOCaml.expression_of_string ~filename s in
       let sy_exp = LiquidFromOCaml.translate_expression env ml_exp in
-      let ty_exp =
-        LiquidCheck.typecheck_code ~warnings:true env contract ty sy_exp in
+      let ty_exp = LiquidCheck.typecheck_code
+          ~only_typecheck:false ~warnings:true env contract ty sy_exp in
       let loc = LiquidLoc.loc_in_file filename in
       let ty_exp = translate_const_exp loc ty_exp in
       let s = LiquidPrinter.Michelson.line_of_const ty_exp in

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -26,6 +26,8 @@ let const_name_of_datatype = function
   | Tsignature -> "sig"
   | Ttuple _ -> "tuple"
   | Toption _ -> "opt"
+  | Trecord _ -> "record"
+  | Tsum _ -> "sum"
   | Tlist _ -> "l"
   | Tset _ -> "s"
   | Tmap _ -> "map"

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -35,7 +35,6 @@ let const_name_of_datatype = function
   | Tor _ -> "or"
   | Tlambda _ | Tclosure _  -> "fun"
   | Tfail -> "fail"
-  | Ttype _ -> "ty"
 
 
 let rec var_of node =

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -11,7 +11,7 @@ open LiquidTypes
 
 let noloc = LiquidLoc.noloc
 
-let mk desc = { desc; ty = (); bv = StringSet.empty; fail = false }
+let mk desc = mk desc ()
 
 let const_name_of_datatype = function
   | Tunit -> "u"

--- a/tools/liquidity/liquidEncode.ml
+++ b/tools/liquidity/liquidEncode.ml
@@ -1,0 +1,883 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright (c) 2017       .                                          *)
+(*    Fabrice Le Fessant, OCamlPro SAS <fabrice@lefessant.net>            *)
+(*                                                                        *)
+(*    All rights reserved. No warranty, explicit or implicit, provided.   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open LiquidTypes
+
+let noloc env = LiquidLoc.loc_in_file env.env.filename
+
+let error loc msg =
+  LiquidLoc.raise_error ~loc ("Type error: " ^^ msg ^^ "%!")
+
+let mk_nat i =
+  mk (Const (Tnat, CNat (LiquidPrinter.integer_of_int i))) Tnat
+
+let mk_nil list_ty =
+  mk (Const (list_ty, CList [])) list_ty
+
+let mk_tuple loc l =
+  let tuple_ty = Ttuple (List.map (fun t -> t.ty) l) in
+  mk (Apply (Prim_tuple, loc, l)) tuple_ty
+
+let const_unit = mk (Const (Tunit, CUnit)) Tunit
+
+let const_true = mk (Const (Tbool, CBool true)) Tbool
+
+let const_false = mk (Const (Tbool, CBool false)) Tbool
+
+let unused env ty =
+  mk (Apply(Prim_unused, noloc env, [const_unit])) ty
+
+let uniq_ident env name =
+  env.counter := !(env.counter) + 1;
+  Printf.sprintf "%s/%d" name !(env.counter)
+
+let new_binding env name ty =
+  let new_name = uniq_ident env name in
+  let count = ref 0 in
+  let env = { env with
+              vars = StringMap.add name (new_name, ty, count) env.vars } in
+  (new_name, env, count)
+
+let maybe_reset_vars env transfer =
+  if transfer then
+    { env with
+      vars = StringMap.empty;
+      clos_env = None;
+    }
+  else env
+
+(* Find variable name in either the global environment or the closure
+   environment, returns a corresponding expression *)
+let find_var ?(count_used=true) env loc name =
+  try
+    let (name, ty, count) = StringMap.find name env.vars in
+    if count_used then incr count;
+    mk (Var (name, loc, [])) ty
+  with Not_found ->
+  match env.clos_env with
+  | None -> error loc "unbound variable %S" name
+  | Some ce ->
+    try
+      let v, (cpt_in, cpt_out) = StringMap.find name ce.env_bindings in
+      if count_used then begin
+        incr cpt_in;
+        incr cpt_out;
+      end;
+      v
+    with Not_found ->
+      error loc "unbound variable %S" name
+
+(* Create environment for closure *)
+let env_for_clos env loc bvs arg_name arg_type =
+  let _, free_vars = StringSet.fold (fun v (index, free_vars) ->
+      try
+        let index = index + 1 in
+        match env.clos_env with
+        | None ->
+          let (bname, btype, cpt_out) = StringMap.find v env.vars in
+          (index,
+           StringMap.add v (bname, btype, index, (ref 0, cpt_out)) free_vars)
+        | Some ce ->
+          let bname, btype, _, (cpt_in, cpt_out) =
+            StringMap.find v ce.env_vars in
+          (index,
+           StringMap.add v (bname, btype, index, (cpt_in, cpt_out)) free_vars)
+      with Not_found ->
+        (index, free_vars)
+    ) bvs (0, StringMap.empty)
+  in
+  let free_vars_l =
+    StringMap.bindings free_vars
+    |> List.sort (fun (_, (_,_,i1,_)) (_, (_,_,i2,_)) -> compare i1 i2)
+  in
+  let ext_env = env in
+  let env = { env with vars = StringMap.empty } in
+  match free_vars_l with
+  | [] -> (* no closure environment *)
+    let (new_name, env, _) = new_binding env arg_name arg_type in
+    env, new_name, arg_type, []
+  | _ ->
+    let env_arg_name = uniq_ident env "closure_env" in
+    let env_arg_type =
+      Ttuple (arg_type :: List.map (fun (_, (_,ty,_,_)) -> ty) free_vars_l) in
+    let env_arg_var = mk (Var (env_arg_name, loc, [])) env_arg_type in
+    let new_name = uniq_ident env arg_name in
+    let env_vars =
+      StringMap.add arg_name
+        (new_name, arg_type, 0, (ref 0, ref 0)) free_vars in
+    let size = StringMap.cardinal env_vars in
+    let env_bindings =
+      StringMap.map (fun (_, ty, index, count) ->
+          let ei = mk_nat index in
+          let accessor =
+            if index + 1 = size then Prim_tuple_get_last
+            else Prim_tuple_get in
+          let exp = mk (Apply(accessor, loc, [env_arg_var; ei])) ty in
+          exp, count
+        ) env_vars
+    in
+    let call_bindings = List.map (fun (name, _) ->
+        name, find_var ~count_used:false ext_env loc name
+      ) free_vars_l
+    in
+    (* Format.eprintf "--- Closure %s ---@." env_arg_name; *)
+    (* StringMap.iter (fun name (e,_) -> *)
+    (*     Format.eprintf "%s -> %s@." *)
+    (*       name (LiquidPrinter.Liquid.string_of_code e) *)
+    (*   ) env_bindings; *)
+    let env_closure = {
+      env_vars;
+      env_bindings;
+      call_bindings;
+    } in
+    let env =
+      { env with
+        clos_env = Some env_closure
+      }
+    in
+    env, env_arg_name, env_arg_type, call_bindings
+
+
+let rec encode_type ?(keepalias=true) ty =
+  (* if env.only_typecheck then ty *)
+  (* else *)
+  match ty with
+  | Ttez | Tunit | Ttimestamp | Tint | Tnat | Tbool | Tkey | Tkey_hash
+  | Tsignature | Tstring | Tfail -> ty
+  | Ttuple tys ->
+    let tys' = List.map (encode_type ~keepalias) tys in
+    if List.for_all2 (==) tys tys' then ty
+    else Ttuple tys'
+  | Tset t | Tlist t | Toption t ->
+    let t' = encode_type ~keepalias t in
+    if t' == t then ty
+    else begin match ty with
+      | Tset t -> Tset t'
+      | Tlist t -> Tlist t'
+      | Toption t -> Toption t'
+      | _ -> assert false
+    end
+  | Tor (t1, t2) | Tcontract (t1, t2) | Tlambda (t1, t2) | Tmap (t1, t2) ->
+    let t1', t2' = encode_type ~keepalias t1, encode_type ~keepalias t2 in
+    if t1 == t1' && t2 == t2' then ty
+    else begin match ty with
+      | Tor (t1, t2) -> Tor (t1', t2')
+      | Tcontract (t1, t2) -> Tcontract (t1', t2')
+      | Tlambda (t1, t2) -> Tlambda (t1', t2')
+      | Tmap (t1, t2) -> Tmap (t1', t2')
+      | _ -> assert false
+    end
+  | Tclosure  ((t1, t2), t3) ->
+    let t1' = encode_type ~keepalias t1 in
+    let t2' = encode_type ~keepalias t2 in
+    let t3' = encode_type ~keepalias t3 in
+    if t1 == t1' && t2 == t2' && t3 == t3' then ty
+    else Tclosure ((t1', t2'), t3')
+  | Ttype (name, t) ->
+    let t' = encode_type ~keepalias t in
+    if not keepalias then t'
+    else if t' == t then ty
+    else Ttype (name, t')
+  | Trecord labels -> encode_record_type ~keepalias labels
+  | Tsum cstys -> encode_sum_type ~keepalias cstys
+
+and encode_record_type ~keepalias labels =
+  Ttuple (List.map (fun (_, ty) -> encode_type ~keepalias ty) labels)
+
+and encode_sum_type ~keepalias cstys =
+  let rec rassoc = function
+    | [] -> assert false
+    | [_, ty] -> encode_type ~keepalias ty
+    | (_, lty) :: rstys ->
+      Tor (encode_type ~keepalias lty, rassoc rstys)
+  in
+  rassoc cstys
+
+let rec encode_const env c = match c with
+  | CUnit | CBool _ | CInt _ | CNat _ | CTez _ | CTimestamp _ | CString _
+  | CKey _ | CSignature _ | CNone  | CKey_hash _ -> c
+
+  | CSome x -> CSome (encode_const env x)
+  | CLeft x -> CLeft (encode_const env x)
+  | CRight x -> CRight (encode_const env x)
+
+  | CTuple xs -> CTuple (List.map (encode_const env) xs)
+  | CList xs -> CList (List.map (encode_const env) xs)
+  | CSet xs -> CSet (List.map (encode_const env) xs)
+
+  | CMap l ->
+    CMap (List.map (fun (x,y) -> encode_const env x, encode_const env y) l)
+
+  | CRecord labels ->
+    CTuple (List.map (fun (_, x) -> encode_const env x) labels)
+
+  | CConstr (constr, x) ->
+    try
+      let ty_name, _ = StringMap.find constr env.env.constrs in
+      let constr_ty = StringMap.find ty_name env.env.types in
+      match constr_ty with
+      | Tsum constrs ->
+        let rec iter constrs =
+          match constrs with
+          | [] -> assert false
+          | [c, _] ->
+            assert (c = constr);
+            encode_const env x
+          | (c, _) :: constrs ->
+            if c = constr then CLeft (encode_const env x)
+            else CRight (iter constrs)
+        in
+        iter constrs
+      | _ -> raise Not_found
+    with Not_found ->
+      error (noloc env)  "unknown constructor %s" constr
+
+
+let encode_prim_get arg n =
+  let size = match (get_type arg.ty) with
+    | Ttuple tuple -> List.length tuple
+    | Trecord rtys -> List.length rtys
+    | _ -> assert false
+  in
+  let prim =
+    if size = n + 1 then
+      Prim_tuple_get_last
+    else
+      Prim_tuple_get
+  in
+  prim, [arg; mk_nat n]
+
+
+let encode_prim_set arg n v =
+  let size = match (get_type arg.ty) with
+    | Ttuple tuple -> List.length tuple
+    | Trecord rtys -> List.length rtys
+    | _ -> assert false
+  in
+  let prim =
+    if size = n + 1 then
+      Prim_tuple_set_last
+    else
+      Prim_tuple_set
+  in
+  prim, [arg; mk_nat n; v]
+
+let rec encode env ( exp : typed_exp ) =
+  match exp.desc with
+
+  | Const (ty, cst) ->
+    mk (Const (ty, encode_const env cst)) ty
+
+  | Let (name, loc, e, body) ->
+
+     let e = encode env e in
+     let env = maybe_reset_vars env e.transfer in
+     let (new_name, env, count) = new_binding env name e.ty in
+     let body = encode env body in
+     (* check_used env name loc count; *)
+     if (not e.transfer) && (not e.fail) then begin
+         match !count with
+         | 0 ->
+           env.to_inline :=
+             StringMap.add new_name (const_unit) !(env.to_inline)
+         | 1 ->
+            env.to_inline := StringMap.add new_name e !(env.to_inline)
+         | _ -> ()
+     end;
+     mk (Let (new_name, loc, e, body)) body.ty
+
+  | Var (name, loc, labels) ->
+    let e = find_var env loc name in
+    List.fold_left
+      (fun e label ->
+         let ty_name, ty = match first_alias e.ty with
+           | Some (ty_name, (Trecord _ as ty)) -> ty_name, ty
+           | _ -> error loc "not a record"
+         in
+         let arg1 = mk e.desc ty in
+         let n, label_ty =
+           try
+             let (ty_name', n, label_ty) =
+               StringMap.find label env.env.labels in
+             if ty_name' <> ty_name then
+               error loc "label for wrong record";
+             n, label_ty
+           with Not_found ->
+             error loc "bad label"
+         in
+         let prim, args = encode_prim_get arg1 n in
+         mk (Apply(prim, loc, args)) label_ty
+      ) e labels
+
+  | SetVar (name, loc, [], e) -> encode env e
+
+  | SetVar (name, loc, label :: labels, arg) ->
+     let arg1 = find_var env loc name in
+     let label_types = match get_type arg1.ty with
+       | Trecord label_types -> label_types
+       | _ -> assert false
+     in
+     let exception Return of (int * datatype) in
+     let n, lty =
+       try
+         List.iteri (fun n (l, lty) ->
+             if l = label then raise (Return (n, lty))
+           ) label_types;
+         error loc "bad label"
+       with Return n -> n
+     in
+     let arg =
+       match labels with
+       | [] ->
+         let arg = encode env arg in
+         if arg.transfer then error loc "transfer within set-field";
+         arg
+       | _::_ ->
+         let prim, args = encode_prim_get arg1 n in
+         let get_exp = mk (Apply(prim, loc, args)) lty in
+         let tmp_name = uniq_ident env "tmp#" in
+         let (new_name, env, count) = new_binding env tmp_name lty in
+         let body =
+           encode env
+             { exp with desc = SetVar (tmp_name, loc, labels, arg) }
+         in
+         { body with
+           desc = Let (new_name, loc, get_exp, body) }
+     in
+     let prim, args = encode_prim_set arg1 n arg in
+     mk (Apply(prim, loc, args)) arg1.ty
+
+  | Seq (exp1, exp2) ->
+    (* TODO: if not exp.fail then remove exp1 *)
+    let exp1 = encode env exp1 in
+    let exp2 = encode env exp2 in
+    mk (Seq (exp1, exp2)) exp2.ty
+
+  | If (cond, ifthen, ifelse) ->
+    let cond = encode env cond in
+    let ifthen = encode env ifthen in
+    let ifelse = encode env ifelse in
+    mk (If (cond, ifthen, ifelse)) ifthen.ty
+
+  | LetTransfer (storage_name, result_name,
+                 loc,
+                 contract_exp, tez_exp,
+                 storage_exp, arg_exp, body) ->
+    let tez_exp = encode env tez_exp in
+    let contract_exp = encode env contract_exp in
+    let arg_exp = encode env arg_exp in
+    let storage_exp = encode env storage_exp in
+    let return_ty = match contract_exp.ty with
+      | Tcontract (_, return_ty) -> return_ty
+      | _ -> assert false
+    in
+    let (new_storage, env, storage_count) =
+      new_binding env storage_name env.contract.storage in
+    let (new_result, env, result_count) =
+      new_binding env result_name return_ty in
+    let body = encode env body in
+    (* check_used env storage_name loc storage_count; *)
+    (* check_used env result_name loc result_count; *)
+    mk (LetTransfer(new_storage, new_result,
+                    loc,
+                    contract_exp, tez_exp,
+                    storage_exp, arg_exp, body)) body.ty
+
+  | Apply (Prim_unknown, _, _) -> assert false
+
+
+  (* List.rev -> List.reduce (::) *)
+  | Apply (Prim_list_rev, loc, [l]) ->
+    let l = encode env l in
+    let elt_ty = match l.ty with
+      | Tlist ty -> ty
+      | _ -> assert false
+    in
+    let list_ty = l.ty in
+    let arg_name = uniq_ident env "arg" in
+    let arg_ty = Ttuple [elt_ty; list_ty] in
+    let arg = mk (Var (arg_name, loc, [])) arg_ty in
+    let e = mk (Apply(Prim_tuple_get, loc, [arg; mk_nat 0])) elt_ty in
+    let acc =
+      mk (Apply(Prim_tuple_get_last, loc, [arg; mk_nat 1])) list_ty in
+    let f_body = mk (Apply (Prim_Cons, loc, [e; acc])) list_ty in
+    let f_desc = Lambda (arg_name, arg_ty, loc, f_body, list_ty) in
+    let f = mk f_desc (Tlambda (arg_ty, list_ty)) in
+    let empty_acc = mk_nil list_ty in
+    let desc = Apply (Prim_list_reduce, loc, [f; l; empty_acc]) in
+    mk desc list_ty
+
+  (* List.reduce (closure) -> Loop.loop *)
+  | Apply (Prim_list_reduce, loc, [f; l; acc]) ->
+    let f = encode env f in
+    let l = encode env l in
+    let acc = encode env acc in
+    let args = [f; l; acc] in
+    begin match f.ty with
+      | Tclosure ((arg_ty, env_ty), acc_ty) ->
+        let elt_ty = match l.ty with
+          | Tlist ty -> ty
+          | _ -> assert false
+        in
+        let loop_arg_name = uniq_ident env "arg" in
+        let head_name = uniq_ident env "head" in
+        let tail_name = uniq_ident env "tail" in
+        (* let loop_arg_ty = arg_ty in *)
+        let loop_body_ty = Ttuple [Tbool; arg_ty] in
+        let list_ty = Tlist elt_ty in
+        let arg = mk (Var (loop_arg_name, loc, [])) arg_ty in
+        let head = mk (Var (head_name, loc, [])) elt_ty in
+        let tail = mk (Var (tail_name, loc, [])) list_ty in
+        let l' =
+          mk (Apply(Prim_tuple_get, loc, [arg; mk_nat 0])) list_ty in
+        let acc' =
+          mk (Apply(Prim_tuple_get_last, loc, [arg; mk_nat 1])) acc_ty in
+        let nil_case = mk_tuple loc [
+            const_false ;
+            mk_tuple loc [mk_nil list_ty; acc']
+          ] in
+        let cons_case =
+          mk_tuple loc [
+            const_true;
+            mk_tuple loc [
+              tail;
+              mk (Apply (Prim_exec, loc, [
+                  mk_tuple loc [head; acc'];
+                  f
+                ])) acc_ty
+            ]
+          ]
+        in
+        let loop_body = mk
+            (MatchList (l', loc, head_name, tail_name, cons_case, nil_case))
+            loop_body_ty
+        in
+        let loop = mk
+            (Loop (loop_arg_name, loc, loop_body,
+                   mk_tuple loc [l; acc]))
+            (Ttuple [list_ty; acc_ty])
+        in
+        mk (Apply (Prim_tuple_get_last, loc, [loop; mk_nat 1]))
+          acc_ty
+      | _ ->
+        mk (Apply (Prim_list_reduce, loc, args)) acc.ty
+    end
+
+  (* List.map (closure) -> {List.rev(List.reduce (closure)} *)
+  | Apply (Prim_list_map, loc, [f; l]) ->
+    let f' = encode env f in
+    begin match get_type f'.ty with
+      | Tlambda _ ->
+        let l = encode env l in
+        { exp with desc = Apply (Prim_list_map, loc, [f'; l]) }
+      | Tclosure ((arg_ty, _), ty_ret) ->
+        let arg_name = uniq_ident env "arg" in
+        let acc_ty = Tlist ty_ret in
+        let rarg_ty = Ttuple [arg_ty; Tlist ty_ret] in
+        let arg = mk (Var (arg_name, loc, [])) rarg_ty in
+        let x =
+          mk (Apply(Prim_tuple_get, loc, [arg; mk_nat 0])) arg_ty in
+        let acc =
+          mk (Apply(Prim_tuple_get, loc, [arg; mk_nat 1])) acc_ty in
+        let f_body = mk (Apply(Prim_Cons, loc, [
+            mk (Apply(Prim_exec, loc, [x; f])) ty_ret;
+            acc
+          ])) acc_ty in
+        let f_red =
+          mk (Lambda (arg_name, rarg_ty, loc, f_body, acc_ty))
+            (Tlambda (rarg_ty, acc_ty)) in
+        let red =
+          mk (Apply (Prim_list_reduce, loc,
+                     [f_red; l; mk_nil acc_ty])) acc_ty in
+        let rev_red = mk (Apply (Prim_list_rev, loc, [red])) acc_ty in
+        encode env rev_red
+      | _ -> assert false
+    end
+
+  (* Map.reduce (closure) -> {Map.reduce (::) |> List.rev |> List.reduce} *)
+  | Apply (Prim_map_reduce, loc, [f; m; acc]) ->
+    let f' = encode env f in
+    begin match get_type f'.ty with
+      | Tlambda _ ->
+        let m = encode env m in
+        let acc = encode env acc in
+        { exp with desc = Apply (Prim_map_reduce, loc, [f'; m; acc]) }
+      | Tclosure ((Ttuple [kv_ty; acc_ty], _), ty_ret) ->
+        let arg_name = uniq_ident env "arg" in
+        let elts_ty = Tlist kv_ty in
+        let arg_ty = Ttuple [kv_ty; elts_ty] in
+        let arg = mk (Var (arg_name, loc, [])) elts_ty in
+        let kv =
+          mk (Apply(Prim_tuple_get, loc, [arg; mk_nat 0])) kv_ty in
+        let acc_elts =
+          mk (Apply(Prim_tuple_get, loc, [arg; mk_nat 1])) elts_ty in
+        let gather_body =
+          mk (Apply(Prim_Cons, loc, [kv; acc_elts])) elts_ty in
+        let gather_fun =
+          mk (Lambda (arg_name, arg_ty, loc, gather_body, elts_ty))
+            (Tlambda (arg_ty, elts_ty))
+        in
+        let rev_elts =
+          mk (Apply(Prim_map_reduce, loc, [gather_fun; m; mk_nil elts_ty]))
+            elts_ty
+        in
+        let elts = mk (Apply(Prim_list_rev, loc, [rev_elts])) elts_ty in
+        let red = mk (Apply(Prim_list_reduce, loc, [f; elts; acc])) acc_ty in
+        encode env red
+      | _ -> assert false
+    end
+
+  (* Map.map (closure) -> {Map.reduce (Map.update)} *)
+  | Apply (Prim_map_map, loc, [f; m]) ->
+    let f' = encode env f in
+    begin match get_type f'.ty with
+      | Tlambda _ ->
+        let m = encode env m in
+        { exp with desc = Apply (Prim_map_map, loc, [f'; m]) }
+      | Tclosure ((Ttuple [k_ty; v_ty] as kv_ty, _), ty_ret) ->
+        let arg_name = uniq_ident env "arg" in
+        let acc_ty = Tmap (k_ty, ty_ret) in
+        let arg_ty = Ttuple [kv_ty; acc_ty] in
+        let arg = mk (Var (arg_name, loc, [])) arg_ty in
+        let kv =
+          mk (Apply(Prim_tuple_get, loc, [arg; mk_nat 0])) kv_ty in
+        let acc =
+          mk (Apply(Prim_tuple_get, loc, [arg; mk_nat 1])) acc_ty in
+        let k =
+          mk (Apply(Prim_tuple_get, loc, [kv; mk_nat 0])) k_ty in
+        let acc_ty = Tmap (k_ty, ty_ret) in
+        let update_body =
+          mk (Apply(Prim_map_update, loc, [
+              k;
+              mk (Apply(Prim_Some, loc, [
+                  mk (Apply(Prim_exec, loc, [kv; f])) ty_ret
+                ])) (Toption ty_ret);
+              acc
+            ])) acc_ty in
+        let update_fun =
+          mk (Lambda (arg_name, arg_ty, loc, update_body, acc_ty))
+            (Tlambda (arg_ty, acc_ty))
+        in
+        let red =
+          mk (Apply (Prim_map_reduce, loc, [
+              update_fun; m;
+              mk (Const (acc_ty, CMap [])) acc_ty
+            ])) acc_ty in
+        encode env red
+      | _ -> assert false
+    end
+
+  (* Set.reduce (closure) -> {Set.reduce (::) |> List.rev |> List.reduce} *)
+  | Apply (Prim_set_reduce, loc, [f; s; acc]) ->
+    let f' = encode env f in
+    begin match get_type f'.ty with
+      | Tlambda _ ->
+        let s = encode env s in
+        let acc = encode env acc in
+        { exp with desc = Apply (Prim_set_reduce, loc, [f'; s; acc]) }
+      | Tclosure ((Ttuple [elt_ty; acc_ty], _), ty_ret) ->
+        let arg_name = uniq_ident env "arg" in
+        let elts_ty = Tlist elt_ty in
+        let arg_ty = Ttuple [elt_ty; elts_ty] in
+        let arg = mk (Var (arg_name, loc, [])) arg_ty in
+        let elt =
+          mk (Apply(Prim_tuple_get, loc, [arg; mk_nat 0])) elt_ty in
+        let acc_elts =
+          mk (Apply(Prim_tuple_get, loc, [arg; mk_nat 1])) elts_ty in
+        let gather_body =
+          mk (Apply(Prim_Cons, loc, [elt; acc_elts])) elts_ty in
+        let gather_fun =
+          mk (Lambda (arg_name, arg_ty, loc, gather_body, elts_ty))
+            (Tlambda (arg_ty, elts_ty))
+        in
+        let rev_elts =
+          mk (Apply(Prim_set_reduce, loc, [gather_fun; s; mk_nil elts_ty]))
+            elts_ty
+        in
+        let elts = mk (Apply(Prim_list_rev, loc, [rev_elts])) elts_ty in
+        let red = mk (Apply(Prim_list_reduce, loc, [f; elts; acc])) acc_ty in
+        encode env red
+      | _ -> assert false
+    end
+
+  | Apply (prim, loc, args) ->
+    encode_apply env prim loc args exp.ty
+    (* { exp with desc = Apply (prim, loc, List.map (encode env) args) } *)
+
+  | MatchOption (arg, loc, ifnone, name, ifsome) ->
+     let arg = encode env arg in
+     let name_ty = match arg.ty with
+       | Toption ty -> ty
+       | _ -> assert false
+     in
+     let env = maybe_reset_vars env arg.transfer in
+     let ifnone = encode env ifnone in
+     let (new_name, env, count) = new_binding env name name_ty in
+     let ifsome = encode env ifsome in
+     (* check_used env name loc count; *)
+     { exp with desc = MatchOption (arg, loc, ifnone, new_name, ifsome) }
+
+  | MatchNat (arg, loc, plus_name, ifplus, minus_name, ifminus) ->
+     let arg = encode env arg in
+     let env = maybe_reset_vars env arg.transfer in
+     let (plus_name, env2, count_p) = new_binding env plus_name Tnat in
+     let ifplus = encode env2 ifplus in
+     let (minus_name, env3, count_m) = new_binding env minus_name Tnat in
+     let ifminus = encode env3 ifminus in
+     (* check_used env plus_name loc count_p; *)
+     (* check_used env minus_name loc count_m; *)
+     { exp with
+       desc = MatchNat (arg, loc, plus_name, ifplus, minus_name, ifminus) }
+
+  | Loop (name, loc, body, arg) ->
+     let arg = encode env arg in
+     let env = maybe_reset_vars env arg.transfer in
+     let (new_name, env, count) = new_binding env name arg.ty in
+     let body = encode env body in
+     (* check_used env name loc count; *)
+     { exp with desc = Loop (new_name, loc, body, arg) }
+
+  | MatchList (arg, loc, head_name, tail_name, ifcons, ifnil) ->
+     let arg = encode env arg in
+     let elt_ty = match arg.ty with
+       | Tlist ty -> ty
+       | _ -> assert false
+     in
+     let env = maybe_reset_vars env arg.transfer in
+     let ifnil = encode env ifnil in
+     let (new_head_name, env, count) = new_binding env head_name elt_ty in
+     let (new_tail_name, env, count) = new_binding env tail_name arg.ty in
+     let ifcons = encode env ifcons in
+     (* check_used env head_name loc count; *)
+     (* check_used env tail_name loc count; *)
+     { exp with
+       desc =
+         MatchList (arg, loc, new_head_name, new_tail_name, ifcons, ifnil) }
+
+  | Lambda (arg_name, arg_type, loc, body, _) ->
+     let env_at_lambda = env in
+     let lambda_arg_type = arg_type in
+     let lambda_arg_name = arg_name in
+     let lambda_body = body in
+     let bvs = LiquidBoundVariables.bv exp in
+     if StringSet.is_empty bvs then
+       (* not a closure, create a real lambda *)
+       let env = { env_at_lambda with vars = StringMap.empty } in
+       let (new_arg_name, env, arg_count) =
+         new_binding env lambda_arg_name lambda_arg_type in
+       let body = encode env lambda_body in
+       (* check_used env lambda_arg_name loc arg_count; *)
+       let ty = Tlambda (lambda_arg_type, body.ty) in
+       mk (Lambda (new_arg_name, lambda_arg_type, loc, body, body.ty)) ty
+     else
+       (* create closure with environment *)
+       let env, arg_name, arg_type, call_env =
+         env_for_clos env loc bvs arg_name arg_type in
+       let body = encode env body in
+       (* begin match env.clos_env with *)
+       (*   | None -> () *)
+       (*   | Some clos_env -> *)
+       (*     Format.eprintf "--- Closure %s (real:%b)---@." arg_name is_real_closure; *)
+       (*     StringMap.iter (fun name (e, (cpt_in, cpt_out)) -> *)
+       (*         Format.eprintf "%s -> %s , (%d, %d)@." *)
+       (*           name (LiquidPrinter.Liquid.string_of_code e) !cpt_in !cpt_out *)
+       (*       ) clos_env.env_bindings *)
+       (* end; *)
+       (* check_used_in_env env lambda_arg_name loc; *)
+       let desc =
+         Closure (arg_name, arg_type, loc, call_env, body, body.ty) in
+       let call_env_type = match call_env with
+         | [] -> assert false
+         | [_, t] -> t.ty
+         | _ -> Ttuple (List.map (fun (_, t) -> t.ty) call_env)
+       in
+       let ty = Tclosure ((lambda_arg_type, call_env_type), body.ty) in
+       mk desc ty
+
+  | Closure _ -> assert false
+
+  | Record (_loc, []) -> assert false
+  | Record (loc, (( (label, _) :: _ ) as lab_x_exp_list)) ->
+     let ty_name, _, _ =
+       try
+         StringMap.find label env.env.labels
+       with Not_found ->
+         error loc "unbound label %S" label
+     in
+     let record_ty = StringMap.find ty_name env.env.types in
+     let len = List.length (match record_ty with
+         | Trecord rtys -> rtys
+         | _ -> assert false) in
+     let t = Array.make len const_unit in
+     List.iteri (fun i (label, exp) ->
+         let ty_name', label_pos, ty = StringMap.find label env.env.labels in
+         let exp = encode env exp in
+         t.(label_pos) <- exp;
+       ) lab_x_exp_list;
+     let args = Array.to_list t in
+     let ty = Ttype (ty_name, record_ty) in
+     let desc = Apply(Prim_tuple, loc, args) in
+     mk desc ty
+
+  | Constructor(loc, Constr constr, arg) ->
+     let ty_name, arg_ty = StringMap.find constr env.env.constrs in
+     let arg = encode env arg in
+     let constr_ty = StringMap.find ty_name env.env.types in
+     let ty = Ttype (ty_name, constr_ty) in
+     let exp =
+       match constr_ty with
+       | Tsum constrs ->
+         let rec iter constrs orty =
+           match constrs, orty with
+           | [], _ -> assert false
+           | [c, _], orty ->
+             assert (c = constr);
+             arg
+           (* | (c, ty, left_ty, right_ty) :: constrs -> *)
+           | (c, cty) :: constrs, orty ->
+             let left_ty, right_ty = match orty with
+               | Tor (left_ty, right_ty) -> left_ty, right_ty
+               | _ -> assert false
+             in
+             let desc =
+               if c = constr then
+                 (* We use an unused argument to carry the type to
+                    the code generator *)
+                 Apply(Prim_Left, loc, [arg; unused env right_ty])
+               else
+                 let arg = iter constrs right_ty in
+                 Apply(Prim_Right, loc, [arg; unused env left_ty])
+             in
+             mk desc orty
+         in
+         iter constrs (encode_type ~keepalias:false ty)
+       | _ -> assert false
+     in
+     mk exp.desc ty
+
+  | Constructor(loc, Left right_ty, arg) ->
+     let arg = encode env arg in
+     let ty = Tor(arg.ty, right_ty) in
+     let desc = Apply(Prim_Left,loc,[arg; unused env right_ty]) in
+     mk desc ty
+
+  | Constructor(loc, Right left_ty, arg) ->
+     let arg = encode env arg in
+     let ty = Tor(left_ty, arg.ty) in
+     let desc = Apply(Prim_Right,loc,[arg; unused env left_ty]) in
+     mk desc ty
+
+  | Constructor(loc, Source (from_ty, to_ty), _arg) ->
+     let ty = Tcontract(from_ty, to_ty) in
+     let desc = Apply(Prim_Source,loc,[unused env from_ty; unused env to_ty]) in
+     mk desc ty
+
+  | MatchVariant (arg, loc, cases) ->
+    let arg = encode env arg in
+    let constrs = match get_type arg.ty with
+      | Tsum constrs -> constrs
+      | Tor (left_ty, right_ty) ->
+        [ "Left", left_ty; "Right", right_ty]
+      | _ -> assert false
+    in
+    let cases = List.map (fun case ->
+       let c, var, e = match case with
+        | CConstr (c, []), e -> c, "_", e
+        | CConstr (c, [var]), e -> c, var, e
+        | CAny, _ | CConstr _, _ -> assert false
+       in
+       let var_ty = List.assoc c constrs in
+       let (var, env, _) = new_binding env var var_ty in
+       let e = encode env e in
+       (CConstr (c, [var]), e)
+      ) cases
+    in
+    { exp with desc = MatchVariant (arg, loc, cases) }
+
+
+and encode_apply env prim loc args ty =
+  let args = List.map (encode env) args in
+  match prim, args with
+  | Prim_exec, [ x; { ty = Tclosure (_, ty) | Tlambda (_,ty) } ] ->
+    mk (Apply (prim, loc, args)) ty
+
+  | Prim_tuple_get, [ { ty = tuple_ty };
+                      { desc = Const (_, (CInt n | CNat n)) }] ->
+     let tuple = match (get_type tuple_ty) with
+       | Ttuple tuple -> tuple
+       | Trecord rtys -> List.map snd rtys
+       | _ -> assert false
+     in
+     let n = LiquidPrinter.int_of_integer n in
+     let size = List.length tuple in
+     let prim =
+       if size = n + 1 then
+         Prim_tuple_get_last
+       else
+         Prim_tuple_get
+     in
+     let ty = List.nth tuple n in
+     mk (Apply (prim, loc, args)) ty
+
+  | Prim_tuple_set, [ { ty = tuple_ty };
+                      { desc = Const (_, (CInt n | CNat n)) };
+                      { ty } ] ->
+     let tuple = match (get_type tuple_ty) with
+       | Ttuple tuple -> tuple
+       | Trecord rtys -> List.map snd rtys
+       | _ -> assert false
+     in
+     let n = LiquidPrinter.int_of_integer n in
+     let size = List.length tuple in
+     let prim =
+       if size = n + 1 then
+         Prim_tuple_set_last
+       else
+         Prim_tuple_set
+     in
+     let ty =  tuple_ty in
+     mk (Apply (prim, loc, args)) ty
+
+  | _ -> mk (Apply (prim, loc, args)) ty
+
+
+let encode_contract ~warnings env contract =
+  let env =
+    {
+      warnings;
+      counter = ref 0;
+      vars = StringMap.empty;
+      to_inline = ref StringMap.empty;
+      env = env;
+      clos_env = None;
+      contract;
+    } in
+
+  (* "storage/1" *)
+  let (_ , env, _) = new_binding env  "storage" contract.storage in
+  (* "parameter/2" *)
+  let (_, env, _) = new_binding env "parameter" contract.parameter in
+
+  let code = encode env contract.code in
+  { contract with code }, ! (env.to_inline)
+
+
+let encode_code ~warnings env contract code =
+  let env =
+    {
+      warnings;
+      counter = ref 0;
+      vars = StringMap.empty;
+      to_inline = ref StringMap.empty;
+      env = env;
+      clos_env = None;
+      contract ;
+    } in
+
+  encode env code

--- a/tools/liquidity/liquidEncode.mli
+++ b/tools/liquidity/liquidEncode.mli
@@ -12,8 +12,8 @@ open LiquidTypes
 val encode_type : ?keepalias:bool -> datatype -> datatype
 
 val encode_contract :
-  warnings:bool -> env -> typed_exp contract ->
-  typed_exp contract * datatype exp StringMap.t
+  warnings:bool -> env -> typed_contract ->
+  encoded_contract * encoded_exp StringMap.t
 
 val encode_code :
-  warnings:bool -> env -> syntax_exp contract -> typed_exp -> typed_exp
+  warnings:bool -> env -> syntax_contract -> typed_exp -> encoded_exp

--- a/tools/liquidity/liquidEncode.mli
+++ b/tools/liquidity/liquidEncode.mli
@@ -9,7 +9,7 @@
 
 open LiquidTypes
 
-val encode_type : ?keepalias:bool -> datatype -> datatype
+val encode_type : datatype -> datatype
 
 val encode_contract :
   warnings:bool -> env -> typed_contract ->

--- a/tools/liquidity/liquidEncode.mli
+++ b/tools/liquidity/liquidEncode.mli
@@ -9,26 +9,11 @@
 
 open LiquidTypes
 
-val error :
-  location ->
-  ('a, Format.formatter, unit, unit, unit, 'b) format6 -> 'a
+val encode_type : ?keepalias:bool -> datatype -> datatype
 
-val typecheck_contract :
-  warnings:bool -> env -> syntax_exp contract -> typed_exp contract
+val encode_contract :
+  warnings:bool -> env -> typed_exp contract ->
+  typed_exp contract * datatype exp StringMap.t
 
-                       (*
-val uniq_ident : string -> string
-                        *)
-
-val typecheck_code :
-  warnings:bool -> env ->
-  syntax_exp contract ->
-  LiquidTypes.datatype ->
-  syntax_exp ->
-  typed_exp
-
-val check_const_type :
-  ?from_mic:bool ->
-  to_tez:(string -> LiquidTypes.tez) ->
-  LiquidTypes.location ->
-  LiquidTypes.datatype -> LiquidTypes.const -> LiquidTypes.const
+val encode_code :
+  warnings:bool -> env -> syntax_exp contract -> typed_exp -> typed_exp

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -174,8 +174,7 @@ let rec translate_type env typ =
 
   | { ptyp_desc = Ptyp_constr ({ txt = Lident ty_name }, []) } ->
      begin
-       try
-         Ttype (ty_name, StringMap.find ty_name env.types)
+       try StringMap.find ty_name env.types
        with Not_found ->
          unbound_type typ.ptyp_loc ty_name
      end
@@ -801,7 +800,7 @@ let rec translate_head env ext_funs head_exp args =
     let return = match translate_type env return_type with
       | Ttuple [ ret_ty; sto_ty ] ->
         let storage = List.assoc "storage" args in
-        if not (eq_types sto_ty storage) then
+        if sto_ty <> storage then
           error_loc pexp_loc
             "Second component of return type must be identical to storage type";
         ret_ty
@@ -865,7 +864,7 @@ let translate_record ty_name labels env =
          env.labels <- StringMap.add label (ty_name, i, ty) env.labels;
          label, ty) labels
   in
-  let ty = Trecord rtys in
+  let ty = Trecord (ty_name, rtys) in
   env.types <- StringMap.add ty_name ty env.types
 
 let translate_variant ty_name constrs env =
@@ -884,7 +883,7 @@ let translate_variant ty_name constrs env =
          env.constrs <- StringMap.add constr (ty_name, ty) env.constrs;
          constr, ty) constrs
   in
-  let ty = Tsum constrs in
+  let ty = Tsum (ty_name, constrs) in
   env.types <- StringMap.add ty_name ty env.types
 
 let check_version = function

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -369,7 +369,8 @@ and translate_pair exp =
   | Pexp_tuple [e1; e2] -> (e1, e2)
   | _ -> error_loc exp.pexp_loc "pair expected"
 
-let mk desc = { desc; ty = (); bv = StringSet.empty; fail = false }
+
+let mk desc = mk desc ()
 
 let vars_info_pat env pat =
   let rec vars_info_pat_aux acc indexes = function
@@ -819,6 +820,17 @@ let rec translate_head env ext_funs head_exp args =
             head_exp) } ->
      translate_head env ext_funs head_exp
        (("return", translate_type env arg_type) :: args)
+
+  | { pexp_desc =
+        Pexp_fun (
+            Nolabel, None,
+            { ppat_desc =
+                Ppat_extension ({ txt = "invariant"},
+                                PStr [{ pstr_desc = Pstr_eval (exp, [])}])
+            },
+            head_exp) } ->
+    Format.eprintf "invariant@.";
+     translate_head env ext_funs head_exp args
 
   | { pexp_desc =
         Pexp_fun (

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -80,10 +80,10 @@ let () =
 
 
 (* The minimal version of liquidity files that are accepted by this compiler *)
-let minimal_version = 0.12
+let minimal_version = 0.13
 
 (* The maximal version of liquidity files that are accepted by this compiler *)
-let maximal_version = 0.12
+let maximal_version = 0.13
 
 
 open Asttypes
@@ -165,8 +165,8 @@ let rec translate_type env typ =
   | { ptyp_desc = Ptyp_constr ({ txt = Lident "map" },
                                [parameter_type; return_type]) } ->
      Tmap (translate_type env parameter_type, translate_type env return_type)
-  | { ptyp_desc = Ptyp_constr ({ txt = Lident "lambda" },
-                               [parameter_type; return_type]) } ->
+
+  | { ptyp_desc = Ptyp_arrow (_, parameter_type, return_type) } ->
      Tlambda (translate_type env parameter_type, translate_type env return_type)
 
   | { ptyp_desc = Ptyp_tuple types } ->

--- a/tools/liquidity/liquidInterp.ml
+++ b/tools/liquidity/liquidInterp.ml
@@ -23,9 +23,6 @@ let node loc kind args prevs =
   Hashtbl.add nodes num node;
   node
 
-let bv = StringSet.empty
-let mk desc = { desc ; ty = (); bv; fail = false }
-
 let fprint_stack msg fmt stack =
   Format.fprintf fmt "Stack %s:\n" msg;
   List.iter (fun node ->

--- a/tools/liquidity/liquidMain.ml
+++ b/tools/liquidity/liquidMain.ml
@@ -42,18 +42,18 @@ let compile_liquid_file filename =
   FileString.write_file (filename ^ ".syntax")
                         (LiquidPrinter.Liquid.string_of_contract
                            syntax_ast);
-  let typed_ast, to_inline = LiquidCheck.typecheck_contract
-      ~only_typecheck:false ~warnings:true env syntax_ast in
+  let typed_ast = LiquidCheck.typecheck_contract
+      ~warnings:true env syntax_ast in
   if !verbosity>0 then
-    let only_typed_ast, _ = LiquidCheck.typecheck_contract
-        ~only_typecheck:true ~warnings:false env syntax_ast in
-    FileString.write_file (filename ^ ".onlytyped")
-      (LiquidPrinter.Liquid.string_of_contract_types
-         only_typed_ast);
     FileString.write_file (filename ^ ".typed")
+      (LiquidPrinter.Liquid.string_of_contract_types
+         typed_ast);
+  let typed_ast, to_inline =
+    LiquidEncode.encode_contract ~warnings:true env typed_ast in
+  if !verbosity>0 then
+    FileString.write_file (filename ^ ".encoded")
       (LiquidPrinter.Liquid.string_of_contract
          typed_ast);
-  end;
   if !arg_typeonly then exit 0;
 
   let live_ast = LiquidSimplify.simplify_contract typed_ast to_inline in
@@ -101,8 +101,9 @@ let compile_tezos_file filename =
   FileString.write_file  (filename ^ ".liq.pre")
                          (LiquidPrinter.Liquid.string_of_contract c);
   let env = LiquidFromOCaml.initial_env filename in
-  let typed_ast, to_inline = LiquidCheck.typecheck_contract
-      ~only_typecheck:false ~warnings:false env c in
+  let typed_ast = LiquidCheck.typecheck_contract ~warnings:false env c in
+  let typed_ast, to_inline =
+    LiquidEncode.encode_contract ~warnings:false env typed_ast in
   (*  Printf.eprintf "Inlining: %d\n%!" (StringMap.cardinal to_inline); *)
   let live_ast = LiquidSimplify.simplify_contract typed_ast to_inline in
   let untyped_ast = LiquidUntype.untype_contract live_ast in

--- a/tools/liquidity/liquidMain.ml
+++ b/tools/liquidity/liquidMain.ml
@@ -39,12 +39,18 @@ let compile_liquid_file filename =
   FileString.write_file (filename ^ ".syntax")
                         (LiquidPrinter.Liquid.string_of_contract
                            syntax_ast);
-  let typed_ast, to_inline =
-    LiquidCheck.typecheck_contract ~warnings:true env syntax_ast in
+  let typed_ast, to_inline = LiquidCheck.typecheck_contract
+      ~only_typecheck:false ~warnings:true env syntax_ast in
   if !verbosity>0 then
-  FileString.write_file (filename ^ ".typed")
-                        (LiquidPrinter.Liquid.string_of_contract
-                           typed_ast);
+    let only_typed_ast, _ = LiquidCheck.typecheck_contract
+        ~only_typecheck:true ~warnings:false env syntax_ast in
+    FileString.write_file (filename ^ ".onlytyped")
+      (LiquidPrinter.Liquid.string_of_contract
+         only_typed_ast);
+    FileString.write_file (filename ^ ".typed")
+      (LiquidPrinter.Liquid.string_of_contract
+         typed_ast);
+  end;
 
   let live_ast = LiquidSimplify.simplify_contract typed_ast to_inline in
   if !verbosity>0 then
@@ -89,8 +95,8 @@ let compile_tezos_file filename =
   FileString.write_file  (filename ^ ".liq.pre")
                          (LiquidPrinter.Liquid.string_of_contract c);
   let env = LiquidFromOCaml.initial_env filename in
-  let typed_ast, to_inline =
-    LiquidCheck.typecheck_contract ~warnings:false env c in
+  let typed_ast, to_inline = LiquidCheck.typecheck_contract
+      ~only_typecheck:false ~warnings:false env c in
   (*  Printf.eprintf "Inlining: %d\n%!" (StringMap.cardinal to_inline); *)
   let live_ast = LiquidSimplify.simplify_contract typed_ast to_inline in
   let untyped_ast = LiquidUntype.untype_contract live_ast in

--- a/tools/liquidity/liquidMain.ml
+++ b/tools/liquidity/liquidMain.ml
@@ -48,7 +48,7 @@ let compile_liquid_file filename =
     let only_typed_ast, _ = LiquidCheck.typecheck_contract
         ~only_typecheck:true ~warnings:false env syntax_ast in
     FileString.write_file (filename ^ ".onlytyped")
-      (LiquidPrinter.Liquid.string_of_contract
+      (LiquidPrinter.Liquid.string_of_contract_types
          only_typed_ast);
     FileString.write_file (filename ^ ".typed")
       (LiquidPrinter.Liquid.string_of_contract

--- a/tools/liquidity/liquidMain.ml
+++ b/tools/liquidity/liquidMain.ml
@@ -48,15 +48,15 @@ let compile_liquid_file filename =
     FileString.write_file (filename ^ ".typed")
       (LiquidPrinter.Liquid.string_of_contract_types
          typed_ast);
-  let typed_ast, to_inline =
+  let encoded_ast, to_inline =
     LiquidEncode.encode_contract ~warnings:true env typed_ast in
   if !verbosity>0 then
     FileString.write_file (filename ^ ".encoded")
       (LiquidPrinter.Liquid.string_of_contract
-         typed_ast);
+         encoded_ast);
   if !arg_typeonly then exit 0;
 
-  let live_ast = LiquidSimplify.simplify_contract typed_ast to_inline in
+  let live_ast = LiquidSimplify.simplify_contract encoded_ast to_inline in
   if !verbosity>0 then
   FileString.write_file (filename ^ ".simple")
                         (LiquidPrinter.Liquid.string_of_contract
@@ -102,10 +102,10 @@ let compile_tezos_file filename =
                          (LiquidPrinter.Liquid.string_of_contract c);
   let env = LiquidFromOCaml.initial_env filename in
   let typed_ast = LiquidCheck.typecheck_contract ~warnings:false env c in
-  let typed_ast, to_inline =
+  let encode_ast, to_inline =
     LiquidEncode.encode_contract ~warnings:false env typed_ast in
   (*  Printf.eprintf "Inlining: %d\n%!" (StringMap.cardinal to_inline); *)
-  let live_ast = LiquidSimplify.simplify_contract typed_ast to_inline in
+  let live_ast = LiquidSimplify.simplify_contract encode_ast to_inline in
   let untyped_ast = LiquidUntype.untype_contract live_ast in
   let output = filename ^ ".liq" in
   FileString.write_file  output

--- a/tools/liquidity/liquidMain.ml
+++ b/tools/liquidity/liquidMain.ml
@@ -30,6 +30,7 @@ let arg_peephole = ref true
 let arg_keepon = ref false
 let arg_typeonly = ref false
 let arg_parseonly = ref false
+let arg_singleline = ref false
 
 let compile_liquid_file filename =
   let ocaml_ast = LiquidFromOCaml.read_file filename in
@@ -73,9 +74,13 @@ let compile_liquid_file filename =
   (*  let michelson_ast = LiquidEmit.emit_contract pre_michelson in *)
 
   let output = filename ^ ".tz" in
-  FileString.write_file output
-                        (LiquidToTezos.string_of_contract
-                           (LiquidToTezos.convert_contract pre_michelson));
+  let c = LiquidToTezos.convert_contract pre_michelson in
+  let s =
+    if !arg_singleline
+    then LiquidToTezos.line_of_contract c
+    else LiquidToTezos.string_of_contract c
+  in
+  FileString.write_file output s;
   Printf.eprintf "File %S generated\n%!" output;
   Printf.eprintf "If tezos is compiled, you may want to typecheck with:\n";
   Printf.eprintf "  tezos-client typecheck program %s\n" output
@@ -171,6 +176,8 @@ let main () =
       " Disable peephole optimizations";
       "--type-only", Arg.Set arg_typeonly, "Stop after type checking";
       "--parse-only", Arg.Set arg_parseonly, "Stop after parsing";
+      "--single-line", Arg.Set arg_singleline,
+      "Output Michelson on a single line";
       "--data", Arg.Tuple [
         Arg.String (fun s -> Data.contract := s);
         Arg.String (fun s -> Data.parameter := s);

--- a/tools/liquidity/liquidMichelson.ml
+++ b/tools/liquidity/liquidMichelson.ml
@@ -21,7 +21,7 @@ let dup n = {i=DUP n}
 (* n = size of preserved head of stack *)
 let dip n exprs = {i=DIP (n, seq exprs)}
 
-let push ty cst = {i=PUSH (ty, cst)}
+let push ty cst = {i=PUSH (LiquidEncode.encode_type ty, cst)}
 
 (* n = size of preserved head of stack *)
 let drop_stack n depth =
@@ -77,9 +77,11 @@ let translate_code code =
        let env = StringMap.empty in
        let env = StringMap.add arg_name 0 env in
        let depth = 1 in
+       let arg_type = LiquidEncode.encode_type arg_type in
+       let res_type = LiquidEncode.encode_type res_type in
        let body = compile_no_transfer depth env body in
        [ {i=LAMBDA (arg_type, res_type, seq (body @ [
-                                               {i=DIP_DROP (1,1)}]))} ], false
+             {i=DIP_DROP (1,1)}]))} ], false
 
     | Closure (arg_name, p_arg_type, loc, call_env, body, res_type) ->
       let call_env_code = match call_env with
@@ -87,6 +89,8 @@ let translate_code code =
         | [_, e] -> compile_no_transfer depth env e
         | _ -> compile_tuple depth env (List.rev_map snd call_env)
       in
+      let p_arg_type = LiquidEncode.encode_type p_arg_type in
+      let res_type = LiquidEncode.encode_type res_type in
       call_env_code @
       (compile_desc depth env
          (Lambda (arg_name, p_arg_type, loc, body, res_type)) |> fst) @
@@ -141,6 +145,9 @@ let translate_code code =
       let arg = compile_no_transfer (depth+1) env arg in
       f_env @ arg @ [ dip 1 [ dup 1; ii CAR; ii SWAP; ii CDR] ] @
       [ ii PAIR ; ii EXEC ], false
+
+    | Apply (prim, _loc, ([_; { ty = Tlambda _ } ] as args)) ->
+      compile_prim depth env prim args, false
 
     | Apply (prim, _loc, args) ->
        compile_prim depth env prim args, false
@@ -310,24 +317,29 @@ set x n y = x + [ DUP; CAR; SWAP; CDR ]*n +
     | Prim_gas, _ -> [ ii STEPS_TO_QUOTA ]
 
     | Prim_Left, [ arg; { ty = right_ty }] ->
-       compile_no_transfer depth env arg @
-         [ {i=LEFT right_ty} ]
+      let right_ty = LiquidEncode.encode_type right_ty in
+      compile_no_transfer depth env arg @
+      [ {i=LEFT right_ty} ]
     | Prim_Left, _ -> assert false
 
     | Prim_Right, [ arg; { ty = left_ty } ] ->
-       compile_no_transfer depth env arg @
-         [ {i=RIGHT left_ty} ]
+      let left_ty = LiquidEncode.encode_type left_ty in
+      compile_no_transfer depth env arg @
+      [ {i=RIGHT left_ty} ]
     | Prim_Right, _ -> assert false
 
     | Prim_Source, [ { ty = from_ty }; { ty = to_ty } ] ->
-       [ {i=SOURCE (from_ty, to_ty)} ]
+      let from_ty = LiquidEncode.encode_type from_ty in
+      let to_ty = LiquidEncode.encode_type to_ty in
+      [ {i=SOURCE (from_ty, to_ty)} ]
     | Prim_Source, _ -> assert false
 
     (* catch the special case of [a;b;c] where
 the ending NIL is not annotated with a type *)
     | Prim_Cons, [ { ty } as arg; { ty = Tunit } ] ->
-       let arg = compile_no_transfer (depth+1) env arg in
-       [ {i=PUSH (Tlist ty, CList[])} ] @ arg @ [ ii CONS ]
+      let ty = LiquidEncode.encode_type ty in
+      let arg = compile_no_transfer (depth+1) env arg in
+      [ {i=PUSH (Tlist ty, CList[])} ] @ arg @ [ ii CONS ]
 
     (* Should be removed in LiquidCheck *)
     | Prim_unknown, _
@@ -517,7 +529,7 @@ let translate filename ~peephole contract =
   { contract with code }
  *)
 let translate contract =
-  { parameter = LiquidCheck.encode_type contract.parameter;
-    storage = LiquidCheck.encode_type contract.storage;
-    return = LiquidCheck.encode_type contract.return;
+  { parameter = LiquidEncode.encode_type contract.parameter;
+    storage = LiquidEncode.encode_type contract.storage;
+    return = LiquidEncode.encode_type contract.return;
     code = translate_code contract.code }

--- a/tools/liquidity/liquidMichelson.ml
+++ b/tools/liquidity/liquidMichelson.ml
@@ -278,16 +278,17 @@ let translate_code code =
        compile_tuple depth env (List.rev args)
 
     | Prim_tuple_get, [arg; { desc = Const (_, (CInt n | CNat n))} ] ->
+       let size = size_of_type arg.ty in
        let arg = compile_no_transfer depth env arg in
        let n = LiquidPrinter.int_of_integer n in
-       arg @ [  {i=CDAR n} ]
+       let ins =
+         if size = n + 1 then
+           {i=CDDR (n-1)}
+         else
+           {i=CDAR n}
+       in
+       arg @ [ ins ]
     | Prim_tuple_get, _ -> assert false
-
-    | Prim_tuple_get_last, [arg; { desc = Const (_, (CInt n | CNat n))} ] ->
-       let arg = compile_no_transfer depth env arg in
-       let n = LiquidPrinter.int_of_integer n in
-       arg @ [  {i=CDDR (n-1)} ]
-    | Prim_tuple_get_last, _ -> assert false
 
     (*
 set x n y = x + [ DUP; CAR; SWAP; CDR ]*n +
@@ -298,16 +299,11 @@ set x n y = x + [ DUP; CAR; SWAP; CDR ]*n +
     | Prim_tuple_set, [x; { desc = Const (_, (CInt n | CNat n))}; y ] ->
        let x_code = compile_no_transfer depth env x in
        let n = LiquidPrinter.int_of_integer n in
-       let set_code = compile_prim_set false (depth+1) env n y in
+       let size = size_of_type x.ty in
+       let is_last = size = n + 1 in
+       let set_code = compile_prim_set is_last (depth+1) env n y in
        x_code @ set_code
     | Prim_tuple_set, _ -> assert false
-
-    | Prim_tuple_set_last, [x; { desc = Const (_, (CInt n | CNat n))}; y ] ->
-       let x_code = compile_no_transfer depth env x in
-       let n = LiquidPrinter.int_of_integer n in
-       let set_code = compile_prim_set true (depth+1) env n y in
-       x_code @ set_code
-    | Prim_tuple_set_last, _ -> assert false
 
     | Prim_fail,_ -> [ ii FAIL ]
     | Prim_self, _ -> [ ii SELF ]
@@ -430,8 +426,8 @@ the ending NIL is not annotated with a type *)
            assert false
          (*                           | prim, args -> *)
 
-         | (Prim_unknown|Prim_tuple_get_last|Prim_tuple_get
-           | Prim_tuple_set_last|Prim_tuple_set|Prim_tuple|Prim_fail
+         | (Prim_unknown|Prim_tuple_get
+           | Prim_tuple_set|Prim_tuple|Prim_fail
            | Prim_self|Prim_balance|Prim_now|Prim_amount|Prim_gas
            | Prim_Left|Prim_Right|Prim_Source|Prim_unused
            | Prim_coll_find|Prim_coll_update|Prim_coll_mem

--- a/tools/liquidity/liquidMichelson.ml
+++ b/tools/liquidity/liquidMichelson.ml
@@ -517,4 +517,7 @@ let translate filename ~peephole contract =
   { contract with code }
  *)
 let translate contract =
-  { contract with code = translate_code contract.code }
+  { parameter = LiquidCheck.encode_type contract.parameter;
+    storage = LiquidCheck.encode_type contract.storage;
+    return = LiquidCheck.encode_type contract.return;
+    code = translate_code contract.code }

--- a/tools/liquidity/liquidMichelson.mli
+++ b/tools/liquidity/liquidMichelson.mli
@@ -9,4 +9,4 @@
 
 open LiquidTypes
 
-val translate : typed_exp contract -> noloc_michelson contract
+val translate : encoded_exp contract -> noloc_michelson_contract

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -213,17 +213,17 @@ module Michelson = struct
        let indent = fmt.increase_indent indent in
        Printf.bprintf b "(Some%c%s" fmt.newline indent;
        bprint_const fmt b indent cst;
-       Printf.bprintf b "%c%s)" fmt.newline indent;
+       Printf.bprintf b ")";
     | CLeft cst ->
        let indent = fmt.increase_indent indent in
        Printf.bprintf b "(Left%c%s" fmt.newline indent;
        bprint_const fmt b indent cst;
-       Printf.bprintf b "%c%s)" fmt.newline indent;
+       Printf.bprintf b ")";
     | CRight cst ->
        let indent = fmt.increase_indent indent in
        Printf.bprintf b "(Right%c%s" fmt.newline indent;
        bprint_const fmt b indent cst;
-       Printf.bprintf b "%c%s)" fmt.newline indent;
+       Printf.bprintf b ")";
     | CTuple tys -> bprint_const_pairs fmt b indent tys
     | CMap pairs ->
        let indent = fmt.increase_indent indent in
@@ -235,9 +235,9 @@ module Michelson = struct
            bprint_const fmt b indent cst1;
            Printf.bprintf b "%c%s" fmt.newline indent;
            bprint_const fmt b indent cst2;
-           Printf.bprintf b "%c%s)" fmt.newline indent;
+           Printf.bprintf b ")";
          ) pairs;
-       Printf.bprintf b "%c%s)" fmt.newline indent;
+       Printf.bprintf b ")";
     | CList csts ->
        let indent = fmt.increase_indent indent in
        Printf.bprintf b "(List";
@@ -245,7 +245,7 @@ module Michelson = struct
            Printf.bprintf b "%c%s" fmt.newline indent;
            bprint_const fmt b indent cst;
          ) csts;
-       Printf.bprintf b "%c%s)" fmt.newline indent;
+       Printf.bprintf b ")";
     | CSet csts ->
        let indent = fmt.increase_indent indent in
        Printf.bprintf b "(Set";
@@ -253,7 +253,7 @@ module Michelson = struct
            Printf.bprintf b "%c%s" fmt.newline indent;
            bprint_const fmt b indent cst;
          ) csts;
-       Printf.bprintf b "%c%s)" fmt.newline indent;
+       Printf.bprintf b ")";
     | CConstr _ | CRecord _ -> assert false
 
   and bprint_const_pairs fmt b indent tys =

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -830,7 +830,6 @@ module Liquid = struct
     bprint_code ~debug b indent contract.code
 
   let string_of_type = to_string bprint_type
-  let string_of_type_expl = to_string (fun b -> bprint_type ~expand:true b)
   let string_of_const = to_string bprint_const
   let string_of_code ?(debug=false) code =
     to_string (bprint_code ~debug) code

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -257,6 +257,7 @@ module Michelson = struct
            bprint_const fmt b indent cst;
          ) csts;
        Printf.bprintf b "%c%s)" fmt.newline indent;
+    | CConstr _ | CRecord _ -> assert false
 
   and bprint_const_pairs fmt b indent tys =
     match tys with
@@ -592,17 +593,17 @@ module Liquid = struct
     | CUnit -> Printf.bprintf b "()"
     | CNone -> Printf.bprintf b "None"
     | CSome cst ->
-       Printf.bprintf b "(Some ";
-       bprint_const b "" cst;
-       Printf.bprintf b ")";
+      Printf.bprintf b "(Some ";
+      bprint_const b "" cst;
+      Printf.bprintf b ")";
     | CLeft cst ->
-       Printf.bprintf b "(Left ";
-       bprint_const b "" cst;
-       Printf.bprintf b ")";
+      Printf.bprintf b "(Left ";
+      bprint_const b "" cst;
+      Printf.bprintf b ")";
     | CRight cst ->
-       Printf.bprintf b "(Right ";
-       bprint_const b "" cst;
-       Printf.bprintf b ")";
+      Printf.bprintf b "(Right ";
+      bprint_const b "" cst;
+      Printf.bprintf b ")";
     | CTuple [] -> assert false
     | CTuple (c :: cs) ->
       Printf.bprintf b "(";
@@ -633,6 +634,18 @@ module Liquid = struct
         (fun _ c -> bprint_const b "" c)
         (Format.formatter_of_buffer b) csts;
       Printf.bprintf b "])"
+    | CConstr (c, cst) ->
+      Printf.bprintf b "(%s " c;
+      bprint_const b "" cst;
+      Printf.bprintf b ")";
+    | CRecord labels ->
+      Printf.bprintf b "{";
+      Format.pp_print_list ~pp_sep:(fun fmt () -> Format.fprintf fmt "; ")
+        (fun _ (f, cst) ->
+           Printf.bprintf b "%s = " f;
+           bprint_const b "" cst)
+        (Format.formatter_of_buffer b) labels;
+      Printf.bprintf b "}"
 
 
   let rec bprint_code_base bprint_code_rec ~debug b indent code =

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -125,6 +125,7 @@ module Michelson = struct
       | Tkey_hash  -> Printf.bprintf b "key_hash"
       | Tsignature  -> Printf.bprintf b "signature"
       | Ttuple tys -> bprint_type_pairs b indent tys
+      | Trecord _ | Tsum _ -> assert false
       | Tcontract (ty1, ty2) ->
          let indent = indent ^ "  " in
          Printf.bprintf b "(contract\n%s" indent;
@@ -479,6 +480,24 @@ module Liquid = struct
             bprint_type b "" ty;
           ) tys;
         Printf.bprintf b ")";
+      | Trecord [] -> assert false
+      | Trecord ((f, ty) :: rtys) ->
+        Printf.bprintf b "{ ";
+        Printf.bprintf b "%s: " f;
+        bprint_type b "" ty;
+        List.iter (fun (f, ty) ->
+            Printf.bprintf b "; %s: " f;
+            bprint_type b "" ty;
+          ) rtys;
+        Printf.bprintf b " }";
+      | Tsum [] -> assert false
+      | Tsum ((c, ty) :: rtys) ->
+        Printf.bprintf b "%s of " c;
+        bprint_type b "" ty;
+        List.iter (fun (c, ty) ->
+            Printf.bprintf b " | %s of " c;
+            bprint_type b "" ty;
+          ) rtys;
       | Tcontract (ty1, ty2) ->
         Printf.bprintf b "(";
         bprint_type b "" ty1;

--- a/tools/liquidity/liquidPrinter.mli
+++ b/tools/liquidity/liquidPrinter.mli
@@ -36,12 +36,17 @@ end
 
 module Michelson : sig
   val string_of_type : datatype -> string
+  val line_of_type : datatype -> string
   val string_of_const : const -> string
   val line_of_const : const -> string
   val string_of_contract : michelson_contract -> string
+  val line_of_contract : michelson_contract -> string
   val string_of_code : michelson_exp -> string
+  val line_of_code : michelson_exp -> string
   val string_of_noloc_michelson : noloc_michelson -> string
+  val line_of_noloc_michelson : noloc_michelson -> string
   val string_of_loc_michelson : loc_michelson -> string
+  val line_of_loc_michelson : loc_michelson -> string
 end
 
 val string_of_node : node -> string

--- a/tools/liquidity/liquidPrinter.mli
+++ b/tools/liquidity/liquidPrinter.mli
@@ -29,9 +29,9 @@ module Liquid : sig
   val string_of_type : datatype -> string
   val string_of_type_expl : datatype -> string
   val string_of_const : const -> string
-  val string_of_contract : ?debug:bool -> 'a exp contract -> string
-  val string_of_contract_types : ?debug:bool -> typed_exp contract -> string
-  val string_of_code : ?debug:bool -> 'a exp -> string
+  val string_of_contract : ?debug:bool -> ('a, 'b) exp contract -> string
+  val string_of_contract_types : ?debug:bool -> typed_contract -> string
+  val string_of_code : ?debug:bool -> ('a, 'b) exp -> string
   val string_of_code_types : ?debug:bool -> typed_exp -> string
 end
 
@@ -39,7 +39,7 @@ module Michelson : sig
   val string_of_type : datatype -> string
   val string_of_const : const -> string
   val line_of_const : const -> string
-  val string_of_contract : michelson_exp contract -> string
+  val string_of_contract : michelson_contract -> string
   val string_of_code : michelson_exp -> string
   val string_of_noloc_michelson : noloc_michelson -> string
   val string_of_loc_michelson : loc_michelson -> string

--- a/tools/liquidity/liquidPrinter.mli
+++ b/tools/liquidity/liquidPrinter.mli
@@ -27,7 +27,6 @@ val integer_of_int : int -> integer
 
 module Liquid : sig
   val string_of_type : datatype -> string
-  val string_of_type_expl : datatype -> string
   val string_of_const : const -> string
   val string_of_contract : ?debug:bool -> ('a, 'b) exp contract -> string
   val string_of_contract_types : ?debug:bool -> typed_contract -> string

--- a/tools/liquidity/liquidPrinter.mli
+++ b/tools/liquidity/liquidPrinter.mli
@@ -25,24 +25,24 @@ val int_of_integer : integer -> int
 val integer_of_int : int -> integer
 
 
-
 module Liquid : sig
-  val string_of_type : LiquidTypes.datatype -> string
-  val string_of_const : LiquidTypes.const -> string
-  val string_of_contract : ?debug:bool ->
-           'a LiquidTypes.exp LiquidTypes.contract -> string
-  val string_of_code : ?debug:bool -> 'a LiquidTypes.exp -> string
+  val string_of_type : datatype -> string
+  val string_of_type_expl : datatype -> string
+  val string_of_const : const -> string
+  val string_of_contract : ?debug:bool -> 'a exp contract -> string
+  val string_of_contract_types : ?debug:bool -> typed_exp contract -> string
+  val string_of_code : ?debug:bool -> 'a exp -> string
+  val string_of_code_types : ?debug:bool -> typed_exp -> string
 end
 
 module Michelson : sig
-  val string_of_type : LiquidTypes.datatype -> string
-  val string_of_const : LiquidTypes.const -> string
-  val line_of_const : LiquidTypes.const -> string
-  val string_of_contract :
-    LiquidTypes.michelson_exp LiquidTypes.contract -> string
-  val string_of_code : LiquidTypes.michelson_exp -> string
-  val string_of_noloc_michelson : LiquidTypes.noloc_michelson -> string
-  val string_of_loc_michelson : LiquidTypes.loc_michelson -> string
+  val string_of_type : datatype -> string
+  val string_of_const : const -> string
+  val line_of_const : const -> string
+  val string_of_contract : michelson_exp contract -> string
+  val string_of_code : michelson_exp -> string
+  val string_of_noloc_michelson : noloc_michelson -> string
+  val string_of_loc_michelson : loc_michelson -> string
 end
 
-val string_of_node : LiquidTypes.node -> string
+val string_of_node : node -> string

--- a/tools/liquidity/liquidSimplify.mli
+++ b/tools/liquidity/liquidSimplify.mli
@@ -10,4 +10,4 @@
 open LiquidTypes
 
 val simplify_contract :
-  typed_exp contract -> typed_exp StringMap.t -> typed_exp contract
+  encoded_exp contract -> encoded_exp StringMap.t -> encoded_exp contract

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -52,7 +52,6 @@ let rec convert_type ty =
   | Tset x -> typ_constr "set" [convert_type x]
   | Tlist x -> typ_constr "list" [convert_type x]
   | Toption x -> typ_constr "option" [convert_type x]
-  | Ttype (_, ty) -> convert_type ty
   | Tfail | Trecord _ | Tsum _ -> assert false
 
 let rec convert_const expr =

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -8,7 +8,7 @@
 (**************************************************************************)
 
 (* The version that will be required to compile the generated files. *)
-let output_version = "0.12"
+let output_version = "0.13"
 
 (*
 type storage = ...
@@ -46,9 +46,8 @@ let rec convert_type ty =
   | Ttuple args -> Typ.tuple (List.map convert_type args)
   | Tor (x,y) -> typ_constr "variant" [convert_type x; convert_type y]
   | Tcontract (x,y) -> typ_constr "contract" [convert_type x;convert_type y]
-  | Tlambda (x,y) -> typ_constr "lambda" [convert_type x; convert_type y]
-  | Tclosure ((x,e),r) ->
-    typ_constr "closure" [convert_type x; convert_type e; convert_type r]
+  | Tlambda (x,y) -> Typ.arrow Nolabel (convert_type x) (convert_type y)
+  | Tclosure ((x,e),r) -> Typ.arrow Nolabel (convert_type x) (convert_type r)
   | Tmap (x,y) -> typ_constr "map" [convert_type x;convert_type y]
   | Tset x -> typ_constr "set" [convert_type x]
   | Tlist x -> typ_constr "list" [convert_type x]

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -53,8 +53,8 @@ let rec convert_type ty =
   | Tset x -> typ_constr "set" [convert_type x]
   | Tlist x -> typ_constr "list" [convert_type x]
   | Toption x -> typ_constr "option" [convert_type x]
-  | Tfail -> assert false
   | Ttype (_, ty) -> convert_type ty
+  | Tfail | Trecord _ | Tsum _ -> assert false
 
 let rec convert_const expr =
   match expr with

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -72,6 +72,8 @@ let rec convert_const expr =
                              (Some (convert_const x))
   | CRight x -> Exp.construct (lid "Right")
                              (Some (convert_const x))
+  | CConstr (c, x) -> Exp.construct (lid c)
+                        (Some (convert_const x))
   | CTuple args -> Exp.tuple (List.map convert_const args)
   | CTez n -> Exp.constant (Const.float ~suffix:'\231'
                                         (LiquidPrinter.liq_of_tez n))
@@ -108,6 +110,10 @@ let rec convert_const expr =
          ) (Exp.construct (lid "[]") None) list
      in
      Exp.construct (lid "Map") (Some args)
+  | CRecord labels ->
+    Exp.record
+      (List.map (fun (f, x) -> lid f, convert_const x) labels)
+      None
 
 let rec convert_code expr =
   match expr.desc with

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -165,11 +165,7 @@ let rec convert_code expr =
      Exp.construct (lid "Some") (Some (convert_code arg))
   | Apply (Prim_tuple, _loc, args) ->
      Exp.tuple (List.map convert_code args)
-  | Apply (prim_name, _loc, args) ->
-     let prim = match prim_name with
-       | Prim_tuple_get_last -> Prim_tuple_get
-       | _ -> prim_name
-     in
+  | Apply (prim, _loc, args) ->
      let prim_name =
        try
          LiquidTypes.string_of_primitive prim

--- a/tools/liquidity/liquidToOCaml.mli
+++ b/tools/liquidity/liquidToOCaml.mli
@@ -14,5 +14,5 @@ val output_version : string
 val structure_of_contract : syntax_exp contract -> Parsetree.structure
 val string_of_structure : Parsetree.structure -> string
 
-val translate_expression : unit LiquidTypes.exp -> Parsetree.expression
+val translate_expression : syntax_exp -> Parsetree.expression
 val string_of_expression : Parsetree.expression -> string

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -502,6 +502,7 @@ type env = {
 (* fields updated in LiquidCheck *)
 type 'a typecheck_env = {
     warnings : bool;
+    only_typecheck : bool;
     counter : int ref;
     vars : (string * datatype * int ref) StringMap.t;
     env : env;

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -255,7 +255,9 @@ let () =
 
               "::", Prim_Cons;
               "or", Prim_or;
+              "||", Prim_or;
               "&", Prim_and;
+              "&&", Prim_and;
               "xor", Prim_xor;
               "not", Prim_not;
               "abs", Prim_abs;

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -39,6 +39,9 @@ type const =
 
   | CKey_hash of string
 
+  | CRecord of (string * const) list
+  | CConstr of string * const
+
  and datatype =
    (* michelson *)
   | Tunit

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -130,6 +130,10 @@ let first_alias ty =
 let eq_types t1 t2 =
   get_type t1 = get_type t2
 
+let size_of_type ty = match get_type ty with
+  | Ttuple l -> List.length l
+  | Trecord l -> List.length l
+  | _ -> raise (Invalid_argument "size_of_type")
 
 type 'exp contract = {
     parameter : datatype;
@@ -163,9 +167,7 @@ type primitive =
   | Prim_unused
 
   (* primitives *)
-  | Prim_tuple_get_last
   | Prim_tuple_get
-  | Prim_tuple_set_last
   | Prim_tuple_set
   | Prim_tuple
 
@@ -250,8 +252,6 @@ let () =
     )
             [
               "get", Prim_tuple_get;
-              "get_last", Prim_tuple_get_last;
-              "set_last", Prim_tuple_set_last;
               "set", Prim_tuple_set;
               "tuple", Prim_tuple;
 

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -54,6 +54,9 @@ type const =
 
   | Ttuple of datatype list
 
+  | Trecord of (string * datatype) list
+  | Tsum of (string * datatype) list
+
   | Toption of datatype
   | Tlist of datatype
   | Tset of datatype
@@ -67,6 +70,62 @@ type const =
   | Tclosure of (datatype * datatype) * datatype
   | Tfail
   | Ttype of string * datatype
+
+let rec get_type ty = match ty with
+  | Ttez | Tunit | Ttimestamp | Tint | Tnat | Tbool | Tkey | Tkey_hash
+  | Tsignature | Tstring | Tfail -> ty
+  | Ttuple tys ->
+    let tys' = List.map get_type tys in
+    if List.for_all2 (==) tys tys' then ty
+    else Ttuple tys'
+  | Tset t | Tlist t | Toption t ->
+    let t' = get_type t in
+    if t' == t then ty
+    else begin match ty with
+      | Tset t -> Tset t'
+      | Tlist t -> Tlist t'
+      | Toption t -> Toption t'
+      | _ -> assert false
+    end
+  | Tor (t1, t2) | Tcontract (t1, t2) | Tlambda (t1, t2) | Tmap (t1, t2) ->
+    let t1', t2' = get_type t1, get_type t2 in
+    if t1 == t1' && t2 == t2' then ty
+    else begin match ty with
+      | Tor (t1, t2) -> Tor (t1', t2')
+      | Tcontract (t1, t2) -> Tcontract (t1', t2')
+      | Tlambda (t1, t2) -> Tlambda (t1', t2')
+      | Tmap (t1, t2) -> Tmap (t1', t2')
+      | _ -> assert false
+    end
+  | Tclosure  ((t1, t2), t3) ->
+    let t1', t2', t3' = get_type t1, get_type t2, get_type t3 in
+    if t1 == t1' && t2 == t2' && t3 == t3' then ty
+    else Tclosure ((t1', t2'), t3')
+  | Trecord ntys | Tsum ntys ->
+    let change = ref false in
+      let ntys' = List.map (fun (l, ty) ->
+        let ty' = get_type ty in
+        if ty' != ty then change := true;
+        (l, ty')
+      ) ntys in
+    if !change then match ty with
+      | Trecord _ -> Trecord ntys'
+      | Tsum _ -> Tsum ntys'
+      | _ -> assert false
+    else ty
+
+  | Ttype (name, t) -> get_type t
+
+let first_alias ty =
+  let rec aux acc ty = match acc, ty with
+    | _, Ttype (name, ty) -> aux (Some name) ty
+    | Some name, ty -> Some (name, ty)
+    | None, _ -> None
+  in
+  aux None ty
+
+let eq_types t1 t2 =
+  get_type t1 = get_type t2
 
 
 type 'exp contract = {
@@ -462,16 +521,6 @@ type loc_michelson = {
 let mic ins = ins
 let mic_loc loc ins = { loc; ins }
 
-type type_kind =
-  | Type_alias
-  | Type_record of datatype list * int StringMap.t
-  | Type_variant of
-      (string
-       * datatype (* final type *)
-       * datatype (* left type *)
-       * datatype (* right type *)
-      ) list
-
 type closure_env = {
   env_vars :  (string (* name outside closure *)
                * datatype
@@ -492,7 +541,7 @@ type env = {
 
     (* fields modified in LiquidFromOCaml *)
     (* type definitions *)
-    mutable types : (datatype * type_kind) StringMap.t;
+    mutable types : datatype StringMap.t;
     (* labels of records in type definitions *)
     mutable labels : (string * int * datatype) StringMap.t;
     (* constructors of sum-types in type definitions *)

--- a/tools/liquidity/liquidUntype.ml
+++ b/tools/liquidity/liquidUntype.ml
@@ -13,7 +13,7 @@
 
 open LiquidTypes
 
-let mk desc = { desc; ty = (); bv = StringSet.empty; fail = false }
+let mk desc = mk desc ()
 
 type env = {
     env_map : string StringMap.t;

--- a/tools/liquidity/liquidUntype.ml
+++ b/tools/liquidity/liquidUntype.ml
@@ -90,10 +90,6 @@ let rec untype (env : env) (code : encoded_exp) : syntax_exp =
     | Apply(Prim_Right, loc, [arg; unused]) ->
        Constructor(loc, Right unused.ty, untype env arg)
     | Apply (prim, loc, args) ->
-       let prim = match prim with
-         | Prim_tuple_get_last -> Prim_tuple_get
-         | _ -> prim
-       in
        Apply(prim, loc, List.map (untype env) args)
 
     | Lambda (arg_name, arg_type, loc, body, res_type) ->

--- a/tools/liquidity/liquidUntype.ml
+++ b/tools/liquidity/liquidUntype.ml
@@ -75,7 +75,7 @@ let find_free env var_arg bv =
 scopes. Unfortunately, without hash-consing, this can be quite expensive.
  *)
 
-let rec untype (env : env) (code : typed_exp) =
+let rec untype (env : env) (code : encoded_exp) : syntax_exp =
   let desc =
     match code.desc with
     | If (cond, ifthen, ifelse) ->

--- a/tools/liquidity/liquidUntype.mli
+++ b/tools/liquidity/liquidUntype.mli
@@ -9,4 +9,4 @@
 
 open LiquidTypes
 
-val untype_contract : typed_exp contract -> syntax_exp contract
+val untype_contract : encoded_exp contract -> syntax_exp contract

--- a/tools/liquidity/with-tezos/liquidFromTezos.ml
+++ b/tools/liquidity/with-tezos/liquidFromTezos.ml
@@ -43,6 +43,8 @@ let rec convert_const expr =
   | Script_repr.Prim(_, "None", [], _debug) -> CNone
 
   | Script_repr.Prim(_, "Some", [x], _debug) -> CSome (convert_const x)
+  | Script_repr.Prim(_, "Left", [x], _debug) -> CLeft (convert_const x)
+  | Script_repr.Prim(_, "Right", [x], _debug) -> CRight (convert_const x)
   | Script_repr.Prim(_, "Pair", [x;y], _debug) -> CTuple [convert_const x;
                                                   convert_const y]
   | Script_repr.Prim(_, "List", args, _debug) -> CList (List.map convert_const args)

--- a/tools/liquidity/with-tezos/liquidToTezos.ml
+++ b/tools/liquidity/with-tezos/liquidToTezos.ml
@@ -35,6 +35,9 @@ let rec convert_const expr =
   | CNone -> Script_repr.Prim(0, "None", [], debug)
 
   | CSome x -> Script_repr.Prim(0, "Some", [convert_const x], debug)
+  | CLeft x -> Script_repr.Prim(0, "Left", [convert_const x], debug)
+  | CRight x -> Script_repr.Prim(0, "Right", [convert_const x], debug)
+
   | CTuple [] -> assert false
   | CTuple [_] -> assert false
   | CTuple [x;y] ->
@@ -45,6 +48,7 @@ let rec convert_const expr =
                                   convert_const (CTuple y)], debug)
   | CList args -> Script_repr.Prim(0, "List",
                                    List.map convert_const args, debug)
+
   | CMap args ->
      Script_repr.Prim(0, "Map",
                       List.map (fun (x,y) ->

--- a/tools/liquidity/with-tezos/liquidToTezos.ml
+++ b/tools/liquidity/with-tezos/liquidToTezos.ml
@@ -217,7 +217,21 @@ let string_of_contract c =
   Client_proto_programs.print_program (fun _ -> None) ppf (c, []);
   Format.flush_str_formatter ()
 
-
+let line_of_contract c =
+  let ppf = Format.str_formatter in
+  let ffs = Format.pp_get_formatter_out_functions ppf () in
+  let new_ffs =
+    { ffs with
+      Format.out_newline = (fun () -> ffs.Format.out_spaces 1);
+      (* Format.out_indent = (fun _ -> ()); *)
+    } in
+  Format.pp_set_formatter_out_functions ppf new_ffs;
+  Format.pp_set_max_boxes ppf 0;
+  Format.pp_set_max_indent ppf 0;
+  Client_proto_programs.print_program (fun _ -> None) ppf (c, []);
+  let s = Format.flush_str_formatter () in
+  Format.pp_set_formatter_out_functions ppf ffs;
+  s
 
 
 let contract_amount = ref "1000.00"

--- a/tools/liquidity/with-tezos/liquidToTezos.ml
+++ b/tools/liquidity/with-tezos/liquidToTezos.ml
@@ -98,7 +98,6 @@ let rec convert_type expr =
   | Tlist x -> prim "list" [convert_type x]
   | Toption x -> prim "option" [convert_type x]
   | Tfail | Trecord _ | Tsum _ -> assert false
-  | Ttype (_, ty) -> convert_type ty
 
 let rec convert_code expr =
   match expr.i with

--- a/tools/liquidity/with-tezos/liquidToTezos.ml
+++ b/tools/liquidity/with-tezos/liquidToTezos.ml
@@ -97,7 +97,7 @@ let rec convert_type expr =
   | Tset x -> prim "set" [convert_type x]
   | Tlist x -> prim "list" [convert_type x]
   | Toption x -> prim "option" [convert_type x]
-  | Tfail -> assert false
+  | Tfail | Trecord _ | Tsum _ -> assert false
   | Ttype (_, ty) -> convert_type ty
 
 let rec convert_code expr =

--- a/tools/liquidity/without-tezos/liquidToTezos.ml
+++ b/tools/liquidity/without-tezos/liquidToTezos.ml
@@ -12,6 +12,9 @@ open LiquidTypes
 let string_of_contract (c : michelson_exp contract) =
   LiquidPrinter.Michelson.string_of_contract c
 
+let line_of_contract (c : michelson_exp contract) =
+  LiquidPrinter.Michelson.line_of_contract c
+
 let convert_contract (c : noloc_michelson contract) =
   LiquidEmit.emit_contract c
 


### PR DESCRIPTION
Type checking is done first, then encoding some of Liquidity constructs (like closures, fields accesses, etc.) are performed in a second phase.

Record and sum types are kept until translation to Michelson, this allows a better display of type error messages.
