### PR TITLE
Use annotations in Michelson to recover variable names when decompiling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,9 +2,9 @@
     NEW FEATURES
     * match%nat construct for int -> nat coercion
     * abs is now int -> int
-    * Command line options --parse-only --type-only
-    * Command line option --single-line to output Michelson on a
-      single line
+    * Command line options --parse-only, --type-only
+    * Command line options --single-line, --compact to output
+      Michelson on a single line
     * Support &&, || Boolean connectors
     * Support Map.add, Map.remove, Set.add, Set.remove
     * Lambda types are now written as t1 -> t2 instead of
@@ -19,6 +19,7 @@
     * Encode to constants when possible
     * Better error messages
     * Accept any name for result of Contract.call
+    * Recover variable names when decompiling
 
     BUG FIXES
     * Fix bug in encoding of closures

--- a/check-rev.sh
+++ b/check-rev.sh
@@ -9,13 +9,15 @@ RED='\033[0;31m'
 TESTDIR=$1
 test=$2
 
+. ./config.sh
+
 echo "\n[check-rev.sh] test = $test, TESTDIR = $TESTDIR"
 
-if [ -f ./tezos/_obuild/tezos-client/tezos-client.asm ] ; then
+if [ -f ${TEZOS_FULL_PATH} ] ; then
     echo "Testing $test.tz ---------------------------------------------"
-    ./tezos/_obuild/tezos-client/tezos-client.asm typecheck program $TESTDIR/$test.tz
+    ${TEZOS_FULL_PATH} typecheck program $TESTDIR/$test.tz
 else
-    echo "\n${RED}./tezos/_obuild/tezos-client/tezos-client.asm not present ! typechecking of $TESTDIR/$test.tz skipped${DEFAULT}\n"
+    echo "\n${RED}${TEZOS_FULL_PATH} not present ! typechecking of $TESTDIR/$test.tz skipped${DEFAULT}\n"
 fi
 
 echo "Generating $test.tz.liq --------------------------------------"
@@ -24,11 +26,11 @@ echo "Generating $test.tz.liq --------------------------------------"
 echo "Compiling $test.tz.liq ---------------------------------------"
 ./_obuild/liquidity/liquidity.asm $TESTDIR/$test.tz.liq || exit 2
 
-if [ -f ./tezos/_obuild/tezos-client/tezos-client.asm ] ; then
+if [ -f ${TEZOS_FULL_PATH} ] ; then
     echo "Testing $test.tz.liq.tz --------------------------------------"
-    ./tezos/_obuild/tezos-client/tezos-client.asm typecheck program $TESTDIR/$test.tz.liq.tz || exit 2
+    ${TEZOS_FULL_PATH} typecheck program $TESTDIR/$test.tz.liq.tz || exit 2
 else
-    echo "\n${RED}./tezos/_obuild/tezos-client/tezos-client.asm not present ! typechecking of $TESTDIR/$test.tz.liq.tz skipped${DEFAULT}\n"
+    echo "\n${RED}${TEZOS_FULL_PATH} not present ! typechecking of $TESTDIR/$test.tz.liq.tz skipped${DEFAULT}\n"
 fi
 
 echo

--- a/tools/liquidity/liquidData.ml
+++ b/tools/liquidity/liquidData.ml
@@ -66,8 +66,7 @@ let data_of_liq ~filename ~contract ~parameter ~storage =
       let sy_exp = LiquidFromOCaml.translate_expression env ml_exp in
       let ty_exp = LiquidCheck.typecheck_code
           ~warnings:true env contract ty sy_exp in
-      let enc_exp = LiquidEncode.encode_code
-          ~warnings:true env contract ty_exp in
+      let enc_exp = LiquidEncode.encode_code env contract ty_exp in
       let loc = LiquidLoc.loc_in_file filename in
       let c = translate_const_exp loc enc_exp in
       let s = LiquidPrinter.Michelson.line_of_const c in

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -55,10 +55,10 @@ let rec var_of node =
   | N_VAR name -> name
   | _ -> match node.node_name with
 
-    | Some name when name.[0] = '@' ->
+    | Some name ->
       (* check_prev_names node node.prevs; *)
-      String.sub name 1 (String.length name - 1)
-    | _ -> match node.kind with
+      name
+    | None -> match node.kind with
 
       (* | N_VAR name -> name *)
       | N_PRIM "CAR" ->

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -38,11 +38,11 @@ let const_name_of_datatype = function
 
 
 let rec check_prev_names node prevs =
-  match node.name with
+  match node.node_name with
   | Some name ->
     List.iter (fun n ->
         begin match n with
-          | { name = Some name'} ->
+          | { node_name = Some name'} ->
             if name' = name then assert (n != node);
           | _ -> ()
         end;
@@ -53,7 +53,7 @@ let rec check_prev_names node prevs =
 let rec var_of node =
   match node.kind with
   | N_VAR name -> name
-  | _ -> match node.name with
+  | _ -> match node.node_name with
 
     | Some name when name.[0] = '@' ->
       (* check_prev_names node node.prevs; *)
@@ -112,14 +112,14 @@ let rec arg_of node =
        match pos, List.length args with
        | 0, 1 -> arg_of if_node
        | _ ->
-          mk (Apply (Prim_tuple_get, noloc, [ arg_of if_node; nat_n pos ]))
+         mk (Apply (Prim_tuple_get, noloc, [ arg_of if_node; nat_n pos ]))
      end
   | N_LOOP_ARG ({ kind = N_LOOP_BEGIN ( _); args } as begin_node, pos ) ->
      begin
        match pos, List.length args with
        | 0, 1 -> arg_of begin_node
        | _ ->
-          mk (Apply (Prim_tuple_get, noloc, [ arg_of begin_node; nat_n pos ]))
+         mk (Apply (Prim_tuple_get, noloc, [ arg_of begin_node; nat_n pos ]))
      end
   | N_LOOP_RESULT (loop_node, begin_node, pos ) ->
      begin
@@ -421,7 +421,7 @@ let decompile contract =
 
   and mklet node desc =
     mk (Let (var_of node, noloc,
-             mk ?name:node.name desc, decompile_next node))
+             mk ?name:node.node_name desc, decompile_next node))
 
   in
   let (begin_node, end_node) = contract.code in

--- a/tools/liquidity/liquidDot.ml
+++ b/tools/liquidity/liquidDot.ml
@@ -22,11 +22,15 @@ let to_string contract =
       Hashtbl.find nodes node.num
     with Not_found ->
       let name =
-        Printf.sprintf "%d:%s" node.num
-                       (match node.kind with
-                        | N_PRIM prim -> prim
-                        | N_VAR var -> Printf.sprintf "var:%s" var
-                        | _ -> LiquidPrinter.string_of_node node)
+        Printf.sprintf "%d:%s%s" node.num
+          (match node.node_name with
+           | Some name -> Printf.sprintf "var:%s =\n" name
+           | None -> ""
+          )
+          (match node.kind with
+           | N_PRIM prim -> prim
+           | N_VAR var -> Printf.sprintf "var:%s" var
+           | _ -> LiquidPrinter.string_of_node node)
       in
       let n = Ocamldot.node g name [] in
       Hashtbl.add nodes node.num n;

--- a/tools/liquidity/liquidEmit.ml
+++ b/tools/liquidity/liquidEmit.ml
@@ -12,6 +12,7 @@ open LiquidTypes
 
 let rec emit_code code =
   match code.i with
+  | ANNOT s -> M_INS_ANNOT s
   | SEQ exprs -> M_INS_EXP ("SEQ", [], List.map emit_code exprs)
   | IF (ifthen, ifelse) ->
      M_INS_EXP ("IF", [], [emit_code ifthen; emit_code ifelse])

--- a/tools/liquidity/liquidEncode.ml
+++ b/tools/liquidity/liquidEncode.ml
@@ -101,7 +101,9 @@ let find_var ?(count_used=true) env loc name =
     let (name, ty) = StringMap.find name env.vars in
     let count = StringMap.find name env.vars_counts in
     if count_used then incr count;
-    let aname = if env.annot then Some (sanitize_name vname) else None in
+    let aname =
+      if env.annot  && name.[0] <> '_' then Some (sanitize_name vname)
+      else None in
     mk ?name:aname (Var (name, loc, [])) ty
   with Not_found ->
   match env.clos_env with
@@ -337,7 +339,7 @@ let rec encode env ( exp : typed_exp ) : encoded_exp =
   | Let (name, loc, e, body) ->
 
      let e = encode env e in
-     let e = if env.annot
+     let e = if env.annot && name.[0] <> '_'
        then { e with name = Some (sanitize_name name) }
        else e
      in

--- a/tools/liquidity/liquidEncode.mli
+++ b/tools/liquidity/liquidEncode.mli
@@ -12,8 +12,7 @@ open LiquidTypes
 val encode_type : datatype -> datatype
 
 val encode_contract :
-  warnings:bool -> env -> typed_contract ->
+  ?annot:bool -> env -> typed_contract ->
   encoded_contract * encoded_exp StringMap.t
 
-val encode_code :
-  warnings:bool -> env -> syntax_contract -> typed_exp -> encoded_exp
+val encode_code : env -> syntax_contract -> typed_exp -> encoded_exp

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -520,7 +520,7 @@ let deconstruct_pat env pat e =
   | [v, _loc, []] -> v, ty, e
   | _ ->
     let var_name =
-      String.concat "_" (List.rev_map (fun (v,_,_) -> v) vars_infos) in
+      String.concat "_" ( "" :: (List.rev_map (fun (v,_,_) -> v) vars_infos)) in
     let e =
       List.fold_left (fun e (v, loc, indexes) ->
           let access = access_of_deconstruct var_name loc indexes in

--- a/tools/liquidity/liquidInterp.ml
+++ b/tools/liquidity/liquidInterp.ml
@@ -14,7 +14,7 @@ let nodes = Hashtbl.create 1000
 let node loc kind args prevs =
   incr counter;
   let num = !counter in
-  let node = { num; loc; name = None; kind; args; next = None; prevs } in
+  let node = { num; loc; node_name = None; kind; args; next = None; prevs } in
   List.iter (fun prev ->
     match prev.next with
     | None -> prev.next <- Some node
@@ -48,7 +48,7 @@ let rec uniformize_stack if_stack stack =
     else
       LiquidMisc.list_make (stack_length - if_stack_length)
         { num = -1; loc = LiquidLoc.noloc;
-          name = None;
+          node_name = None;
           kind = N_UNKNOWN "STACK"; args = [];
           next = None; prevs = [] }
       @ if_stack
@@ -112,10 +112,6 @@ let interp contract =
     match code, stack with
     | [], _ -> (stack, seq)
 
-    | {ins = ANNOT name} :: code, (x :: _ as stack) ->
-      x.name <- Some name;
-      decompile_seq stack seq code
-
     (* Special case for abs *)
     | {ins=ABS; loc} :: {ins=INT} :: code, x :: stack ->
       let n = node loc N_ABS [x] [seq] in
@@ -153,6 +149,15 @@ let interp contract =
 
   and decompile stack (seq : node) ins =
     match ins.ins, stack with
+    | ANNOT name, x :: _ ->
+      x.node_name <- Some name;
+      begin match x.kind, seq.kind with
+        | N_IF_END_RESULT _, N_IF _ ->
+          seq.node_name <- Some name;
+        | _ -> ()
+      end;
+      stack, seq
+
     | ANNOT name, _ -> stack, seq (* ignore *)
 
     | SEQ exprs, _ ->

--- a/tools/liquidity/liquidMichelson.ml
+++ b/tools/liquidity/liquidMichelson.ml
@@ -496,10 +496,16 @@ the ending NIL is not annotated with a type *)
        arg @ [ ii PAIR ] @ args
 
   and compile depth env e =
-    compile_desc depth env e.desc
+    let code, transfer = compile_desc depth env e.desc in
+    match e.name with
+    | Some name -> code @ [ ii (ANNOT name) ], transfer
+    | None -> code, transfer
 
   and compile_no_transfer depth env e =
-    compile_desc_no_transfer depth env e.desc
+    let code = compile_desc_no_transfer depth env e.desc in
+    match e.name with
+    | Some name -> code @ [ ii (ANNOT name) ]
+    | None -> code
 
   in
 

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -278,7 +278,7 @@ module Michelson = struct
 
   let rec bprint_code fmt b indent code =
     match code with
-    | M_INS_ANNOT s -> Printf.bprintf b "{ @%s }" s
+    | M_INS_ANNOT s -> Printf.bprintf b "{ @liq_%s }" s
     | M_INS ins -> Printf.bprintf b "%s ;" ins
     | M_INS_CST (ins,ty,cst) ->
        let indent = fmt.increase_indent indent in
@@ -329,7 +329,7 @@ module Michelson = struct
 
   let bprint_pre_michelson fmt bprint_arg b = function
     | ANNOT a ->
-      Printf.bprintf b "{ @%s }" a;
+      Printf.bprintf b "{ @liq_%s }" a;
     | SEQ args ->
       Printf.bprintf b "{ ";
       List.iter (fun a -> bprint_arg fmt b a; Printf.bprintf b " ; ") args;

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -278,6 +278,7 @@ module Michelson = struct
 
   let rec bprint_code fmt b indent code =
     match code with
+    | M_INS_ANNOT s -> Printf.bprintf b "{ @%s }" s
     | M_INS ins -> Printf.bprintf b "%s ;" ins
     | M_INS_CST (ins,ty,cst) ->
        let indent = fmt.increase_indent indent in
@@ -327,6 +328,8 @@ module Michelson = struct
     ()
 
   let bprint_pre_michelson fmt bprint_arg b = function
+    | ANNOT a ->
+      Printf.bprintf b "{ @%s }" a;
     | SEQ args ->
       Printf.bprintf b "{ ";
       List.iter (fun a -> bprint_arg fmt b a; Printf.bprintf b " ; ") args;

--- a/tools/liquidity/liquidSimplify.ml
+++ b/tools/liquidity/liquidSimplify.ml
@@ -39,7 +39,7 @@ let compute code to_inline =
              else
                if v.ty <> Tunit then raise Exit
                else
-                 { exp with desc = Seq(v, body) }
+                 { exp with desc = Seq(v, body); name = None }
            with Exit ->
              { exp with desc = Let(name, loc, v, body) }
          end
@@ -124,5 +124,16 @@ let compute code to_inline =
 
   iter code
 
-let simplify_contract contract to_inline =
+let simplify_contract ?(decompile=false) contract to_inline =
+  let to_inline =
+    if decompile
+    then
+      StringMap.filter
+        (fun _ e -> match e with
+           | { ty = Tlambda _ } -> false
+           | { name = Some _ } -> false
+           | _ -> true
+        ) to_inline
+    else to_inline
+  in
   { contract with code = compute contract.code to_inline }

--- a/tools/liquidity/liquidSimplify.ml
+++ b/tools/liquidity/liquidSimplify.ml
@@ -131,5 +131,5 @@ let compute decompile code to_inline =
 
   iter code
 
-let simplify_contract ?(decompile=false) contract to_inline =
-  { contract with code = compute decompile contract.code to_inline }
+let simplify_contract ?(decompile_annoted=false) contract to_inline =
+  { contract with code = compute decompile_annoted contract.code to_inline }

--- a/tools/liquidity/liquidSimplify.mli
+++ b/tools/liquidity/liquidSimplify.mli
@@ -10,5 +10,5 @@
 open LiquidTypes
 
 val simplify_contract :
-  ?decompile:bool ->
+  ?decompile_annoted:bool ->
   encoded_exp contract -> encoded_exp StringMap.t -> encoded_exp contract

--- a/tools/liquidity/liquidSimplify.mli
+++ b/tools/liquidity/liquidSimplify.mli
@@ -10,4 +10,5 @@
 open LiquidTypes
 
 val simplify_contract :
+  ?decompile:bool ->
   encoded_exp contract -> encoded_exp StringMap.t -> encoded_exp contract

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -570,7 +570,7 @@ type 'a typecheck_env = {
 type node = {
   num : int;
   loc : location;
-  mutable name : string option;
+  mutable node_name : string option;
   mutable kind : node_kind;
   mutable args : node list; (* dependencies *)
 

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -9,6 +9,7 @@
 
 module StringMap = Map.Make(String)
 module StringSet = Set.Make(String)
+module IntMap = Map.Make(struct type t = int let compare = compare end)
 
 exception InvalidFormat of string * string
 

--- a/tools/liquidity/with-tezos/liquidFromTezos.ml
+++ b/tools/liquidity/with-tezos/liquidFromTezos.ml
@@ -85,6 +85,8 @@ let loc_of_int loc_table index =
 
 let rec convert_code loc_table expr =
   match expr with
+  | Micheline.Seq (index, [], Some name) ->
+    mic_loc (loc_of_int loc_table index) (ANNOT name)
   | Micheline.Seq (index, exprs, _debug) ->
     mic_loc (loc_of_int loc_table index)
       (SEQ (List.map (convert_code loc_table) exprs))

--- a/tools/liquidity/with-tezos/liquidFromTezos.ml
+++ b/tools/liquidity/with-tezos/liquidFromTezos.ml
@@ -118,10 +118,17 @@ let rec convert_type env expr =
   | Prim(_, "option", [x], _debug) -> Toption (convert_type env x)
   | _ -> unknown_expr env "convert_type" expr
 
+let is_liq_annot name =
+  try Scanf.sscanf name "@liq_" true
+  with _ -> false
+
+let liq_annot name =
+  Scanf.sscanf name "@liq_%s" (fun s -> s)
+
 let rec convert_code env expr =
   match expr with
-  | Seq (index, [], Some name) ->
-    mic_loc (loc_of_int env index) (ANNOT name)
+  | Seq (index, [], Some name) when is_liq_annot name ->
+    mic_loc (loc_of_int env index) (ANNOT (liq_annot name))
   | Seq (index, exprs, _debug) ->
     mic_loc (loc_of_int env index)
       (SEQ (List.map (convert_code env) exprs))

--- a/tools/liquidity/with-tezos/liquidFromTezos.mli
+++ b/tools/liquidity/with-tezos/liquidFromTezos.mli
@@ -10,11 +10,11 @@
 exception Missing_program_field of string
 
 val convert_contract :
-  LiquidTezosTypes.loc_table ->
+  LiquidTezosTypes.env ->
   LiquidTezosTypes.contract ->
   LiquidTypes.loc_michelson LiquidTypes.contract
 
 val contract_of_string :
   string -> (* maybe filename *)
   string -> (* content *)
-  (LiquidTezosTypes.contract * LiquidTezosTypes.loc_table) option
+  (LiquidTezosTypes.contract * LiquidTezosTypes.env) option

--- a/tools/liquidity/with-tezos/liquidFromTezos.mli
+++ b/tools/liquidity/with-tezos/liquidFromTezos.mli
@@ -12,7 +12,7 @@ exception Missing_program_field of string
 val convert_contract :
   LiquidTezosTypes.env ->
   LiquidTezosTypes.contract ->
-  LiquidTypes.loc_michelson LiquidTypes.contract
+  LiquidTypes.loc_michelson LiquidTypes.contract * bool (* true if tz annoted *)
 
 val contract_of_string :
   string -> (* maybe filename *)

--- a/tools/liquidity/with-tezos/liquidTezosTypes.ml
+++ b/tools/liquidity/with-tezos/liquidTezosTypes.ml
@@ -6,10 +6,14 @@
 (*    All rights reserved. No warranty, explicit or implicit, provided.   *)
 (*                                                                        *)
 (**************************************************************************)
+open LiquidTypes
 
 type contract = string Micheline.canonical list
 
-type loc_table = (int * LiquidTypes.location) list
+type env = {
+  filename : string;
+  loc_table : location IntMap.t;
+}
 
 type hash = Hash.Operation_hash.t
 

--- a/tools/liquidity/with-tezos/liquidTezosTypes.ml
+++ b/tools/liquidity/with-tezos/liquidTezosTypes.ml
@@ -13,8 +13,7 @@ type contract = string Micheline.canonical list
 type env = {
   filename : string;
   loc_table : location IntMap.t;
+  mutable annoted : bool;
 }
 
 type hash = Hash.Operation_hash.t
-
-exception ParseError of Error_monad.error

--- a/tools/liquidity/with-tezos/liquidToTezos.ml
+++ b/tools/liquidity/with-tezos/liquidToTezos.ml
@@ -96,8 +96,10 @@ let rec convert_type expr =
 
 let rec convert_code expr =
   match expr.i with
+  | ANNOT a ->
+    Micheline.Seq (0, [], Some a)
   | SEQ exprs ->
-     Micheline.Seq (0, List.map convert_code exprs, debug)
+    Micheline.Seq (0, List.map convert_code exprs, debug)
   | DROP -> prim "DROP" []
   | DIP (0, arg) -> assert false
   | DIP (1, arg) -> prim "DIP" [ convert_code arg ]

--- a/tools/liquidity/with-tezos/liquidToTezos.ml
+++ b/tools/liquidity/with-tezos/liquidToTezos.ml
@@ -97,7 +97,7 @@ let rec convert_type expr =
 let rec convert_code expr =
   match expr.i with
   | ANNOT a ->
-    Micheline.Seq (0, [], Some a)
+    Micheline.Seq (0, [], Some ("@"^a))
   | SEQ exprs ->
     Micheline.Seq (0, List.map convert_code exprs, debug)
   | DROP -> prim "DROP" []

--- a/tools/liquidity/with-tezos/liquidToTezos.ml
+++ b/tools/liquidity/with-tezos/liquidToTezos.ml
@@ -97,7 +97,7 @@ let rec convert_type expr =
 let rec convert_code expr =
   match expr.i with
   | ANNOT a ->
-    Micheline.Seq (0, [], Some ("@"^a))
+    Micheline.Seq (0, [], Some ("@liq_"^a))
   | SEQ exprs ->
     Micheline.Seq (0, List.map convert_code exprs, debug)
   | DROP -> prim "DROP" []

--- a/tools/liquidity/with-tezos/liquidToTezos.mli
+++ b/tools/liquidity/with-tezos/liquidToTezos.mli
@@ -15,7 +15,7 @@ val string_of_contract : LiquidTezosTypes.contract -> string
 
 val read_tezos_file :
   string ->
-  LiquidTezosTypes.contract * LiquidTezosTypes.hash * LiquidTezosTypes.loc_table
+  LiquidTezosTypes.contract * LiquidTezosTypes.hash * LiquidTezosTypes.env
 
 val arg_list : bool ref ->
          (Arg.key * Arg.spec * Arg.doc) list

--- a/tools/liquidity/without-tezos/liquidFromTezos.ml
+++ b/tools/liquidity/without-tezos/liquidFromTezos.ml
@@ -11,5 +11,7 @@ open LiquidTypes
 
 exception Missing_program_field of string
 
-let convert_contract loc_table string = assert false (* NOT IMPLEMENTED *)
-let contract_of_string filename string = assert false (* NOT IMPLEMENTED *)
+let convert_contract loc_table string =
+    failwith "mini version cannot decompile"
+let contract_of_string filename string =
+    failwith "mini version cannot decompile"

--- a/tools/liquidity/without-tezos/liquidTezosTypes.ml
+++ b/tools/liquidity/without-tezos/liquidTezosTypes.ml
@@ -7,6 +7,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type loc_table = unit
+type env = unit
 type contract = LiquidTypes.michelson_exp LiquidTypes.contract
 type hash

--- a/tools/liquidity/without-tezos/liquidToTezos.ml
+++ b/tools/liquidity/without-tezos/liquidToTezos.ml
@@ -18,6 +18,7 @@ let line_of_contract (c : michelson_exp contract) =
 let convert_contract (c : noloc_michelson contract) =
   LiquidEmit.emit_contract c
 
-let read_tezos_file (_filename : string) = assert false
+let read_tezos_file (_filename : string) =
+  failwith "mini version cannot decompile"
 
 let arg_list work_done = []


### PR DESCRIPTION
Also better inlining + don't inline functions and named expressions when
decompiling