### PR TITLE
new --init-storage command and modifications to the --data command

### DIFF
--- a/docs/liquidity.html
+++ b/docs/liquidity.html
@@ -11,20 +11,20 @@
 <p>See <a href="http://github.com/OCamlPro/liquidity/tree/master/tests">examples</a> in the <a href="http://github.com/OCamlPro/liquidity">Github</a> project.</p>
 <h2 id="contract-format">Contract Format</h2>
 <p>All the contracts have the following form:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml">[%%version <span class="fl">0.3</span>]
-
-&lt;... local declarations ...&gt;
-
-<span class="kw">let</span>%init storage
-      (x : TYPE)
-      (x : TYPE)
-      ... =
-      BODY
-
-<span class="kw">let</span>%entry main
-      (parameter : TYPE)
-      (storage : TYPE) =
-      BODY</code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb1-1" data-line-number="1">[%%version <span class="fl">0.3</span>]</a>
+<a class="sourceLine" id="cb1-2" data-line-number="2"></a>
+<a class="sourceLine" id="cb1-3" data-line-number="3">&lt;... local declarations ...&gt;</a>
+<a class="sourceLine" id="cb1-4" data-line-number="4"></a>
+<a class="sourceLine" id="cb1-5" data-line-number="5"><span class="kw">let</span>%init storage</a>
+<a class="sourceLine" id="cb1-6" data-line-number="6">      (x : TYPE)</a>
+<a class="sourceLine" id="cb1-7" data-line-number="7">      (x : TYPE)</a>
+<a class="sourceLine" id="cb1-8" data-line-number="8">      ... =</a>
+<a class="sourceLine" id="cb1-9" data-line-number="9">      BODY</a>
+<a class="sourceLine" id="cb1-10" data-line-number="10"></a>
+<a class="sourceLine" id="cb1-11" data-line-number="11"><span class="kw">let</span>%entry main</a>
+<a class="sourceLine" id="cb1-12" data-line-number="12">      (parameter : TYPE)</a>
+<a class="sourceLine" id="cb1-13" data-line-number="13">      (storage : TYPE) =</a>
+<a class="sourceLine" id="cb1-14" data-line-number="14">      BODY</a></code></pre></div>
 <p>The <code>version</code> statement tells the compiler in which version of Liquidity the contract is written. The compiler will reject any contract that has a version that it does not understand (too old, more recent). We expect to reach version 1.0 at the launch of the Tezos network.</p>
 <p>The <code>main</code> function is the default entry point for the contract. <code>let%entry</code> is the construct used to declare entry points (there is currently only one entry point, but there will be probably more in the future). The declaration takes two parameters with names <code>parameter</code>, <code>storage</code>, the arguments to the function. Their types must always be specified. The return type of the function must also be specified by a type annotation.</p>
 <p>A contract always returns a pair <code>(operations, storage)</code>, where <code>operations</code> is a list of internal operations to perform after exectution of the contract, and <code>storage</code> is the final state of the contract after the call. The type of the pair must match the type of a pair where the first component is a list of opertations and the second is the type of the argument <code>storage</code> of <code>main</code>.</p>
@@ -62,9 +62,9 @@
 <p>Record and variant types must be declared beforehand and are referred to by their names.</p>
 <h2 id="calling-another-contract">Calling another contract</h2>
 <p>Calling another contract is done by constructing an operation with the built-in <code>Contract.call</code> function, and <strong>returning</strong> this value at the end of the contract. Internal contract calls are performed after execution of the contract is over, in the order in which the resulting operations are returned.</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> op = Contract.call CONTRACT AMOUNT ARG <span class="kw">in</span>
-BODY
-( op :: OTHER_OPERATIONS, STORAGE)</code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="kw">let</span> op = Contract.call CONTRACT AMOUNT ARG <span class="kw">in</span></a>
+<a class="sourceLine" id="cb2-2" data-line-number="2">BODY</a>
+<a class="sourceLine" id="cb2-3" data-line-number="3">( op :: OTHER_OPERATIONS, STORAGE)</a></code></pre></div>
 <p>where:</p>
 <ul>
 <li><code>CONTRACT</code> is the value of the contract being called;</li>
@@ -92,7 +92,7 @@ BODY
 <li><code>CREATE_ACCOUNT</code> : <code>Account.create</code>. Creates a new account.</li>
 <li><code>CREATE_CONTRACT</code> : <code>Contract.create</code>. Creates a new contract.</li>
 <li><code>SET_DELEGATE</code> : <code>Contract.set_delegate</code>. Sets the delegate (or unset, if argument is <code>None</code>) of the current contract.</li>
-<li><code>CONTRACT param_type</code> : <code>(Contract.at addr : param_type contract  option)</code>: returns the contract stored at this address, if it exists</li>
+<li><code>CONTRACT param_type</code> : <code>(Contract.at addr : param_type contract    option)</code>: returns the contract stored at this address, if it exists</li>
 <li><code>EXEC</code> : <code>Lambda.pipe x f</code> or <code>x |&gt; f</code> or <code>f x</code>, is the application of the lambda <code>f</code> on the argument <code>x</code>.</li>
 <li><code>IMPLICIT_ACCOUNT</code> : <code>Account.default key_hash</code>. Returns the default contract (of type <code>unit contract</code>) associated with a key hash.</li>
 <li><code>ADDRESS</code> : <code>Contract.address</code> to retrieve the address of a contract</li>
@@ -148,9 +148,9 @@ BODY
 <li><code>ISNAT</code> : <code>is_nat x</code> return <code>(Some y)</code> iff x is positive, where y is of type <code>nat</code> and y = x</li>
 </ul>
 <p>For converting <code>int</code> to <code>nat</code>, Liquidity provides a special pattern-matching construct <code>match%nat</code>, on two constructors <code>Plus</code> and <code>Minus</code>. For instance, in the following where <code>x</code> has type <code>int</code>:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">match</span>%nat x <span class="kw">with</span>
-| Plus p -&gt; p + <span class="dv">1</span>p
-| Minus m -&gt; m + <span class="dv">1</span>p</code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="kw">match</span>%nat x <span class="kw">with</span></a>
+<a class="sourceLine" id="cb3-2" data-line-number="2">| Plus p -&gt; p + <span class="dv">1</span>p</a>
+<a class="sourceLine" id="cb3-3" data-line-number="3">| Minus m -&gt; m + <span class="dv">1</span>p</a></code></pre></div>
 <p><code>m</code> and <code>p</code> are of type <code>nat</code> and:</p>
 <ul>
 <li><code>x = int m</code> when <code>x</code> is positive or null</li>
@@ -165,7 +165,7 @@ BODY
 </ul>
 <p>As in Michelson, there are different types of integers:</p>
 <ul>
-<li>int : an unbounded integer, positive or negative, simply written <code>0</code>,<code>1</code>,<code>2</code>,<code>-1</code>,<code>-2</code>,...</li>
+<li>int : an unbounded integer, positive or negative, simply written <code>0</code>,<code>1</code>,<code>2</code>,<code>-1</code>,<code>-2</code>,…</li>
 <li>nat : an unbounded positive integer, written either with a <code>p</code> suffix (<code>0p</code>, <code>12p</code>, etc.) or as an integer with a type coercion ( <code>(0 : nat)</code> ).</li>
 <li>tez : an unbounded positive float of Tezzies, written either with a <code>tz</code> suffix (<code>1.00tz</code>, etc.) or as a string with type coercion (<code>(&quot;1.00&quot; : tez)</code>).</li>
 </ul>
@@ -183,7 +183,7 @@ BODY
 <ul>
 <li><code>tz1YLtLqD1fWHthSVHPD116oYvsd4PTAHUoc</code> is a key hash</li>
 <li><code>edpkuit3FiCUhd6pmqf9ztUTdUs1isMTbF9RBGfwKk1ZrdTmeP9ypN</code> is a public key</li>
-<li><code>edsigedsigthTzJ8X7MPmNeEwybRAvdxS1pupqcM5Mk4uCuyZAe7uEk68YpuGDeViW8wSXMr   Ci5CwoNgqs8V2w8ayB5dMJzrYCHhD8C7</code> is a signature</li>
+<li><code>edsigedsigthTzJ8X7MPmNeEwybRAvdxS1pupqcM5Mk4uCuyZAe7uEk68YpuGDeViW8wSXMr  Ci5CwoNgqs8V2w8ayB5dMJzrYCHhD8C7</code> is a signature</li>
 </ul>
 <p>There are also three types of collections: lists, sets and maps. Constants collections can be created directly:</p>
 <ul>
@@ -203,115 +203,115 @@ BODY
 <p>Tuples in Liquidity are compiled to pairs in Michelson:</p>
 <pre><code>(x, y, z) &lt;=&gt; Pair x (Pair y z)</code></pre>
 <p>Tuples can be accessed using the field access notation of Liquidity:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> t = (x,y,z) <span class="kw">in</span>
-<span class="kw">let</span> should_be_true = t.(<span class="dv">2</span>) = z <span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb5-1" data-line-number="1"><span class="kw">let</span> t = (x,y,z) <span class="kw">in</span></a>
+<a class="sourceLine" id="cb5-2" data-line-number="2"><span class="kw">let</span> should_be_true = t.(<span class="dv">2</span>) = z <span class="kw">in</span></a>
+<a class="sourceLine" id="cb5-3" data-line-number="3">...</a></code></pre></div>
 <p>A new tuple can be created from another one using the field access update notation of Liquidity:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> t = (<span class="dv">1</span>,<span class="dv">2</span>,<span class="dv">3</span>) <span class="kw">in</span>
-<span class="kw">let</span> z = t.(<span class="dv">2</span>) &lt;- <span class="dv">4</span> <span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb6"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb6-1" data-line-number="1"><span class="kw">let</span> t = (<span class="dv">1</span>,<span class="dv">2</span>,<span class="dv">3</span>) <span class="kw">in</span></a>
+<a class="sourceLine" id="cb6-2" data-line-number="2"><span class="kw">let</span> z = t.(<span class="dv">2</span>) &lt;- <span class="dv">4</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb6-3" data-line-number="3">...</a></code></pre></div>
 <p>Tuples can be deconstructed:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="co">(* t : (int * (bool * nat) * int) *)</span>
-<span class="kw">let</span> _, (b, _), i = t <span class="kw">in</span>
-...
-<span class="co">(* b : bool</span>
-<span class="co">   i : int *)</span></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb7-1" data-line-number="1"><span class="co">(* t : (int * (bool * nat) * int) *)</span></a>
+<a class="sourceLine" id="cb7-2" data-line-number="2"><span class="kw">let</span> _, (b, _), i = t <span class="kw">in</span></a>
+<a class="sourceLine" id="cb7-3" data-line-number="3">...</a>
+<a class="sourceLine" id="cb7-4" data-line-number="4"><span class="co">(* b : bool</span></a>
+<a class="sourceLine" id="cb7-5" data-line-number="5"><span class="co">   i : int *)</span></a></code></pre></div>
 <h2 id="records">Records</h2>
 <p>Record types can be declared and used inside a liquidity contract:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">type</span> storage = {
-  x : <span class="dt">string</span>;
-  y : <span class="dt">int</span>;
-}</code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb8-1" data-line-number="1"><span class="kw">type</span> storage = {</a>
+<a class="sourceLine" id="cb8-2" data-line-number="2">  x : <span class="dt">string</span>;</a>
+<a class="sourceLine" id="cb8-3" data-line-number="3">  y : <span class="dt">int</span>;</a>
+<a class="sourceLine" id="cb8-4" data-line-number="4">}</a></code></pre></div>
 <p>Such types can be created and used inside programs:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> r = { x = <span class="st">&quot;foo&quot;</span>; y = <span class="dv">3</span> } <span class="kw">in</span>
-r.x</code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb9-1" data-line-number="1"><span class="kw">let</span> r = { x = <span class="st">&quot;foo&quot;</span>; y = <span class="dv">3</span> } <span class="kw">in</span></a>
+<a class="sourceLine" id="cb9-2" data-line-number="2">r.x</a></code></pre></div>
 <p>Records are compiled as tuples.</p>
 <p>Deep record creation is possible using the notation:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> r1 = { x = <span class="dv">1</span>; y = { z = <span class="dv">3</span> } } <span class="kw">in</span>
-<span class="kw">let</span> r2 = r1.y.z &lt;- <span class="dv">4</span> <span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb10"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb10-1" data-line-number="1"><span class="kw">let</span> r1 = { x = <span class="dv">1</span>; y = { z = <span class="dv">3</span> } } <span class="kw">in</span></a>
+<a class="sourceLine" id="cb10-2" data-line-number="2"><span class="kw">let</span> r2 = r1.y.z &lt;- <span class="dv">4</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb10-3" data-line-number="3">...</a></code></pre></div>
 <h2 id="variants">Variants</h2>
 <p>Variants should be defined before use, before the contract declaration:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">type</span> t =
-| X
-| Y <span class="kw">of</span> <span class="dt">int</span>
-| Z <span class="kw">of</span> <span class="dt">string</span> * nat</code></pre></div>
+<div class="sourceCode" id="cb11"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb11-1" data-line-number="1"><span class="kw">type</span> t =</a>
+<a class="sourceLine" id="cb11-2" data-line-number="2">| X</a>
+<a class="sourceLine" id="cb11-3" data-line-number="3">| Y <span class="kw">of</span> <span class="dt">int</span></a>
+<a class="sourceLine" id="cb11-4" data-line-number="4">| Z <span class="kw">of</span> <span class="dt">string</span> * nat</a></code></pre></div>
 <p>Variants can be created using:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> x = X <span class="dv">3</span> <span class="kw">in</span>
-<span class="kw">let</span> y = Z s <span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb12"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb12-1" data-line-number="1"><span class="kw">let</span> x = X <span class="dv">3</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb12-2" data-line-number="2"><span class="kw">let</span> y = Z s <span class="kw">in</span></a>
+<a class="sourceLine" id="cb12-3" data-line-number="3">...</a></code></pre></div>
 <p>The <code>match</code> construct can be used to pattern-match on them, but only on the first constructor:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">match</span> x <span class="kw">with</span>
-| X -&gt; ...
-| Y i -&gt; ...
-| Z s -&gt; ...</code></pre></div>
+<div class="sourceCode" id="cb13"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb13-1" data-line-number="1"><span class="kw">match</span> x <span class="kw">with</span></a>
+<a class="sourceLine" id="cb13-2" data-line-number="2">| X -&gt; ...</a>
+<a class="sourceLine" id="cb13-3" data-line-number="3">| Y i -&gt; ...</a>
+<a class="sourceLine" id="cb13-4" data-line-number="4">| Z s -&gt; ...</a></code></pre></div>
 <p>where <code>i</code> and <code>s</code> are variables that are bound by the construct to the parameter of the variant.</p>
 <p>Parameters of variants can also be deconstructed when they are tuples, so one can write:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">match</span> x <span class="kw">with</span>
-| X -&gt; ...
-| Y i -&gt; ...
-| Z (s, n) -&gt; ...</code></pre></div>
+<div class="sourceCode" id="cb14"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb14-1" data-line-number="1"><span class="kw">match</span> x <span class="kw">with</span></a>
+<a class="sourceLine" id="cb14-2" data-line-number="2">| X -&gt; ...</a>
+<a class="sourceLine" id="cb14-3" data-line-number="3">| Y i -&gt; ...</a>
+<a class="sourceLine" id="cb14-4" data-line-number="4">| Z (s, n) -&gt; ...</a></code></pre></div>
 <p>A special case of variants is the <code>Left | Right</code> predefined variant, called <code>variant</code>:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">type</span> (`left, `right) variant =
-| Left <span class="kw">of</span> `left
-| Right <span class="kw">of</span> `right</code></pre></div>
+<div class="sourceCode" id="cb15"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb15-1" data-line-number="1"><span class="kw">type</span> (`left, `right) variant =</a>
+<a class="sourceLine" id="cb15-2" data-line-number="2">| Left <span class="kw">of</span> `left</a>
+<a class="sourceLine" id="cb15-3" data-line-number="3">| Right <span class="kw">of</span> `right</a></code></pre></div>
 <p>All occurrences of these variants should be constrained with type annotations:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> x = (Left <span class="dv">3</span> : (<span class="dt">int</span>, <span class="dt">string</span>) variant) <span class="kw">in</span>
-<span class="kw">match</span> x <span class="kw">with</span>
-| Left left  -&gt; ...
-| Right right -&gt; ...</code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb16-1" data-line-number="1"><span class="kw">let</span> x = (Left <span class="dv">3</span> : (<span class="dt">int</span>, <span class="dt">string</span>) variant) <span class="kw">in</span></a>
+<a class="sourceLine" id="cb16-2" data-line-number="2"><span class="kw">match</span> x <span class="kw">with</span></a>
+<a class="sourceLine" id="cb16-3" data-line-number="3">| Left left  -&gt; ...</a>
+<a class="sourceLine" id="cb16-4" data-line-number="4">| Right right -&gt; ...</a></code></pre></div>
 <p>Another special variant is the <code>Source</code> variant: it is used to refer to the contract that called the current contract.</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> s = (Source : (<span class="dt">unit</span>, <span class="dt">unit</span>) contract) <span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb17"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb17-1" data-line-number="1"><span class="kw">let</span> s = (Source : (<span class="dt">unit</span>, <span class="dt">unit</span>) contract) <span class="kw">in</span></a>
+<a class="sourceLine" id="cb17-2" data-line-number="2">...</a></code></pre></div>
 <p>As for <code>Left</code> and <code>Right</code>, <code>Source</code> occurrences should be constrained by type annotations.</p>
 <h2 id="functions-and-closures">Functions and Closures</h2>
 <p>Unlike Michelson, functions in Liquidity can also be closures. They can take multiple arguments and are curryfied. Because closures are lambda-lifted, it is however recommended to use a single tuple argument when possible. Arguments must be annotated with their (monomorphic) type, while the return type is inferred.</p>
 <p>Function applications are often done using the <code>Lambda.pipe</code> function or the <code>|&gt;</code> operator:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml">  <span class="kw">let</span> <span class="dt">succ</span> = <span class="kw">fun</span> (x : <span class="dt">int</span>) -&gt; x + <span class="dv">1</span> <span class="kw">in</span>
-  <span class="kw">let</span> one = <span class="dv">0</span> |&gt; <span class="dt">succ</span> <span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb18"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb18-1" data-line-number="1">  <span class="kw">let</span> <span class="dt">succ</span> = <span class="kw">fun</span> (x : <span class="dt">int</span>) -&gt; x + <span class="dv">1</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb18-2" data-line-number="2">  <span class="kw">let</span> one = <span class="dv">0</span> |&gt; <span class="dt">succ</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb18-3" data-line-number="3">...</a></code></pre></div>
 <p>but they can also be done directly:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml">...
-  <span class="kw">let</span> <span class="dt">succ</span> (x : <span class="dt">int</span>) = x + <span class="dv">1</span> <span class="kw">in</span>
-  <span class="kw">let</span> one = <span class="dt">succ</span> <span class="dv">0</span> <span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb19"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb19-1" data-line-number="1">...</a>
+<a class="sourceLine" id="cb19-2" data-line-number="2">  <span class="kw">let</span> <span class="dt">succ</span> (x : <span class="dt">int</span>) = x + <span class="dv">1</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb19-3" data-line-number="3">  <span class="kw">let</span> one = <span class="dt">succ</span> <span class="dv">0</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb19-4" data-line-number="4">...</a></code></pre></div>
 <p>A toplevel function can also be defined before the main entry point:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml">[%%version <span class="fl">0.2</span>]
-
-<span class="kw">let</span> <span class="dt">succ</span> (x : <span class="dt">int</span>) = x + <span class="dv">1</span>
-
-<span class="kw">let</span>%entry main ... =
-   ...
-   <span class="kw">let</span> one = <span class="dt">succ</span> <span class="dv">0</span> <span class="kw">in</span>
-   ...</code></pre></div>
+<div class="sourceCode" id="cb20"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb20-1" data-line-number="1">[%%version <span class="fl">0.2</span>]</a>
+<a class="sourceLine" id="cb20-2" data-line-number="2"></a>
+<a class="sourceLine" id="cb20-3" data-line-number="3"><span class="kw">let</span> <span class="dt">succ</span> (x : <span class="dt">int</span>) = x + <span class="dv">1</span></a>
+<a class="sourceLine" id="cb20-4" data-line-number="4"></a>
+<a class="sourceLine" id="cb20-5" data-line-number="5"><span class="kw">let</span>%entry main ... =</a>
+<a class="sourceLine" id="cb20-6" data-line-number="6">   ...</a>
+<a class="sourceLine" id="cb20-7" data-line-number="7">   <span class="kw">let</span> one = <span class="dt">succ</span> <span class="dv">0</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb20-8" data-line-number="8">   ...</a></code></pre></div>
 <p>Closures can be created with the same syntax:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> p = <span class="dv">10</span> <span class="kw">in</span>
-<span class="kw">let</span> sum_and_add_p (x : <span class="dt">int</span>) (y : <span class="dt">int</span>) = x + y + p <span class="kw">in</span>
-<span class="kw">let</span> r = add_p <span class="dv">3</span> <span class="dv">4</span> <span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb21"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb21-1" data-line-number="1"><span class="kw">let</span> p = <span class="dv">10</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb21-2" data-line-number="2"><span class="kw">let</span> sum_and_add_p (x : <span class="dt">int</span>) (y : <span class="dt">int</span>) = x + y + p <span class="kw">in</span></a>
+<a class="sourceLine" id="cb21-3" data-line-number="3"><span class="kw">let</span> r = add_p <span class="dv">3</span> <span class="dv">4</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb21-4" data-line-number="4">...</a></code></pre></div>
 <p>This is equivalent to:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> p = <span class="dv">10</span> <span class="kw">in</span>
-<span class="kw">let</span> sum_and_add_p =
-  <span class="kw">fun</span> (x : <span class="dt">int</span>) -&gt;
-    <span class="kw">fun</span> (y : <span class="dt">int</span>) -&gt;
-      x + y + p
-<span class="kw">in</span>
-<span class="kw">let</span> r = <span class="dv">4</span> |&gt; (<span class="dv">3</span> |&gt; add_p) <span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb22"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb22-1" data-line-number="1"><span class="kw">let</span> p = <span class="dv">10</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb22-2" data-line-number="2"><span class="kw">let</span> sum_and_add_p =</a>
+<a class="sourceLine" id="cb22-3" data-line-number="3">  <span class="kw">fun</span> (x : <span class="dt">int</span>) -&gt;</a>
+<a class="sourceLine" id="cb22-4" data-line-number="4">    <span class="kw">fun</span> (y : <span class="dt">int</span>) -&gt;</a>
+<a class="sourceLine" id="cb22-5" data-line-number="5">      x + y + p</a>
+<a class="sourceLine" id="cb22-6" data-line-number="6"><span class="kw">in</span></a>
+<a class="sourceLine" id="cb22-7" data-line-number="7"><span class="kw">let</span> r = <span class="dv">4</span> |&gt; (<span class="dv">3</span> |&gt; add_p) <span class="kw">in</span></a>
+<a class="sourceLine" id="cb22-8" data-line-number="8">...</a></code></pre></div>
 <p>Functions with multiple arguments should take a tuple as argument because curried versions will generate larger code and should be avoided unless partial application is important. The previous function should be written as:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> sum_and_add_p ((x : <span class="dt">int</span>), (y : <span class="dt">int</span>)) =
-  <span class="kw">let</span> p = <span class="dv">10</span> <span class="kw">in</span>
-  x + y + p
-<span class="kw">in</span>
-<span class="kw">let</span> r = add_p (<span class="dv">3</span>, <span class="dv">4</span>) <span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb23"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb23-1" data-line-number="1"><span class="kw">let</span> sum_and_add_p ((x : <span class="dt">int</span>), (y : <span class="dt">int</span>)) =</a>
+<a class="sourceLine" id="cb23-2" data-line-number="2">  <span class="kw">let</span> p = <span class="dv">10</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb23-3" data-line-number="3">  x + y + p</a>
+<a class="sourceLine" id="cb23-4" data-line-number="4"><span class="kw">in</span></a>
+<a class="sourceLine" id="cb23-5" data-line-number="5"><span class="kw">let</span> r = add_p (<span class="dv">3</span>, <span class="dv">4</span>) <span class="kw">in</span></a>
+<a class="sourceLine" id="cb23-6" data-line-number="6">...</a></code></pre></div>
 <h2 id="loops">Loops</h2>
 <p>Loops in liquidity share some syntax with functions, but the body of the loop is not a function, so it can access the environment, as would a closure do:</p>
-<div class="sourceCode"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><span class="kw">let</span> end_loop = <span class="dv">5</span> <span class="kw">in</span>
-<span class="kw">let</span> x = Loop.loop (<span class="kw">fun</span> x -&gt;
-    ...
-    (x &lt; end_loop, x&#39;)
-  ) x_init
-<span class="kw">in</span>
-...</code></pre></div>
+<div class="sourceCode" id="cb24"><pre class="sourceCode ocaml"><code class="sourceCode ocaml"><a class="sourceLine" id="cb24-1" data-line-number="1"><span class="kw">let</span> end_loop = <span class="dv">5</span> <span class="kw">in</span></a>
+<a class="sourceLine" id="cb24-2" data-line-number="2"><span class="kw">let</span> x = Loop.loop (<span class="kw">fun</span> x -&gt;</a>
+<a class="sourceLine" id="cb24-3" data-line-number="3">    ...</a>
+<a class="sourceLine" id="cb24-4" data-line-number="4">    (x &lt; end_loop, x&#39;)</a>
+<a class="sourceLine" id="cb24-5" data-line-number="5">  ) x_init</a>
+<a class="sourceLine" id="cb24-6" data-line-number="6"><span class="kw">in</span></a>
+<a class="sourceLine" id="cb24-7" data-line-number="7">...</a></code></pre></div>
 <p>As shown in this example, the body of the loop returns a pair, whose first part is the condition to remain in the loop, and the second part is the accumulator.</p>

--- a/tools/liquidity/liquidData.ml
+++ b/tools/liquidity/liquidData.ml
@@ -125,8 +125,7 @@ let data_of_liq ~filename ~contract ~parameter ~storage =
   let translate filename s ty =
     try
       let c = translate { env with filename } contract.contract_sig s ty in
-      let s = LiquidPrinter.Michelson.line_of_const c in
-      Ok s
+      Ok c
     with LiquidError error ->
       Error error
   in

--- a/tools/liquidity/liquidData.mli
+++ b/tools/liquidity/liquidData.mli
@@ -17,7 +17,7 @@ val data_of_liq :
   filename:string ->
   contract:string ->
   parameter:string ->
-  storage:string -> (string,error) result * (string,error) result
+  storage:string -> (const,error) result * (const,error) result
 
 val translate :
   env -> contract_sig -> string -> datatype -> const

--- a/tools/liquidity/liquidData.mli
+++ b/tools/liquidity/liquidData.mli
@@ -16,8 +16,8 @@ val translate_const_exp : location -> encoded_exp -> const
 val data_of_liq :
   filename:string ->
   contract:string ->
-  parameter:string ->
-  storage:string -> (const,error) result * (const,error) result
+  typ:string -> 
+  parameter:string -> (const,error) result
 
 val translate :
   env -> contract_sig -> string -> datatype -> const

--- a/tools/liquidity/liquidDeploy.ml
+++ b/tools/liquidity/liquidDeploy.ml
@@ -828,6 +828,10 @@ let get_public_key_from_secret_key sk =
 
 let init_storage ?source
     liquid init_params_strings =
+  let source = match source, !LiquidOptions.source with
+    | Some source, _ | _, Some source -> source
+    | None, None -> raise (ResponseError "init_storage: Missing source")
+  in
   let env, syntax_ast, pre_michelson, pre_init_infos = compile_liquid liquid in
   let contract_sig = syntax_ast.contract_sig in
   let pre_init, init_infos = match pre_init_infos with

--- a/tools/liquidity/liquidDeploy.mli
+++ b/tools/liquidity/liquidDeploy.mli
@@ -78,8 +78,7 @@ module type S = sig
     from -> string -> string ->
     (operation list * LiquidTypes.const * big_map_diff option * trace) t
 
-(** compute the initial storage for a specific script
-      ![LiquidOptions], returns storage data *)
+  (** Compute the initial storage for a specific script, returns storage data *)
   val init_storage : from -> string list -> LiquidTypes.const t
 
   (** Forge a deployment operation contract on the Tezos node specified in

--- a/tools/liquidity/liquidDeploy.mli
+++ b/tools/liquidity/liquidDeploy.mli
@@ -78,6 +78,10 @@ module type S = sig
     from -> string -> string ->
     (operation list * LiquidTypes.const * big_map_diff option * trace) t
 
+(** compute the initial storage for a specific script
+      ![LiquidOptions], returns storage data *)
+  val init_storage : from -> string list -> LiquidTypes.const t
+
   (** Forge a deployment operation contract on the Tezos node specified in
       ![LiquidOptions], returns the hex-encoded operation *)
   val forge_deploy :

--- a/tools/liquidity/liquidMain.ml
+++ b/tools/liquidity/liquidMain.ml
@@ -250,6 +250,17 @@ module Data = struct
     Printf.eprintf "Raw operation:\n--------------\n%!";
     Printf.printf "%s\n%!" op
 
+  let init_storage () =
+    let storage =
+      LiquidDeploy.Sync.init_storage
+        (LiquidDeploy.From_file !contract) (List.rev !init_inputs)
+    in
+    Printf.eprintf "Initial storage:\n--------------\n%!";
+    if !LiquidOptions.json then
+      Printf.printf "%s\n%!" LiquidToTezos.(json_of_const @@ convert_const storage)
+    else
+      Printf.printf "%s\n%!" (LiquidData.string_of_const storage)
+
   let deploy () =
     match
       LiquidDeploy.Sync.deploy
@@ -378,6 +389,16 @@ let main () =
 
       "--spendable", Arg.Set LiquidOptions.spendable,
       " With --[forge-]deploy, deploy a spendable contract";
+
+      "--init-storage", Arg.Tuple [
+        Arg.String (fun s -> Data.contract := s);
+        Arg.Rest Data.register_deploy_input;
+        Arg.Unit (fun () ->
+            work_done := true;
+            Data.init_storage ());
+      ],
+      "FILE.liq INPUT1 INPUT2 ... Forge deployment operation for contract";
+
 
       "--forge-deploy", Arg.Tuple [
         Arg.String (fun s -> Data.contract := s);

--- a/tools/liquidity/without-tezos/liquidDeploy.ml
+++ b/tools/liquidity/without-tezos/liquidDeploy.ml
@@ -73,6 +73,8 @@ module type S = sig
     (operation list * LiquidTypes.const * big_map_diff option) t
   val run_debug : from -> string -> string ->
     (operation list * LiquidTypes.const * big_map_diff option * trace) t
+  val init_storage :
+    from -> string list -> LiquidTypes.const t
   val forge_deploy : ?delegatable:bool -> ?spendable:bool ->
     from -> string list -> string t
   val deploy : ?delegatable:bool -> ?spendable:bool ->
@@ -90,6 +92,9 @@ module Dummy = struct
 
   let run_debug _ _ _ =
     failwith "mini version cannot run debug"
+
+  let init_storage _ _ =
+    failwith "mini version cannot deploy"
 
   let forge_deploy ?(delegatable=false) ?(spendable=false) _ _ =
     failwith "mini version cannot deploy"


### PR DESCRIPTION
This adds two features to the liquidity command:
  - a command --init-storage which computes the initial storage for the given parameters. The command prints the storage in json or liquidity format
  - the ability for the --data command to prints its output in json format
  - the storage argument for the --data command is made optional. This allows to check or translate the parameter of the smart contract easily.
