### PR TITLE
Install fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean: _obuild clean-tests clean-sources
 
 build-deps:
 	opam install ocp-build ocplib-endian zarith calendar digestif hex ocurl lwt \
-	       lwt_log uri sodium bigstring ezjsonm
+	       lwt_log uri sodium bigstring ezjsonm pandoc
 
 distclean: clean
 	rm -rf _obuild

--- a/docs/sphinx/src/installation/index.rst
+++ b/docs/sphinx/src/installation/index.rst
@@ -37,6 +37,7 @@ As of Aug 15, 2018, the following process should work:
 4. Install Liquidity dependencies::
 
      make build-deps
+     eval `opam env`
 
 5. Build and install::
 


### PR DESCRIPTION
Hi 😄

Just completed install process and hit a few minor snags I wanted to help correct.

First run of make:

```
❯ make
ocp-build init
make: ocp-build: No such file or directory
make: *** [_obuild] Error 1
```

Fixed with an additional `eval (opam env)` post `build-dep` installation.

Second run of make:

```
Error:
[34.1] 'pandoc' '-o' './liquidity.html' 'liquidity.md'

Error while executing subprocess
  exception Unix_error(No such file or directory, execvp, pandoc)
```

Fixed with adding `pandoc` to list of deps.

Hope this will help others avoid these issues and have an even smoother onboarding 👍