### PR TITLE
Account.transfer with key_hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ doc:
 NTESTS=42
 NREVTESTS=9
 SIMPLE_TESTS= `seq -f 'test%.0f' 0 $(NTESTS)`
-MORE_TESTS=test_ifcons test_if test_loop test_option test_transfer test_left \
+MORE_TESTS=test_ifcons test_if test_loop test_option test_transfer test_call test_left \
   test_extfun test_left_constr test_closure test_closure2 test_closure3 \
   test_map test_rev test_reduce_closure test_map_closure test_mapreduce_closure \
   test_mapmap_closure test_setreduce_closure test_left_match test_loop_left \

--- a/docs/sphinx/src/reference/liquidity.rst
+++ b/docs/sphinx/src/reference/liquidity.rst
@@ -54,8 +54,7 @@ be given a unique name within the same contract.
 
 If there is an entry point named ``main``, it will be the default
 entry point for the contract, *i.e.* the one that is called when the
-entry point is not specified in ``Contract.call`` and
-``Contract.transfer``.
+entry point is not specified in ``Contract.call``.
 
 An entry point always returns a pair ``(operations, storage)``, where
 ``operations`` is a list of internal operations to perform after
@@ -492,8 +491,8 @@ Operations on numeric values
 Operations on contracts
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-* ``Contract.call: ~dest:'S.instance -> ~amount:tez ->
-  ?entry:<entry_name> ~parameter:'a -> operation``. Forge an internal
+* ``Contract.call: dest:'S.instance -> amount:tez ->
+  ?entry:<entry_name> parameter:'a -> operation``. Forge an internal
   contract call. It is translated to ``TRANSFER_TOKENS`` in Michelson.
   Arguments can be labeled, in which case they can be given
   in any order. The entry point name is optional (``main`` by default).
@@ -505,21 +504,26 @@ Operations on contracts
     ...
     ([op], storage)
 
-* ``Contract.transfer: ~dest:'S.instance -> ~amount:tez ->
-  operation``. Forge an internal transaction. It is translated to
-  ``TRANSFER_TOKENS`` in Michelson.  Arguments can be labeled, in
-  which case they can be given in any order.
-
-  ``Contract.transfer ~dest:c ~amount:a`` is syntactic sugar for
-  ``Contract.call ~dest:c ~entry:main ~parameter:() ~amount:a``.
-
-* ``<c.entry>: 'parameter -> ~amount:tez -> operation``. Forge an
+* ``<c.entry>: 'parameter -> amount:tez -> operation``. Forge an
   internal contract call. It is translated to ``TRANSFER_TOKENS`` in
   Michelson.  The amount argument can be labeled, in which case it can
   appear before the parameter.
 
   ``c.my_entry p ~amount:a`` is syntactic sugar for
   ``Contract.call ~dest:c ~entry:my_entry ~parameter:p ~amount:a``.
+
+* ``Account.transfer: dest:key_hash -> amount:tez ->
+  operation``. Forge an internal transaction to the implicit (_i.e._
+  default) account contract of ``dest``. Arguments can be labeled, in
+  which case they can be given in any order. *The resulting operation
+  cannot fail.*
+
+  Example::
+
+    let op =
+      Account.transfer ~dest:tz1YLtLqD1fWHthSVHPD116oYvsd4PTAHUoc ~amount:1tz in
+    ...
+    ([op], storage)
 
 * ``Account.create: manager:key_hash -> delegate:key_hash option ->
   delegatable:bool -> amount:tez -> operation * address``. Forge an
@@ -1258,15 +1262,13 @@ Contracts can also be used as first class values::
     ~storage:0
     (contract C)
 
-**Instances** of contracts can be called with four different syntaxes:
+**Instances** of contracts can be called with three different syntaxes:
 
-- ``Contract.transfer c 1tz``
 - ``Contract.call ~dest:c ~amount:1tz ~parameter:"hello"``
 - ``Contract.call ~dest:c ~amount:1tz ~entry:main ~parameter:"hello"``
 - ``c.main "hello" ~amount:1tz``
 
-The last three ones are equivalent, while the first one is simply
-syntactic sugar for ``c.main () ~amount:1tz``.
+These calls are all equivalent.
 
 Toplevel Contracts
 ~~~~~~~~~~~~~~~~~~

--- a/docs/sphinx/src/tutorial/game.rst
+++ b/docs/sphinx/src/tutorial/game.rst
@@ -103,7 +103,8 @@ A game consists in three values, stored in a record:
 #. ``bet`` is the amount that was sent with the first transaction by
    the player. It constitute the bet amount.
 #. ``player`` is the key hash (tz1...) on which the player who made
-   the bet wishes to be payed in the event of a win.
+   the bet wishes to be payed in the event of a win (we ask for a
+   ``key_hash`` so that the payout operation cannot fail).
 
 We also give an initializer function that can be used to deploy the
 contract with an initial value. It takes as argument the address of
@@ -244,8 +245,7 @@ the smart contract.
           | None -> 0tz
           | Some (g, _) -> g in
         let reimbursed = game.bet + gain in
-        let dest = Account.default game.player in
-        [ Contract.transfer ~dest ~amount:reimbursed ]
+        [ Account.transfer ~dest:game.player ~amount:reimbursed ]
 
 Otherwise, if the random number is greater or equal to the previously
 chosen number, then the player won. We compute her gain and the

--- a/tests/others/game.liq
+++ b/tests/others/game.liq
@@ -1,4 +1,4 @@
-[%%version 0.402]
+[%%version 0.403]
 
 type game = {
   number : nat;
@@ -49,8 +49,7 @@ let%entry finish (random_number : nat) storage =
           | None -> 0tz
           | Some (g, _) -> g in
         let reimbursed = game.bet + gain in
-        let dest = Account.default game.player in
-        [ Contract.transfer ~dest ~amount:reimbursed ]
+        [ Account.transfer ~dest:game.player ~amount:reimbursed ]
     in
     let storage = storage.game <- (None : game option) in
     (ops, storage)

--- a/tests/test24.liq
+++ b/tests/test24.liq
@@ -22,7 +22,7 @@ let%entry main
   match m with
   | A _ ->
     let amount = 0tz in
-    let op = Contract.transfer ~dest:c ~amount in
+    let op = Contract.call ~dest:c ~entry:main ~amount () in
     [op], storage
   | B ->
     let op = Contract.call c 0tz main ~parameter:() in

--- a/tests/test_call.liq
+++ b/tests/test_call.liq
@@ -1,0 +1,16 @@
+
+(* transfers *)
+
+[%%version 0.4]
+
+type storage = tez
+
+let%entry main
+      (parameter : UnitContract.instance)
+      (storage : tez) =
+
+      let amount = Current.amount () in
+      let storage = storage + amount in
+      let op = Contract.call parameter amount () in
+
+      ( [op], storage )

--- a/tests/test_transfer.liq
+++ b/tests/test_transfer.liq
@@ -1,16 +1,16 @@
 
 (* transfers *)
 
-[%%version 0.4]
+[%%version 0.403]
 
 type storage = tez
 
 let%entry main
-      (parameter : UnitContract.instance)
+      (dest : key_hash)
       (storage : tez) =
 
-      let amount = Current.amount () in
-      let storage = storage + amount in
-      let op = Contract.call parameter amount () in
+      let storage = storage + Current.amount () in
+      let amount = storage in
+      let op = Account.transfer dest amount in
 
       ( [op], storage )

--- a/tools/liquidity/liquidData.ml
+++ b/tools/liquidity/liquidData.ml
@@ -127,6 +127,7 @@ let rec translate_const_exp (exp : encoded_exp) =
   | If _
   | Seq _
   | Transfer _
+  | Call _
   | MatchOption _
   | MatchNat _
   | MatchList _

--- a/tools/liquidity/liquidDecode.ml
+++ b/tools/liquidity/liquidDecode.ml
@@ -45,17 +45,23 @@ let rec decode ( exp : encoded_exp ) : typed_exp =
     let ifelse = decode ifelse in
     mk ?name:exp.name ~loc (If { cond; ifthen; ifelse }) exp.ty
 
-  | Transfer { contract; amount; entry; arg } ->
+  | Transfer { dest; amount } ->
+    let dest = decode dest in
+    let amount = decode amount in
+    let desc = Transfer { dest; amount } in
+    mk ?name:exp.name ~loc desc exp.ty
+
+  | Call { contract; amount; entry; arg } ->
     let amount = decode amount in
     let contract = decode contract in
     let desc = match entry, arg.desc with
       | None, Constructor { constr = Constr c; arg } when is_entry_case c ->
         let entry = Some (entry_name_of_case c) in
         let arg = decode arg in
-        Transfer { contract; amount; entry; arg }
+        Call { contract; amount; entry; arg }
       | _, _ ->
         let arg = decode arg in
-        Transfer { contract; amount; entry; arg }
+        Call { contract; amount; entry; arg }
     in
     mk ?name:exp.name ~loc desc exp.ty
 

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -602,16 +602,21 @@ let rec decompile contract =
         mklet node desc
       | N_LAMBDA_END _, [arg] -> arg_of arg
 
-      | N_TRANSFER, [contract; amount; arg] ->
+      | N_TRANSFER, [dest; amount] ->
+        mklet node
+          (Transfer { dest = arg_of dest;
+                      amount = arg_of amount })
+
+      | N_CALL, [contract; amount; arg] ->
         let entry, arg = match arg.kind, arg.args with
           | N_CONSTR c, [arg] when is_entry_case c ->
             Some (entry_name_of_case c), arg
           | _ -> None, arg in
         mklet node
-          (Transfer { contract = arg_of contract;
-                      amount = arg_of amount;
-                      entry;
-                      arg = arg_of arg })
+          (Call { contract = arg_of contract;
+                  amount = arg_of amount;
+                  entry;
+                  arg = arg_of arg })
       (* TODO *)
 
       | N_CREATE_CONTRACT contract, args ->
@@ -630,6 +635,7 @@ let rec decompile contract =
         N_LAMBDA_END _
       | N_LAMBDA _
       | N_TRANSFER
+      | N_CALL
       | N_LOOP _
       | N_LOOP_LEFT _
       | N_FOLD _

--- a/tools/liquidity/liquidDot.ml
+++ b/tools/liquidity/liquidDot.ml
@@ -87,6 +87,7 @@ let rec to_dot ~sub_contract_of contract =
         | N_RIGHT _
         | N_ABS
         | N_TRANSFER
+        | N_CALL
         | N_CONTRACT _
         | N_UNPACK _
         | N_PROJ _

--- a/tools/liquidity/liquidInit.ml
+++ b/tools/liquidity/liquidInit.ml
@@ -34,8 +34,9 @@ let rec subst_empty_big_map storage_ty code =
       LiquidLoc.raise_error ~loc
         "Only use empty big map constants in storage initializer"
     | Const _ -> desc
-    | Transfer _ -> assert false
     | Var _ -> desc
+
+    | Transfer _ | Call _ -> assert false
 
     | Failwith arg ->
       let arg' = subst_empty_big_map storage_ty arg in

--- a/tools/liquidity/liquidInterp.ml
+++ b/tools/liquidity/liquidInterp.ml
@@ -748,8 +748,14 @@ let rec interp contract =
       let x = node ins.loc N_FAILWITH [arg] [seq] in
       [x], x
 
+    | TRANSFER_TOKENS,
+      { kind = N_CONST (Tunit, CUnit) } :: amount ::
+      { kind = N_PRIM "IMPLICIT_ACCOUNT"; args = [ key ] } :: stack ->
+      let x = node ins.loc N_TRANSFER [ key; amount ] [seq] in
+      x :: stack, x
+
     | TRANSFER_TOKENS, arg :: amount :: contract :: stack ->
-      let x = node ins.loc N_TRANSFER [contract; amount; arg] [seq] in
+      let x = node ins.loc N_CALL [contract; amount; arg] [seq] in
       x :: stack, x
 
     | SOURCE, stack ->

--- a/tools/liquidity/liquidMichelson.ml
+++ b/tools/liquidity/liquidMichelson.ml
@@ -203,10 +203,18 @@ let rec translate_code ~parameter_name ~storage_name code =
       let loc = loc_of_many cond in
       cond @ [ ii ~loc @@ IF (seq ifthen, seq ifelse)]
 
-    | Transfer { entry = Some _ } ->
+    | Transfer { dest; amount } ->
+      (* Contract.transfer compiled to IMPLICIT_ACCOUNT + TRANSFER_TOKENS *)
+      let dest = compile depth env dest in
+      let amount = compile (depth+1) env amount in
+      dest @ [ ii ~loc IMPLICIT_ACCOUNT ] @
+      amount @
+      [ push ~loc Tunit CUnit; ii ~loc TRANSFER_TOKENS ]
+
+    | Call { entry = Some _ } ->
       assert false (* should have been encoded *)
 
-    | Transfer { contract; amount; entry = None; arg } ->
+    | Call { contract; amount; entry = None; arg } ->
       (* Contract.call (encoded) compiled to TRANSFER_TOKENS *)
       let contract = compile depth env contract in
       let amount = compile (depth+1) env amount in

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -1085,14 +1085,20 @@ module Liquid = struct
       bprint_code_rec ~debug b indent exp1;
       Printf.bprintf b ";";
       bprint_code_rec ~debug b indent exp2
-    | Transfer { contract; amount; entry = None; arg } ->
+    | Transfer { dest; amount } ->
+      Printf.bprintf b "\n%s(Account.transfer" indent;
+      let indent2 = indent ^ "  " in
+      bprint_code_rec ~debug b indent2 dest;
+      bprint_code_rec ~debug b indent2 amount;
+      Printf.bprintf b ")"
+    | Call { contract; amount; entry = None; arg } ->
       Printf.bprintf b "\n%s(Contract.call" indent;
       let indent2 = indent ^ "  " in
       bprint_code_rec ~debug b indent2 contract;
       bprint_code_rec ~debug b indent2 amount;
       bprint_code_rec ~debug b indent2 arg;
       Printf.bprintf b ")"
-    | Transfer { contract; amount; entry = Some entry; arg } ->
+    | Call { contract; amount; entry = Some entry; arg } ->
       Printf.bprintf b "\n%s(" indent;
       bprint_code_rec ~debug b indent contract;
       Printf.bprintf b ".%s" entry;
@@ -1346,6 +1352,7 @@ let string_of_node node =
   | N_IF_PLUS _ -> "N_IF_PLUS"
   | N_IF_MINUS _ -> "N_IF_MINUS"
   | N_TRANSFER -> "N_TRANSFER"
+  | N_CALL -> "N_CALL"
   | N_CONST (ty, cst) -> "N_CONST " ^ Liquid.string_of_const cst
   | N_PRIM string ->
     Printf.sprintf "N_PRIM %s" string

--- a/tools/liquidity/liquidSimplify.ml
+++ b/tools/liquidity/liquidSimplify.ml
@@ -45,8 +45,10 @@ let rec compute decompile code to_inline =
     | Map { arg; body } -> 30 + size arg + size body
     | Fold { body; arg; acc }
     | MapFold { body; arg; acc } -> 30 + size body + size arg + size acc
-    | Transfer { contract; amount; arg } ->
+    | Call { contract; amount; arg } ->
       1 + size contract + size amount + size arg
+    | Transfer { dest; amount } ->
+      1 + size dest + size amount
 
     | Apply { args } ->
       List.fold_left (fun acc e -> acc + size e) 1 args
@@ -235,11 +237,16 @@ let rec compute decompile code to_inline =
       let args = List.map iter args in
       { exp with desc = Apply { prim; args } }
 
-    | Transfer { contract; amount; entry; arg } ->
+    | Transfer { dest; amount } ->
+      let dest = iter dest in
+      let amount = iter amount in
+      { exp with desc = Transfer { dest; amount } }
+
+    | Call { contract; amount; entry; arg } ->
       let contract = iter contract in
       let amount = iter amount in
       let arg = iter arg in
-      { exp with desc = Transfer { contract; amount; entry; arg } }
+      { exp with desc = Call { contract; amount; entry; arg } }
 
     | Lambda { arg_name; arg_ty; body; ret_ty; recursive } ->
       let body = iter body in

--- a/tools/liquidity/liquidToOCaml.ml
+++ b/tools/liquidity/liquidToOCaml.ml
@@ -8,7 +8,7 @@
 (**************************************************************************)
 
 (* The version that will be required to compile the generated files. *)
-let output_version = "0.402"
+let output_version = "0.403"
 
 open Asttypes
 open Longident
@@ -422,15 +422,14 @@ let rec convert_code ~abbrev (expr : (datatype, 'a) exp) =
           (convert_code ~abbrev ifcons);
       ]
 
-  | Transfer { contract; amount; entry = None;
-               arg = { desc = Const { const = CUnit }} } ->
-    Exp.apply ~loc (Exp.ident (lid "Contract.transfer"))
+  | Transfer { dest; amount } ->
+    Exp.apply ~loc (Exp.ident (lid "Account.transfer"))
       [
-        Labelled "dest", convert_code ~abbrev contract;
+        Labelled "dest", convert_code ~abbrev dest;
         Labelled "amount", convert_code ~abbrev amount;
       ]
 
-  | Transfer { contract; amount; entry = None; arg } ->
+  | Call { contract; amount; entry = None; arg } ->
     Exp.apply ~loc (Exp.ident (lid "Contract.call"))
       [
         Labelled "dest", convert_code ~abbrev contract;
@@ -438,7 +437,7 @@ let rec convert_code ~abbrev (expr : (datatype, 'a) exp) =
         Labelled "parameter", convert_code ~abbrev arg;
       ]
 
-  | Transfer { contract; amount; entry = Some entry; arg } ->
+  | Call { contract; amount; entry = Some entry; arg } ->
     let contract_exp = convert_code ~abbrev contract in
     Exp.apply ~loc
       (Exp.field contract_exp (lid entry))

--- a/tools/liquidity/liquidUntype.ml
+++ b/tools/liquidity/liquidUntype.ml
@@ -205,11 +205,15 @@ let rec untype (env : env) (code : (datatype, 'a) exp) : (datatype, 'b) exp =
       let ifcons = untype env ifcons in
       MatchList { arg; head_name; tail_name; ifcons; ifnil }
 
-    | Transfer { contract; amount; entry; arg } ->
-      Transfer { contract = untype env contract;
-                 amount = untype env amount;
-                 entry;
-                 arg = untype env arg }
+    | Transfer { dest; amount } ->
+      Transfer { dest = untype env dest;
+                 amount = untype env amount }
+
+    | Call { contract; amount; entry; arg } ->
+      Call { contract = untype env contract;
+             amount = untype env amount;
+             entry;
+             arg = untype env arg }
 
     | MatchVariant { arg; cases } ->
       let arg = untype env arg in


### PR DESCRIPTION
```ocaml
Account.transfer : dest:key_hash -> amount:tez -> operation
```

This new built-in function replaces `Contract.transfer`.
This makes it clear whether a call is susceptible to code execution or
not. An operation resulting from `Account.transfer` cannot fail.

`Contract.call` is unchanged.