### PR TITLE
basic support for ReasonML syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean: _obuild clean-tests clean-sources
 
 build-deps:
 	opam install ocp-build ocplib-endian zarith calendar digestif.0.7 hex ocurl lwt \
-	       lwt_log uri sodium bigstring ezjsonm
+	       lwt_log uri sodium bigstring ezjsonm menhir
 
 distclean: clean
 	rm -rf _obuild

--- a/tools/liquidity/build.ocp2
+++ b/tools/liquidity/build.ocp2
@@ -78,6 +78,21 @@ OCaml.library("ocplib-liquidity-base",
 OCaml.library("ocplib-liquidity-ocaml",
    ocaml + {
      files = [
+       "reason/reason_string.ml";
+       "reason/reason_attributes.ml";
+       "reason/reason_syntax_util.mli";
+       "reason/reason_syntax_util.ml";
+       "reason/reason_config.ml";
+       "reason/reason_parser.mly", { ocamlyacc= [ "menhir"; "--table"] };
+       "reason/reason_comment.ml";
+       "reason/lexer_warning.ml";
+       "reason/reason_lexer.mll";
+       "reason/reason_location.ml";
+       "reason/reason_layout.ml";
+       "reason/reason_heuristics.ml";
+       "reason/reason_pprint_ast.ml"; 
+       "reason/reason_toolchain.ml";
+
        "ocaml/liquidOCamlParser.mly";
        "ocaml/liquidOCamlLexer.mll";
        "ocaml/liquidOCamlParse.ml";
@@ -88,12 +103,19 @@ OCaml.library("ocplib-liquidity-ocaml",
        "liquidData.ml";
      ];
      requires = [
+        "easy-format";
+        "ocaml-migrate-parsetree";
+        "menhirLib";
+        
         "ocplib-liquidity-base";
         "compiler-libs.common";
         "compiler-libs.bytecomp";
      ];
 
    });
+
+
+
 
 if ( with_tezos ) {
 OCaml.library("ocplib-liquidity-with-tezos",

--- a/tools/liquidity/liquidFromOCaml.ml
+++ b/tools/liquidity/liquidFromOCaml.ml
@@ -345,6 +345,9 @@ let rec translate_type env ?expected typ =
     Tlambda (translate_type env (* ?expected:expected *) parameter_type,
              translate_type env return_type)
 
+  | { ptyp_desc = Ptyp_tuple [ty] } ->
+    translate_type env ?expected ty
+
   | { ptyp_desc = Ptyp_tuple types } ->
     let expecteds = match expected with
       | Some (Ttuple tys) when List.length types = List.length tys ->
@@ -486,6 +489,9 @@ let rec translate_const env exp =
 
   | { pexp_desc = Pexp_constant (Pconst_string (s, None)) } ->
     CString s, Some Tstring
+
+  | { pexp_desc = Pexp_tuple [exp] } ->
+    translate_const env exp
 
   | { pexp_desc = Pexp_tuple exps } ->
     let csts, tys = List.split (List.map (translate_const env) exps) in
@@ -703,6 +709,7 @@ let rec translate_const env exp =
 
 and translate_list exp =
   match exp.pexp_desc with
+  | Pexp_tuple [exp] -> translate_list exp
   | Pexp_construct({ txt = Lident "[]" }, None) -> []
 
   | Pexp_construct({ txt = Lident "::" },
@@ -713,6 +720,7 @@ and translate_list exp =
 
 and translate_pair exp =
   match exp.pexp_desc with
+  | Pexp_tuple [exp] -> translate_pair exp
   | Pexp_tuple [e1; e2] -> (e1, e2)
   | _ -> error_loc exp.pexp_loc "pair expected"
 
@@ -736,6 +744,9 @@ let vars_info_pat env pat =
     | { ppat_desc = Ppat_construct ({ txt = Lident "()" }, None); ppat_loc } ->
       ("_", loc_of_loc ppat_loc, indexes) :: acc,
       Tunit
+
+    | { ppat_desc = Ppat_tuple [pat] } ->
+      vars_info_pat_aux acc indexes pat
 
     | { ppat_desc = Ppat_tuple pats } ->
       let _, acc, tys =
@@ -1580,6 +1591,9 @@ let rec translate_code contracts env exp =
                           | Some arg -> translate_code contracts env arg }
 
         (* TODO *)
+        | { pexp_desc = Pexp_tuple [exp] } ->
+          (translate_code contracts env exp).desc
+
         | { pexp_desc = Pexp_tuple exps } ->
           let exps = List.map (translate_code contracts env) exps in
           begin

--- a/tools/liquidity/liquidMain.ml
+++ b/tools/liquidity/liquidMain.ml
@@ -261,19 +261,22 @@ let compile_files () =
     List.partition (fun filename ->
         Filename.check_suffix filename ".tz" ||
         Filename.check_suffix filename ".json") others in
-  match liq_files, tz_files, unknown with
-  | _, _, _ :: _ ->
+  match unknown with
+    [] ->
+    begin match liq_files, tz_files with
+      | [], [] ->
+        Format.eprintf "No files given as arguments@.";
+        raise Bad_arg
+      | [], _ ->
+        compile_tezos_files tz_files
+      | _, _ ->
+        compile_liquid_files liq_files;
+        compile_tezos_files tz_files
+    end
+  | _ ->
     Format.eprintf "Error: unknown extension for files: %a@."
       (Format.pp_print_list Format.pp_print_string) unknown;
     exit 2
-  | [], [], _ ->
-    Format.eprintf "No files given as arguments@.";
-    raise Bad_arg
-  | [], _, _ ->
-    compile_tezos_files tz_files
-  | _, _, _ ->
-    compile_liquid_files liq_files;
-    compile_tezos_files tz_files
 
 let translate () =
   let files = Data.get_files () in
@@ -467,11 +470,32 @@ let parse_tez_to_string expl amount =
   | _ -> assert false
 
 
+let convert_file filename =
+  if not (Filename.check_suffix filename ".liq") then
+    Printf.kprintf
+      failwith "Error: don't know what to do with filename %S" filename;
+
+  let syntax = !LiquidOptions.ocaml_syntax in
+  let ic = open_in filename in
+  let lexbuf = Lexing.from_channel ic in
+  let str = LiquidOCamlParse.implementation lexbuf in
+
+  LiquidOptions.ocaml_syntax := not syntax;
+  let s = LiquidOCamlPrinter.string_of_structure str in
+  LiquidOptions.ocaml_syntax := syntax;
+  Printf.printf "%s%!" s;
+  ()
+
 let main () =
   let work_done = ref false in
   let arg_list = Arg.align [
       "--verbose", Arg.Unit (fun () -> incr LiquidOptions.verbosity),
       " Increment verbosity";
+
+      "--re", Arg.Clear LiquidOptions.ocaml_syntax, " Use ReasonML syntax";
+      "--convert", Arg.String (fun s ->
+          convert_file s;
+          work_done := true), " Switch between OCaml and ReasonML syntax (stdout)";
 
       "--version", Arg.Unit (fun () ->
           Format.printf "%s@." LiquidToOCaml.output_version;

--- a/tools/liquidity/liquidOptions.ml
+++ b/tools/liquidity/liquidOptions.ml
@@ -97,3 +97,5 @@ let protocol = ref (None : proto option)
 
 let main_id = "NetXdQprcVkpaWU"
 let zeronet_id = "NetXSzLHKwSumh7"
+
+let ocaml_syntax = ref true

--- a/tools/liquidity/ocaml/liquidOCamlLexer.mll-orig
+++ b/tools/liquidity/ocaml/liquidOCamlLexer.mll-orig
@@ -1,0 +1,793 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* The lexer definition *)
+
+{
+open Lexing
+open Misc
+open Parser
+
+type error =
+  | Illegal_character of char
+  | Illegal_escape of string
+  | Unterminated_comment of Location.t
+  | Unterminated_string
+  | Unterminated_string_in_comment of Location.t * Location.t
+  | Keyword_as_label of string
+  | Invalid_literal of string
+  | Invalid_directive of string * string option
+;;
+
+exception Error of error * Location.t;;
+
+(* The table of keywords *)
+
+let keyword_table =
+  create_hashtable 149 [
+    "and", AND;
+    "as", AS;
+    "assert", ASSERT;
+    "begin", BEGIN;
+    "class", CLASS;
+    "constraint", CONSTRAINT;
+    "do", DO;
+    "done", DONE;
+    "downto", DOWNTO;
+    "else", ELSE;
+    "end", END;
+    "exception", EXCEPTION;
+    "external", EXTERNAL;
+    "false", FALSE;
+    "for", FOR;
+    "fun", FUN;
+    "function", FUNCTION;
+    "functor", FUNCTOR;
+    "if", IF;
+    "in", IN;
+    "include", INCLUDE;
+    "inherit", INHERIT;
+    "initializer", INITIALIZER;
+    "lazy", LAZY;
+    "let", LET;
+    "match", MATCH;
+    "method", METHOD;
+    "module", MODULE;
+    "mutable", MUTABLE;
+    "new", NEW;
+    "nonrec", NONREC;
+    "object", OBJECT;
+    "of", OF;
+    "open", OPEN;
+    "or", OR;
+(*  "parser", PARSER; *)
+    "private", PRIVATE;
+    "rec", REC;
+    "sig", SIG;
+    "struct", STRUCT;
+    "then", THEN;
+    "to", TO;
+    "true", TRUE;
+    "try", TRY;
+    "type", TYPE;
+    "val", VAL;
+    "virtual", VIRTUAL;
+    "when", WHEN;
+    "while", WHILE;
+    "with", WITH;
+
+    "lor", INFIXOP3("lor"); (* Should be INFIXOP2 *)
+    "lxor", INFIXOP3("lxor"); (* Should be INFIXOP2 *)
+    "mod", INFIXOP3("mod");
+    "land", INFIXOP3("land");
+    "lsl", INFIXOP4("lsl");
+    "lsr", INFIXOP4("lsr");
+    "asr", INFIXOP4("asr")
+]
+
+(* To buffer string literals *)
+
+let initial_string_buffer = Bytes.create 256
+let string_buff = ref initial_string_buffer
+let string_index = ref 0
+
+let reset_string_buffer () =
+  string_buff := initial_string_buffer;
+  string_index := 0
+
+let store_string_char c =
+  if !string_index >= Bytes.length !string_buff then begin
+    let new_buff = Bytes.create (Bytes.length (!string_buff) * 2) in
+    Bytes.blit !string_buff 0 new_buff 0 (Bytes.length !string_buff);
+    string_buff := new_buff
+  end;
+  Bytes.unsafe_set !string_buff !string_index c;
+  incr string_index
+
+let store_string s =
+  for i = 0 to String.length s - 1 do
+    store_string_char s.[i];
+  done
+
+let store_lexeme lexbuf =
+  store_string (Lexing.lexeme lexbuf)
+
+let get_stored_string () =
+  let s = Bytes.sub_string !string_buff 0 !string_index in
+  string_buff := initial_string_buffer;
+  s
+
+(* To store the position of the beginning of a string and comment *)
+let string_start_loc = ref Location.none;;
+let comment_start_loc = ref [];;
+let in_comment () = !comment_start_loc <> [];;
+let is_in_string = ref false
+let in_string () = !is_in_string
+let print_warnings = ref true
+
+(* Escaped chars are interpreted in strings unless they are in comments. *)
+let store_escaped_char lexbuf c =
+  if in_comment () then store_lexeme lexbuf else store_string_char c
+
+let with_comment_buffer comment lexbuf =
+  let start_loc = Location.curr lexbuf  in
+  comment_start_loc := [start_loc];
+  reset_string_buffer ();
+  let end_loc = comment lexbuf in
+  let s = get_stored_string () in
+  reset_string_buffer ();
+  let loc = { start_loc with Location.loc_end = end_loc.Location.loc_end } in
+  s, loc
+
+(* To translate escape sequences *)
+
+let char_for_backslash = function
+  | 'n' -> '\010'
+  | 'r' -> '\013'
+  | 'b' -> '\008'
+  | 't' -> '\009'
+  | c   -> c
+
+let char_for_decimal_code lexbuf i =
+  let c = 100 * (Char.code(Lexing.lexeme_char lexbuf i) - 48) +
+           10 * (Char.code(Lexing.lexeme_char lexbuf (i+1)) - 48) +
+                (Char.code(Lexing.lexeme_char lexbuf (i+2)) - 48) in
+  if (c < 0 || c > 255) then
+    if in_comment ()
+    then 'x'
+    else raise (Error(Illegal_escape (Lexing.lexeme lexbuf),
+                      Location.curr lexbuf))
+  else Char.chr c
+
+let char_for_octal_code lexbuf i =
+  let c = 64 * (Char.code(Lexing.lexeme_char lexbuf i) - 48) +
+           8 * (Char.code(Lexing.lexeme_char lexbuf (i+1)) - 48) +
+               (Char.code(Lexing.lexeme_char lexbuf (i+2)) - 48) in
+  Char.chr c
+
+let char_for_hexadecimal_code lexbuf i =
+  let d1 = Char.code (Lexing.lexeme_char lexbuf i) in
+  let val1 = if d1 >= 97 then d1 - 87
+             else if d1 >= 65 then d1 - 55
+             else d1 - 48
+  in
+  let d2 = Char.code (Lexing.lexeme_char lexbuf (i+1)) in
+  let val2 = if d2 >= 97 then d2 - 87
+             else if d2 >= 65 then d2 - 55
+             else d2 - 48
+  in
+  Char.chr (val1 * 16 + val2)
+
+(* recover the name from a LABEL or OPTLABEL token *)
+
+let get_label_name lexbuf =
+  let s = Lexing.lexeme lexbuf in
+  let name = String.sub s 1 (String.length s - 2) in
+  if Hashtbl.mem keyword_table name then
+    raise (Error(Keyword_as_label name, Location.curr lexbuf));
+  name
+;;
+
+(* Update the current location with file name and line number. *)
+
+let update_loc lexbuf file line absolute chars =
+  let pos = lexbuf.lex_curr_p in
+  let new_file = match file with
+                 | None -> pos.pos_fname
+                 | Some s -> s
+  in
+  lexbuf.lex_curr_p <- { pos with
+    pos_fname = new_file;
+    pos_lnum = if absolute then line else pos.pos_lnum + line;
+    pos_bol = pos.pos_cnum - chars;
+  }
+;;
+
+let preprocessor = ref None
+
+let escaped_newlines = ref false
+
+(* Warn about Latin-1 characters used in idents *)
+
+let warn_latin1 lexbuf =
+  Location.prerr_warning (Location.curr lexbuf)
+    (Warnings.Deprecated "ISO-Latin1 characters in identifiers")
+;;
+
+let handle_docstrings = ref true
+let comment_list = ref []
+
+let add_comment com =
+  comment_list := com :: !comment_list
+
+let add_docstring_comment ds =
+  let com =
+    ("*" ^ Docstrings.docstring_body ds, Docstrings.docstring_loc ds)
+  in
+    add_comment com
+
+let comments () = List.rev !comment_list
+
+(* Error report *)
+
+open Format
+
+let report_error ppf = function
+  | Illegal_character c ->
+      fprintf ppf "Illegal character (%s)" (Char.escaped c)
+  | Illegal_escape s ->
+      fprintf ppf "Illegal backslash escape in string or character (%s)" s
+  | Unterminated_comment _ ->
+      fprintf ppf "Comment not terminated"
+  | Unterminated_string ->
+      fprintf ppf "String literal not terminated"
+  | Unterminated_string_in_comment (_, loc) ->
+      fprintf ppf "This comment contains an unterminated string literal@.\
+                   %aString literal begins here"
+              Location.print_error loc
+  | Keyword_as_label kwd ->
+      fprintf ppf "`%s' is a keyword, it cannot be used as label name" kwd
+  | Invalid_literal s ->
+      fprintf ppf "Invalid literal %s" s
+  | Invalid_directive (dir, explanation) ->
+      fprintf ppf "Invalid lexer directive %S" dir;
+      begin match explanation with
+        | None -> ()
+        | Some expl -> fprintf ppf ": %s" expl
+      end
+
+let () =
+  Location.register_error_of_exn
+    (function
+      | Error (err, loc) ->
+          Some (Location.error_of_printer loc report_error err)
+      | _ ->
+          None
+    )
+
+}
+
+let newline = ('\013'* '\010')
+let blank = [' ' '\009' '\012']
+let lowercase = ['a'-'z' '_']
+let uppercase = ['A'-'Z']
+let identchar = ['A'-'Z' 'a'-'z' '_' '\'' '0'-'9']
+let lowercase_latin1 = ['a'-'z' '\223'-'\246' '\248'-'\255' '_']
+let uppercase_latin1 = ['A'-'Z' '\192'-'\214' '\216'-'\222']
+let identchar_latin1 =
+  ['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255' '\'' '0'-'9']
+let symbolchar =
+  ['!' '$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
+let decimal_literal =
+  ['0'-'9'] ['0'-'9' '_']*
+let hex_literal =
+  '0' ['x' 'X'] ['0'-'9' 'A'-'F' 'a'-'f']['0'-'9' 'A'-'F' 'a'-'f' '_']*
+let oct_literal =
+  '0' ['o' 'O'] ['0'-'7'] ['0'-'7' '_']*
+let bin_literal =
+  '0' ['b' 'B'] ['0'-'1'] ['0'-'1' '_']*
+let int_literal =
+  decimal_literal | hex_literal | oct_literal | bin_literal
+let float_literal =
+  ['0'-'9'] ['0'-'9' '_']*
+  ('.' ['0'-'9' '_']* )?
+  (['e' 'E'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
+let hex_float_literal =
+  '0' ['x' 'X']
+  ['0'-'9' 'A'-'F' 'a'-'f'] ['0'-'9' 'A'-'F' 'a'-'f' '_']*
+  ('.' ['0'-'9' 'A'-'F' 'a'-'f' '_']* )?
+  (['p' 'P'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
+let literal_modifier = ['G'-'Z' 'g'-'z']
+
+rule token = parse
+  | "\\" newline {
+      if not !escaped_newlines then
+        raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
+                     Location.curr lexbuf));
+      update_loc lexbuf None 1 false 0;
+      token lexbuf }
+  | newline
+      { update_loc lexbuf None 1 false 0;
+        EOL }
+  | blank +
+      { token lexbuf }
+  | "_"
+      { UNDERSCORE }
+  | "~"
+      { TILDE }
+  | "~" lowercase identchar * ':'
+      { LABEL (get_label_name lexbuf) }
+  | "~" lowercase_latin1 identchar_latin1 * ':'
+      { warn_latin1 lexbuf; LABEL (get_label_name lexbuf) }
+  | "?"
+      { QUESTION }
+  | "?" lowercase identchar * ':'
+      { OPTLABEL (get_label_name lexbuf) }
+  | "?" lowercase_latin1 identchar_latin1 * ':'
+      { warn_latin1 lexbuf; OPTLABEL (get_label_name lexbuf) }
+  | lowercase identchar *
+      { let s = Lexing.lexeme lexbuf in
+        try Hashtbl.find keyword_table s
+        with Not_found -> LIDENT s }
+  | lowercase_latin1 identchar_latin1 *
+      { warn_latin1 lexbuf; LIDENT (Lexing.lexeme lexbuf) }
+  | uppercase identchar *
+      { UIDENT(Lexing.lexeme lexbuf) }       (* No capitalized keywords *)
+  | uppercase_latin1 identchar_latin1 *
+      { warn_latin1 lexbuf; UIDENT(Lexing.lexeme lexbuf) }
+  | int_literal { INT (Lexing.lexeme lexbuf, None) }
+  | (int_literal as lit) (literal_modifier as modif)
+      { INT (lit, Some modif) }
+  | float_literal | hex_float_literal
+      { FLOAT (Lexing.lexeme lexbuf, None) }
+  | ((float_literal | hex_float_literal) as lit) (literal_modifier as modif)
+      { FLOAT (lit, Some modif) }
+  | (float_literal | hex_float_literal | int_literal) identchar+
+      { raise (Error(Invalid_literal (Lexing.lexeme lexbuf),
+                     Location.curr lexbuf)) }
+  | "\""
+      { reset_string_buffer();
+        is_in_string := true;
+        let string_start = lexbuf.lex_start_p in
+        string_start_loc := Location.curr lexbuf;
+        string lexbuf;
+        is_in_string := false;
+        lexbuf.lex_start_p <- string_start;
+        STRING (get_stored_string(), None) }
+  | "{" lowercase* "|"
+      { reset_string_buffer();
+        let delim = Lexing.lexeme lexbuf in
+        let delim = String.sub delim 1 (String.length delim - 2) in
+        is_in_string := true;
+        let string_start = lexbuf.lex_start_p in
+        string_start_loc := Location.curr lexbuf;
+        quoted_string delim lexbuf;
+        is_in_string := false;
+        lexbuf.lex_start_p <- string_start;
+        STRING (get_stored_string(), Some delim) }
+  | "\'" newline "\'"
+      { update_loc lexbuf None 1 false 1;
+        CHAR (Lexing.lexeme_char lexbuf 1) }
+  | "\'" [^ '\\' '\'' '\010' '\013'] "\'"
+      { CHAR(Lexing.lexeme_char lexbuf 1) }
+  | "\'\\" ['\\' '\'' '\"' 'n' 't' 'b' 'r' ' '] "\'"
+      { CHAR(char_for_backslash (Lexing.lexeme_char lexbuf 2)) }
+  | "\'\\" ['0'-'9'] ['0'-'9'] ['0'-'9'] "\'"
+      { CHAR(char_for_decimal_code lexbuf 2) }
+  | "\'\\" 'o' ['0'-'3'] ['0'-'7'] ['0'-'7'] "\'"
+      { CHAR(char_for_octal_code lexbuf 3) }
+  | "\'\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] "\'"
+      { CHAR(char_for_hexadecimal_code lexbuf 3) }
+  | "\'\\" _
+      { let l = Lexing.lexeme lexbuf in
+        let esc = String.sub l 1 (String.length l - 1) in
+        raise (Error(Illegal_escape esc, Location.curr lexbuf))
+      }
+  | "(*"
+      { let s, loc = with_comment_buffer comment lexbuf in
+        COMMENT (s, loc) }
+  | "(**"
+      { let s, loc = with_comment_buffer comment lexbuf in
+        if !handle_docstrings then
+          DOCSTRING (Docstrings.docstring s loc)
+        else
+          COMMENT ("*" ^ s, loc)
+      }
+  | "(**" (('*'+) as stars)
+      { let s, loc =
+          with_comment_buffer
+            (fun lexbuf ->
+               store_string ("*" ^ stars);
+               comment lexbuf)
+            lexbuf
+        in
+        COMMENT (s, loc) }
+  | "(*)"
+      { if !print_warnings then
+          Location.prerr_warning (Location.curr lexbuf) Warnings.Comment_start;
+        let s, loc = with_comment_buffer comment lexbuf in
+        COMMENT (s, loc) }
+  | "(*" (('*'*) as stars) "*)"
+      { if !handle_docstrings && stars="" then
+         (* (**) is an empty docstring *)
+          DOCSTRING(Docstrings.docstring "" (Location.curr lexbuf))
+        else
+          COMMENT (stars, Location.curr lexbuf) }
+  | "*)"
+      { let loc = Location.curr lexbuf in
+        Location.prerr_warning loc Warnings.Comment_not_end;
+        lexbuf.Lexing.lex_curr_pos <- lexbuf.Lexing.lex_curr_pos - 1;
+        let curpos = lexbuf.lex_curr_p in
+        lexbuf.lex_curr_p <- { curpos with pos_cnum = curpos.pos_cnum - 1 };
+        STAR
+      }
+  | ("#" [' ' '\t']* (['0'-'9']+ as num) [' ' '\t']*
+        ("\"" ([^ '\010' '\013' '\"' ] * as name) "\"")?) as directive
+        [^ '\010' '\013'] * newline
+      {
+        match int_of_string num with
+        | exception _ ->
+            (* PR#7165 *)
+            let loc = Location.curr lexbuf in
+            let explanation = "line number out of range" in
+            let error = Invalid_directive (directive, Some explanation) in
+            raise (Error (error, loc))
+        | line_num ->
+           (* Documentation says that the line number should be
+              positive, but we have never guarded against this and it
+              might have useful hackish uses. *)
+            update_loc lexbuf name line_num true 0;
+            token lexbuf
+      }
+  | "#"  { HASH }
+  | "&"  { AMPERSAND }
+  | "&&" { AMPERAMPER }
+  | "`"  { BACKQUOTE }
+  | "\'" { QUOTE }
+  | "("  { LPAREN }
+  | ")"  { RPAREN }
+  | "*"  { STAR }
+  | ","  { COMMA }
+  | "->" { MINUSGREATER }
+  | "."  { DOT }
+  | ".." { DOTDOT }
+  | ":"  { COLON }
+  | "::" { COLONCOLON }
+  | ":=" { COLONEQUAL }
+  | ":>" { COLONGREATER }
+  | ";"  { SEMI }
+  | ";;" { SEMISEMI }
+  | "<"  { LESS }
+  | "<-" { LESSMINUS }
+  | "="  { EQUAL }
+  | "["  { LBRACKET }
+  | "[|" { LBRACKETBAR }
+  | "[<" { LBRACKETLESS }
+  | "[>" { LBRACKETGREATER }
+  | "]"  { RBRACKET }
+  | "{"  { LBRACE }
+  | "{<" { LBRACELESS }
+  | "|"  { BAR }
+  | "||" { BARBAR }
+  | "|]" { BARRBRACKET }
+  | ">"  { GREATER }
+  | ">]" { GREATERRBRACKET }
+  | "}"  { RBRACE }
+  | ">}" { GREATERRBRACE }
+  | "[@" { LBRACKETAT }
+  | "[@@"  { LBRACKETATAT }
+  | "[@@@" { LBRACKETATATAT }
+  | "[%"   { LBRACKETPERCENT }
+  | "[%%"  { LBRACKETPERCENTPERCENT }
+  | "!"  { BANG }
+  | "!=" { INFIXOP0 "!=" }
+  | "+"  { PLUS }
+  | "+." { PLUSDOT }
+  | "+=" { PLUSEQ }
+  | "-"  { MINUS }
+  | "-." { MINUSDOT }
+
+  | "!" symbolchar +
+            { PREFIXOP(Lexing.lexeme lexbuf) }
+  | ['~' '?'] symbolchar +
+            { PREFIXOP(Lexing.lexeme lexbuf) }
+  | ['=' '<' '>' '|' '&' '$'] symbolchar *
+            { INFIXOP0(Lexing.lexeme lexbuf) }
+  | ['@' '^'] symbolchar *
+            { INFIXOP1(Lexing.lexeme lexbuf) }
+  | ['+' '-'] symbolchar *
+            { INFIXOP2(Lexing.lexeme lexbuf) }
+  | "**" symbolchar *
+            { INFIXOP4(Lexing.lexeme lexbuf) }
+  | '%'     { PERCENT }
+  | ['*' '/' '%'] symbolchar *
+            { INFIXOP3(Lexing.lexeme lexbuf) }
+  | '#' (symbolchar | '#') +
+            { HASHOP(Lexing.lexeme lexbuf) }
+  | eof { EOF }
+  | _
+      { raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
+                     Location.curr lexbuf))
+      }
+
+and comment = parse
+    "(*"
+      { comment_start_loc := (Location.curr lexbuf) :: !comment_start_loc;
+        store_lexeme lexbuf;
+        comment lexbuf;
+      }
+  | "*)"
+      { match !comment_start_loc with
+        | [] -> assert false
+        | [_] -> comment_start_loc := []; Location.curr lexbuf
+        | _ :: l -> comment_start_loc := l;
+                  store_lexeme lexbuf;
+                  comment lexbuf;
+       }
+  | "\""
+      {
+        string_start_loc := Location.curr lexbuf;
+        store_string_char '\"';
+        is_in_string := true;
+        begin try string lexbuf
+        with Error (Unterminated_string, str_start) ->
+          match !comment_start_loc with
+          | [] -> assert false
+          | loc :: _ ->
+            let start = List.hd (List.rev !comment_start_loc) in
+            comment_start_loc := [];
+            raise (Error (Unterminated_string_in_comment (start, str_start),
+                          loc))
+        end;
+        is_in_string := false;
+        store_string_char '\"';
+        comment lexbuf }
+  | "{" lowercase* "|"
+      {
+        let delim = Lexing.lexeme lexbuf in
+        let delim = String.sub delim 1 (String.length delim - 2) in
+        string_start_loc := Location.curr lexbuf;
+        store_lexeme lexbuf;
+        is_in_string := true;
+        begin try quoted_string delim lexbuf
+        with Error (Unterminated_string, str_start) ->
+          match !comment_start_loc with
+          | [] -> assert false
+          | loc :: _ ->
+            let start = List.hd (List.rev !comment_start_loc) in
+            comment_start_loc := [];
+            raise (Error (Unterminated_string_in_comment (start, str_start),
+                          loc))
+        end;
+        is_in_string := false;
+        store_string_char '|';
+        store_string delim;
+        store_string_char '}';
+        comment lexbuf }
+
+  | "\'\'"
+      { store_lexeme lexbuf; comment lexbuf }
+  | "\'" newline "\'"
+      { update_loc lexbuf None 1 false 1;
+        store_lexeme lexbuf;
+        comment lexbuf
+      }
+  | "\'" [^ '\\' '\'' '\010' '\013' ] "\'"
+      { store_lexeme lexbuf; comment lexbuf }
+  | "\'\\" ['\\' '\"' '\'' 'n' 't' 'b' 'r' ' '] "\'"
+      { store_lexeme lexbuf; comment lexbuf }
+  | "\'\\" ['0'-'9'] ['0'-'9'] ['0'-'9'] "\'"
+      { store_lexeme lexbuf; comment lexbuf }
+  | "\'\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] "\'"
+      { store_lexeme lexbuf; comment lexbuf }
+  | eof
+      { match !comment_start_loc with
+        | [] -> assert false
+        | loc :: _ ->
+          let start = List.hd (List.rev !comment_start_loc) in
+          comment_start_loc := [];
+          raise (Error (Unterminated_comment start, loc))
+      }
+  | newline
+      { update_loc lexbuf None 1 false 0;
+        store_lexeme lexbuf;
+        comment lexbuf
+      }
+  | _
+      { store_lexeme lexbuf; comment lexbuf }
+
+and string = parse
+    '\"'
+      { () }
+  | '\\' newline ([' ' '\t'] * as space)
+      { update_loc lexbuf None 1 false (String.length space);
+        if in_comment () then store_lexeme lexbuf;
+        string lexbuf
+      }
+  | '\\' ['\\' '\'' '\"' 'n' 't' 'b' 'r' ' ']
+      { store_escaped_char lexbuf
+                           (char_for_backslash(Lexing.lexeme_char lexbuf 1));
+        string lexbuf }
+  | '\\' ['0'-'9'] ['0'-'9'] ['0'-'9']
+      { store_escaped_char lexbuf (char_for_decimal_code lexbuf 1);
+         string lexbuf }
+  | '\\' 'o' ['0'-'3'] ['0'-'7'] ['0'-'7']
+      { store_escaped_char lexbuf (char_for_octal_code lexbuf 2);
+         string lexbuf }
+  | '\\' 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F']
+      { store_escaped_char lexbuf (char_for_hexadecimal_code lexbuf 2);
+         string lexbuf }
+  | '\\' _
+      { if not (in_comment ()) then begin
+(*  Should be an error, but we are very lax.
+          raise (Error (Illegal_escape (Lexing.lexeme lexbuf),
+                        Location.curr lexbuf))
+*)
+          let loc = Location.curr lexbuf in
+          Location.prerr_warning loc Warnings.Illegal_backslash;
+        end;
+        store_lexeme lexbuf;
+        string lexbuf
+      }
+  | newline
+      { if not (in_comment ()) then
+          Location.prerr_warning (Location.curr lexbuf) Warnings.Eol_in_string;
+        update_loc lexbuf None 1 false 0;
+        store_lexeme lexbuf;
+        string lexbuf
+      }
+  | eof
+      { is_in_string := false;
+        raise (Error (Unterminated_string, !string_start_loc)) }
+  | _
+      { store_string_char(Lexing.lexeme_char lexbuf 0);
+        string lexbuf }
+
+and quoted_string delim = parse
+  | newline
+      { update_loc lexbuf None 1 false 0;
+        store_lexeme lexbuf;
+        quoted_string delim lexbuf
+      }
+  | eof
+      { is_in_string := false;
+        raise (Error (Unterminated_string, !string_start_loc)) }
+  | "|" lowercase* "}"
+      {
+        let edelim = Lexing.lexeme lexbuf in
+        let edelim = String.sub edelim 1 (String.length edelim - 2) in
+        if delim = edelim then ()
+        else (store_lexeme lexbuf; quoted_string delim lexbuf)
+      }
+  | _
+      { store_string_char(Lexing.lexeme_char lexbuf 0);
+        quoted_string delim lexbuf }
+
+and skip_hash_bang = parse
+  | "#!" [^ '\n']* '\n' [^ '\n']* "\n!#\n"
+       { update_loc lexbuf None 3 false 0 }
+  | "#!" [^ '\n']* '\n'
+       { update_loc lexbuf None 1 false 0 }
+  | "" { () }
+
+{
+
+  let token_with_comments lexbuf =
+    match !preprocessor with
+    | None -> token lexbuf
+    | Some (_init, preprocess) -> preprocess token lexbuf
+
+  type newline_state =
+    | NoLine (* There have been no blank lines yet. *)
+    | NewLine
+        (* There have been no blank lines, and the previous
+           token was a newline. *)
+    | BlankLine (* There have been blank lines. *)
+
+  type doc_state =
+    | Initial  (* There have been no docstrings yet *)
+    | After of docstring list
+        (* There have been docstrings, none of which were
+           preceeded by a blank line *)
+    | Before of docstring list * docstring list * docstring list
+        (* There have been docstrings, some of which were
+           preceeded by a blank line *)
+
+  and docstring = Docstrings.docstring
+
+  let token lexbuf =
+    let post_pos = lexeme_end_p lexbuf in
+    let attach lines docs pre_pos =
+      let open Docstrings in
+        match docs, lines with
+        | Initial, _ -> ()
+        | After a, (NoLine | NewLine) ->
+            set_post_docstrings post_pos (List.rev a);
+            set_pre_docstrings pre_pos a;
+        | After a, BlankLine ->
+            set_post_docstrings post_pos (List.rev a);
+            set_pre_extra_docstrings pre_pos (List.rev a)
+        | Before(a, f, b), (NoLine | NewLine) ->
+            set_post_docstrings post_pos (List.rev a);
+            set_post_extra_docstrings post_pos
+              (List.rev_append f (List.rev b));
+            set_floating_docstrings pre_pos (List.rev f);
+            set_pre_extra_docstrings pre_pos (List.rev a);
+            set_pre_docstrings pre_pos b
+        | Before(a, f, b), BlankLine ->
+            set_post_docstrings post_pos (List.rev a);
+            set_post_extra_docstrings post_pos
+              (List.rev_append f (List.rev b));
+            set_floating_docstrings pre_pos
+              (List.rev_append f (List.rev b));
+            set_pre_extra_docstrings pre_pos (List.rev a)
+    in
+    let rec loop lines docs lexbuf =
+      match token_with_comments lexbuf with
+      | COMMENT (s, loc) ->
+          add_comment (s, loc);
+          let lines' =
+            match lines with
+            | NoLine -> NoLine
+            | NewLine -> NoLine
+            | BlankLine -> BlankLine
+          in
+          loop lines' docs lexbuf
+      | EOL ->
+          let lines' =
+            match lines with
+            | NoLine -> NewLine
+            | NewLine -> BlankLine
+            | BlankLine -> BlankLine
+          in
+          loop lines' docs lexbuf
+      | DOCSTRING doc ->
+          Docstrings.register doc;
+          add_docstring_comment doc;
+          let docs' =
+            if Docstrings.docstring_body doc = "/*" then
+              match docs with
+              | Initial -> Before([], [doc], [])
+              | After a -> Before (a, [doc], [])
+              | Before(a, f, b) -> Before(a, doc :: b @ f, [])
+            else
+              match docs, lines with
+              | Initial, (NoLine | NewLine) -> After [doc]
+              | Initial, BlankLine -> Before([], [], [doc])
+              | After a, (NoLine | NewLine) -> After (doc :: a)
+              | After a, BlankLine -> Before (a, [], [doc])
+              | Before(a, f, b), (NoLine | NewLine) -> Before(a, f, doc :: b)
+              | Before(a, f, b), BlankLine -> Before(a, b @ f, [doc])
+          in
+          loop NoLine docs' lexbuf
+      | tok ->
+          attach lines docs (lexeme_start_p lexbuf);
+          tok
+    in
+      loop NoLine Initial lexbuf
+
+  let init () =
+    is_in_string := false;
+    comment_start_loc := [];
+    comment_list := [];
+    match !preprocessor with
+    | None -> ()
+    | Some (init, _preprocess) -> init ()
+
+  let set_preprocessor init preprocess =
+    escaped_newlines := true;
+    preprocessor := Some (init, preprocess)
+
+}

--- a/tools/liquidity/ocaml/liquidOCamlParse.ml
+++ b/tools/liquidity/ocaml/liquidOCamlParse.ml
@@ -13,58 +13,92 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Parser = LiquidOCamlParser
-module Lexer = LiquidOCamlLexer
+module OCAML = struct
+  module Parser = LiquidOCamlParser
+  module Lexer = LiquidOCamlLexer
 
-(* Entry points in the parser *)
+  (* Entry points in the parser *)
 
-(* Skip tokens to the end of the phrase *)
+  (* Skip tokens to the end of the phrase *)
 
-let rec skip_phrase lexbuf =
-  try
-    match Lexer.token lexbuf with
-      Parser.SEMISEMI | Parser.EOF -> ()
-    | _ -> skip_phrase lexbuf
-  with
-  | Lexer.Error (Lexer.Unterminated_comment _, _)
-  | Lexer.Error (Lexer.Unterminated_string, _)
-  | Lexer.Error (Lexer.Unterminated_string_in_comment _, _)
-  | Lexer.Error (Lexer.Illegal_character _, _) -> skip_phrase lexbuf
-;;
+  let rec skip_phrase lexbuf =
+    try
+      match Lexer.token lexbuf with
+        Parser.SEMISEMI | Parser.EOF -> ()
+      | _ -> skip_phrase lexbuf
+    with
+    | Lexer.Error (Lexer.Unterminated_comment _, _)
+    | Lexer.Error (Lexer.Unterminated_string, _)
+    | Lexer.Error (Lexer.Unterminated_string_in_comment _, _)
+    | Lexer.Error (Lexer.Illegal_character _, _) -> skip_phrase lexbuf
+  ;;
 
-let maybe_skip_phrase lexbuf =
-  if Parsing.is_current_lookahead Parser.SEMISEMI
-  || Parsing.is_current_lookahead Parser.EOF
-  then ()
-  else skip_phrase lexbuf
+  let maybe_skip_phrase lexbuf =
+    if Parsing.is_current_lookahead Parser.SEMISEMI
+    || Parsing.is_current_lookahead Parser.EOF
+    then ()
+    else skip_phrase lexbuf
 
-let wrap parsing_fun lexbuf =
-  try
-    Docstrings.init ();
-    Lexer.init ();
-    let ast = parsing_fun Lexer.token lexbuf in
-    Parsing.clear_parser();
-    Docstrings.warn_bad_docstrings ();
-    ast
-  with
-  | Lexer.Error(Lexer.Illegal_character _, _) as err
-    when !Location.input_name = "//toplevel//"->
-    skip_phrase lexbuf;
-    raise err
-  | Syntaxerr.Error _ as err
-    when !Location.input_name = "//toplevel//" ->
-    maybe_skip_phrase lexbuf;
-    raise err
-  | Parsing.Parse_error | Syntaxerr.Escape_error ->
-    let loc = Location.curr lexbuf in
-    if !Location.input_name = "//toplevel//"
-    then maybe_skip_phrase lexbuf;
-    raise(Syntaxerr.Error(Syntaxerr.Other loc))
+  let wrap parsing_fun lexbuf =
+    try
+      Docstrings.init ();
+      Lexer.init ();
+      let ast = parsing_fun Lexer.token lexbuf in
+      Parsing.clear_parser();
+      Docstrings.warn_bad_docstrings ();
+      ast
+    with
+    | Lexer.Error(Lexer.Illegal_character _, _) as err
+      when !Location.input_name = "//toplevel//"->
+      skip_phrase lexbuf;
+      raise err
+    | Syntaxerr.Error _ as err
+      when !Location.input_name = "//toplevel//" ->
+      maybe_skip_phrase lexbuf;
+      raise err
+    | Parsing.Parse_error | Syntaxerr.Escape_error ->
+      let loc = Location.curr lexbuf in
+      if !Location.input_name = "//toplevel//"
+      then maybe_skip_phrase lexbuf;
+      raise(Syntaxerr.Error(Syntaxerr.Other loc))
 
-let implementation = wrap Parser.implementation
-and interface = wrap Parser.interface
-and toplevel_phrase = wrap Parser.toplevel_phrase
-and use_file = wrap Parser.use_file
-and core_type = wrap Parser.parse_core_type
-and expression = wrap Parser.parse_expression
-and pattern = wrap Parser.parse_pattern
+  let implementation = wrap Parser.implementation
+  and interface = wrap Parser.interface
+  and toplevel_phrase = wrap Parser.toplevel_phrase
+  and use_file = wrap Parser.use_file
+  and core_type = wrap Parser.parse_core_type
+  and expression = wrap Parser.parse_expression
+  and pattern = wrap Parser.parse_pattern
+end
+
+module RE = struct
+
+  open Reason_toolchain
+
+  let implementation lexbuf =
+    try
+      To_current.copy_structure (RE.implementation lexbuf)
+    with
+    | Reason_syntax_util.Error (loc, err) ->
+      raise (Syntaxerr.Error(Syntaxerr.Other loc))
+
+  let core_type lexbuf =
+    To_current.copy_core_type (RE.core_type lexbuf)
+
+
+end
+
+
+let implementation buf =
+  if  !LiquidOptions.ocaml_syntax then
+    OCAML.implementation buf
+  else
+    RE.implementation buf
+
+let core_type buf =
+  if  !LiquidOptions.ocaml_syntax then
+    OCAML.core_type buf
+  else
+    RE.core_type buf
+
+let expression = OCAML.expression

--- a/tools/liquidity/ocaml/liquidOCamlParse.mli
+++ b/tools/liquidity/ocaml/liquidOCamlParse.mli
@@ -1,0 +1,18 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+val implementation : Lexing.lexbuf -> Parsetree.structure
+val expression : Lexing.lexbuf -> Parsetree.expression
+val core_type :  Lexing.lexbuf -> Parsetree.core_type

--- a/tools/liquidity/ocaml/liquidOCamlParser.mly-orig
+++ b/tools/liquidity/ocaml/liquidOCamlParser.mly-orig
@@ -1,0 +1,2582 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 1996 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* The parser definition */
+
+%{
+open Location
+open Asttypes
+open Longident
+open Parsetree
+open Ast_helper
+open Docstrings
+
+let mktyp d = Typ.mk ~loc:(symbol_rloc()) d
+let mkpat d = Pat.mk ~loc:(symbol_rloc()) d
+let mkexp d = Exp.mk ~loc:(symbol_rloc()) d
+let mkmty ?attrs d = Mty.mk ~loc:(symbol_rloc()) ?attrs d
+let mksig d = Sig.mk ~loc:(symbol_rloc()) d
+let mkmod ?attrs d = Mod.mk ~loc:(symbol_rloc()) ?attrs d
+let mkstr d = Str.mk ~loc:(symbol_rloc()) d
+let mkclass ?attrs d = Cl.mk ~loc:(symbol_rloc()) ?attrs d
+let mkcty ?attrs d = Cty.mk ~loc:(symbol_rloc()) ?attrs d
+let mkctf ?attrs ?docs d =
+  Ctf.mk ~loc:(symbol_rloc()) ?attrs ?docs d
+let mkcf ?attrs ?docs d =
+  Cf.mk ~loc:(symbol_rloc()) ?attrs ?docs d
+
+let mkrhs rhs pos = mkloc rhs (rhs_loc pos)
+
+let reloc_pat x = { x with ppat_loc = symbol_rloc () };;
+let reloc_exp x = { x with pexp_loc = symbol_rloc () };;
+
+let mkoperator name pos =
+  let loc = rhs_loc pos in
+  Exp.mk ~loc (Pexp_ident(mkloc (Lident name) loc))
+
+let mkpatvar name pos =
+  Pat.mk ~loc:(rhs_loc pos) (Ppat_var (mkrhs name pos))
+
+(*
+  Ghost expressions and patterns:
+  expressions and patterns that do not appear explicitly in the
+  source file they have the loc_ghost flag set to true.
+  Then the profiler will not try to instrument them and the
+  -annot option will not try to display their type.
+
+  Every grammar rule that generates an element with a location must
+  make at most one non-ghost element, the topmost one.
+
+  How to tell whether your location must be ghost:
+  A location corresponds to a range of characters in the source file.
+  If the location contains a piece of code that is syntactically
+  valid (according to the documentation), and corresponds to the
+  AST node, then the location must be real; in all other cases,
+  it must be ghost.
+*)
+let ghexp d = Exp.mk ~loc:(symbol_gloc ()) d
+let ghpat d = Pat.mk ~loc:(symbol_gloc ()) d
+let ghtyp d = Typ.mk ~loc:(symbol_gloc ()) d
+let ghloc d = { txt = d; loc = symbol_gloc () }
+let ghstr d = Str.mk ~loc:(symbol_gloc()) d
+let ghsig d = Sig.mk ~loc:(symbol_gloc()) d
+
+let mkinfix arg1 name arg2 =
+  mkexp(Pexp_apply(mkoperator name 2, [Nolabel, arg1; Nolabel, arg2]))
+
+let neg_string f =
+  if String.length f > 0 && f.[0] = '-'
+  then String.sub f 1 (String.length f - 1)
+  else "-" ^ f
+
+let mkuminus name arg =
+  match name, arg.pexp_desc with
+  | "-", Pexp_constant(Pconst_integer (n,m)) ->
+      mkexp(Pexp_constant(Pconst_integer(neg_string n,m)))
+  | ("-" | "-."), Pexp_constant(Pconst_float (f, m)) ->
+      mkexp(Pexp_constant(Pconst_float(neg_string f, m)))
+  | _ ->
+      mkexp(Pexp_apply(mkoperator ("~" ^ name) 1, [Nolabel, arg]))
+
+let mkuplus name arg =
+  let desc = arg.pexp_desc in
+  match name, desc with
+  | "+", Pexp_constant(Pconst_integer _)
+  | ("+" | "+."), Pexp_constant(Pconst_float _) -> mkexp desc
+  | _ ->
+      mkexp(Pexp_apply(mkoperator ("~" ^ name) 1, [Nolabel, arg]))
+
+let mkexp_cons consloc args loc =
+  Exp.mk ~loc (Pexp_construct(mkloc (Lident "::") consloc, Some args))
+
+let mkpat_cons consloc args loc =
+  Pat.mk ~loc (Ppat_construct(mkloc (Lident "::") consloc, Some args))
+
+let rec mktailexp nilloc = function
+    [] ->
+      let loc = { nilloc with loc_ghost = true } in
+      let nil = { txt = Lident "[]"; loc = loc } in
+      Exp.mk ~loc (Pexp_construct (nil, None))
+  | e1 :: el ->
+      let exp_el = mktailexp nilloc el in
+      let loc = {loc_start = e1.pexp_loc.loc_start;
+               loc_end = exp_el.pexp_loc.loc_end;
+               loc_ghost = true}
+      in
+      let arg = Exp.mk ~loc (Pexp_tuple [e1; exp_el]) in
+      mkexp_cons {loc with loc_ghost = true} arg loc
+
+let rec mktailpat nilloc = function
+    [] ->
+      let loc = { nilloc with loc_ghost = true } in
+      let nil = { txt = Lident "[]"; loc = loc } in
+      Pat.mk ~loc (Ppat_construct (nil, None))
+  | p1 :: pl ->
+      let pat_pl = mktailpat nilloc pl in
+      let loc = {loc_start = p1.ppat_loc.loc_start;
+               loc_end = pat_pl.ppat_loc.loc_end;
+               loc_ghost = true}
+      in
+      let arg = Pat.mk ~loc (Ppat_tuple [p1; pat_pl]) in
+      mkpat_cons {loc with loc_ghost = true} arg loc
+
+let mkstrexp e attrs =
+  { pstr_desc = Pstr_eval (e, attrs); pstr_loc = e.pexp_loc }
+
+let mkexp_constraint e (t1, t2) =
+  match t1, t2 with
+  | Some t, None -> ghexp(Pexp_constraint(e, t))
+  | _, Some t -> ghexp(Pexp_coerce(e, t1, t))
+  | None, None -> assert false
+
+let mkexp_opt_constraint e = function
+  | None -> e
+  | Some constraint_ -> mkexp_constraint e constraint_
+
+let mkpat_opt_constraint p = function
+  | None -> p
+  | Some typ -> mkpat (Ppat_constraint(p, typ))
+
+let array_function str name =
+  ghloc (Ldot(Lident str, (if !Clflags.fast then "unsafe_" ^ name else name)))
+
+let syntax_error () =
+  raise Syntaxerr.Escape_error
+
+let unclosed opening_name opening_num closing_name closing_num =
+  raise(Syntaxerr.Error(Syntaxerr.Unclosed(rhs_loc opening_num, opening_name,
+                                           rhs_loc closing_num, closing_name)))
+
+let expecting pos nonterm =
+    raise Syntaxerr.(Error(Expecting(rhs_loc pos, nonterm)))
+
+let not_expecting pos nonterm =
+    raise Syntaxerr.(Error(Not_expecting(rhs_loc pos, nonterm)))
+
+let bigarray_function str name =
+  ghloc (Ldot(Ldot(Lident "Bigarray", str), name))
+
+let bigarray_untuplify = function
+    { pexp_desc = Pexp_tuple explist; pexp_loc = _ } -> explist
+  | exp -> [exp]
+
+let bigarray_get arr arg =
+  let get = if !Clflags.fast then "unsafe_get" else "get" in
+  match bigarray_untuplify arg with
+    [c1] ->
+      mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array1" get)),
+                       [Nolabel, arr; Nolabel, c1]))
+  | [c1;c2] ->
+      mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array2" get)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, c2]))
+  | [c1;c2;c3] ->
+      mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array3" get)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, c2; Nolabel, c3]))
+  | coords ->
+      mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Genarray" "get")),
+                       [Nolabel, arr; Nolabel, ghexp(Pexp_array coords)]))
+
+let bigarray_set arr arg newval =
+  let set = if !Clflags.fast then "unsafe_set" else "set" in
+  match bigarray_untuplify arg with
+    [c1] ->
+      mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array1" set)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, newval]))
+  | [c1;c2] ->
+      mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array2" set)),
+                       [Nolabel, arr; Nolabel, c1;
+                        Nolabel, c2; Nolabel, newval]))
+  | [c1;c2;c3] ->
+      mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Array3" set)),
+                       [Nolabel, arr; Nolabel, c1;
+                        Nolabel, c2; Nolabel, c3; Nolabel, newval]))
+  | coords ->
+      mkexp(Pexp_apply(ghexp(Pexp_ident(bigarray_function "Genarray" "set")),
+                       [Nolabel, arr;
+                        Nolabel, ghexp(Pexp_array coords);
+                        Nolabel, newval]))
+
+let lapply p1 p2 =
+  if !Clflags.applicative_functors
+  then Lapply(p1, p2)
+  else raise (Syntaxerr.Error(Syntaxerr.Applicative_path (symbol_rloc())))
+
+let exp_of_label lbl pos =
+  mkexp (Pexp_ident(mkrhs (Lident(Longident.last lbl)) pos))
+
+let pat_of_label lbl pos =
+  mkpat (Ppat_var (mkrhs (Longident.last lbl) pos))
+
+let mk_newtypes newtypes exp =
+  List.fold_right (fun newtype exp -> mkexp (Pexp_newtype (newtype, exp)))
+    newtypes exp
+
+let wrap_type_annotation newtypes core_type body =
+  let exp = mkexp(Pexp_constraint(body,core_type)) in
+  let exp = mk_newtypes newtypes exp in
+  (exp, ghtyp(Ptyp_poly(newtypes, Typ.varify_constructors newtypes core_type)))
+
+let wrap_exp_attrs body (ext, attrs) =
+  (* todo: keep exact location for the entire attribute *)
+  let body = {body with pexp_attributes = attrs @ body.pexp_attributes} in
+  match ext with
+  | None -> body
+  | Some id -> ghexp(Pexp_extension (id, PStr [mkstrexp body []]))
+
+let mkexp_attrs d attrs =
+  wrap_exp_attrs (mkexp d) attrs
+
+let wrap_typ_attrs typ (ext, attrs) =
+  (* todo: keep exact location for the entire attribute *)
+  let typ = {typ with ptyp_attributes = attrs @ typ.ptyp_attributes} in
+  match ext with
+  | None -> typ
+  | Some id -> ghtyp(Ptyp_extension (id, PTyp typ))
+
+let mktyp_attrs d attrs =
+  wrap_typ_attrs (mktyp d) attrs
+
+let wrap_pat_attrs pat (ext, attrs) =
+  (* todo: keep exact location for the entire attribute *)
+  let pat = {pat with ppat_attributes = attrs @ pat.ppat_attributes} in
+  match ext with
+  | None -> pat
+  | Some id -> ghpat(Ppat_extension (id, PPat (pat, None)))
+
+let mkpat_attrs d attrs =
+  wrap_pat_attrs (mkpat d) attrs
+
+let wrap_class_attrs body attrs =
+  {body with pcl_attributes = attrs @ body.pcl_attributes}
+let wrap_mod_attrs body attrs =
+  {body with pmod_attributes = attrs @ body.pmod_attributes}
+let wrap_mty_attrs body attrs =
+  {body with pmty_attributes = attrs @ body.pmty_attributes}
+
+let wrap_str_ext body ext =
+  match ext with
+  | None -> body
+  | Some id -> ghstr(Pstr_extension ((id, PStr [body]), []))
+
+let mkstr_ext d ext =
+  wrap_str_ext (mkstr d) ext
+
+let wrap_sig_ext body ext =
+  match ext with
+  | None -> body
+  | Some id -> ghsig(Psig_extension ((id, PSig [body]), []))
+
+let mksig_ext d ext =
+  wrap_sig_ext (mksig d) ext
+
+let text_str pos = Str.text (rhs_text pos)
+let text_sig pos = Sig.text (rhs_text pos)
+let text_cstr pos = Cf.text (rhs_text pos)
+let text_csig pos = Ctf.text (rhs_text pos)
+let text_def pos = [Ptop_def (Str.text (rhs_text pos))]
+
+let extra_text text pos items =
+  let pre_extras = rhs_pre_extra_text pos in
+  let post_extras = rhs_post_extra_text pos in
+    text pre_extras @ items @ text post_extras
+
+let extra_str pos items = extra_text Str.text pos items
+let extra_sig pos items = extra_text Sig.text pos items
+let extra_cstr pos items = extra_text Cf.text pos items
+let extra_csig pos items = extra_text Ctf.text pos items
+let extra_def pos items =
+  extra_text (fun txt -> [Ptop_def (Str.text txt)]) pos items
+
+let extra_rhs_core_type ct ~pos =
+  let docs = rhs_info pos in
+  { ct with ptyp_attributes = add_info_attrs docs ct.ptyp_attributes }
+
+type let_binding =
+  { lb_pattern: pattern;
+    lb_expression: expression;
+    lb_attributes: attributes;
+    lb_docs: docs Lazy.t;
+    lb_text: text Lazy.t;
+    lb_loc: Location.t; }
+
+type let_bindings =
+  { lbs_bindings: let_binding list;
+    lbs_rec: rec_flag;
+    lbs_extension: string Asttypes.loc option;
+    lbs_loc: Location.t }
+
+let mklb first (p, e) attrs =
+  { lb_pattern = p;
+    lb_expression = e;
+    lb_attributes = attrs;
+    lb_docs = symbol_docs_lazy ();
+    lb_text = if first then empty_text_lazy
+              else symbol_text_lazy ();
+    lb_loc = symbol_rloc (); }
+
+let mklbs ext rf lb =
+  { lbs_bindings = [lb];
+    lbs_rec = rf;
+    lbs_extension = ext ;
+    lbs_loc = symbol_rloc (); }
+
+let addlb lbs lb =
+  { lbs with lbs_bindings = lb :: lbs.lbs_bindings }
+
+let val_of_let_bindings lbs =
+  let bindings =
+    List.map
+      (fun lb ->
+         Vb.mk ~loc:lb.lb_loc ~attrs:lb.lb_attributes
+           ~docs:(Lazy.force lb.lb_docs)
+           ~text:(Lazy.force lb.lb_text)
+           lb.lb_pattern lb.lb_expression)
+      lbs.lbs_bindings
+  in
+  let str = mkstr(Pstr_value(lbs.lbs_rec, List.rev bindings)) in
+  match lbs.lbs_extension with
+  | None -> str
+  | Some id -> ghstr (Pstr_extension((id, PStr [str]), []))
+
+let expr_of_let_bindings lbs body =
+  let bindings =
+    List.map
+      (fun lb ->
+         Vb.mk ~loc:lb.lb_loc ~attrs:lb.lb_attributes
+           lb.lb_pattern lb.lb_expression)
+      lbs.lbs_bindings
+  in
+    mkexp_attrs (Pexp_let(lbs.lbs_rec, List.rev bindings, body))
+      (lbs.lbs_extension, [])
+
+let class_of_let_bindings lbs body =
+  let bindings =
+    List.map
+      (fun lb ->
+         Vb.mk ~loc:lb.lb_loc ~attrs:lb.lb_attributes
+           lb.lb_pattern lb.lb_expression)
+      lbs.lbs_bindings
+  in
+    if lbs.lbs_extension <> None then
+      raise Syntaxerr.(Error(Not_expecting(lbs.lbs_loc, "extension")));
+    mkclass(Pcl_let (lbs.lbs_rec, List.rev bindings, body))
+
+
+(* Alternatively, we could keep the generic module type in the Parsetree
+   and extract the package type during type-checking. In that case,
+   the assertions below should be turned into explicit checks. *)
+let package_type_of_module_type pmty =
+  let err loc s =
+    raise (Syntaxerr.Error (Syntaxerr.Invalid_package_type (loc, s)))
+  in
+  let map_cstr = function
+    | Pwith_type (lid, ptyp) ->
+        let loc = ptyp.ptype_loc in
+        if ptyp.ptype_params <> [] then
+          err loc "parametrized types are not supported";
+        if ptyp.ptype_cstrs <> [] then
+          err loc "constrained types are not supported";
+        if ptyp.ptype_private <> Public then
+          err loc "private types are not supported";
+
+        (* restrictions below are checked by the 'with_constraint' rule *)
+        assert (ptyp.ptype_kind = Ptype_abstract);
+        assert (ptyp.ptype_attributes = []);
+        let ty =
+          match ptyp.ptype_manifest with
+          | Some ty -> ty
+          | None -> assert false
+        in
+        (lid, ty)
+    | _ ->
+        err pmty.pmty_loc "only 'with type t =' constraints are supported"
+  in
+  match pmty with
+  | {pmty_desc = Pmty_ident lid} -> (lid, [])
+  | {pmty_desc = Pmty_with({pmty_desc = Pmty_ident lid}, cstrs)} ->
+      (lid, List.map map_cstr cstrs)
+  | _ ->
+      err pmty.pmty_loc
+        "only module type identifier and 'with type' constraints are supported"
+
+
+%}
+
+/* Tokens */
+
+%token AMPERAMPER
+%token AMPERSAND
+%token AND
+%token AS
+%token ASSERT
+%token BACKQUOTE
+%token BANG
+%token BAR
+%token BARBAR
+%token BARRBRACKET
+%token BEGIN
+%token <char> CHAR
+%token CLASS
+%token COLON
+%token COLONCOLON
+%token COLONEQUAL
+%token COLONGREATER
+%token COMMA
+%token CONSTRAINT
+%token DO
+%token DONE
+%token DOT
+%token DOTDOT
+%token DOWNTO
+%token ELSE
+%token END
+%token EOF
+%token EQUAL
+%token EXCEPTION
+%token EXTERNAL
+%token FALSE
+%token <string * char option> FLOAT
+%token FOR
+%token FUN
+%token FUNCTION
+%token FUNCTOR
+%token GREATER
+%token GREATERRBRACE
+%token GREATERRBRACKET
+%token IF
+%token IN
+%token INCLUDE
+%token <string> INFIXOP0
+%token <string> INFIXOP1
+%token <string> INFIXOP2
+%token <string> INFIXOP3
+%token <string> INFIXOP4
+%token INHERIT
+%token INITIALIZER
+%token <string * char option> INT
+%token <string> LABEL
+%token LAZY
+%token LBRACE
+%token LBRACELESS
+%token LBRACKET
+%token LBRACKETBAR
+%token LBRACKETLESS
+%token LBRACKETGREATER
+%token LBRACKETPERCENT
+%token LBRACKETPERCENTPERCENT
+%token LESS
+%token LESSMINUS
+%token LET
+%token <string> LIDENT
+%token LPAREN
+%token LBRACKETAT
+%token LBRACKETATAT
+%token LBRACKETATATAT
+%token MATCH
+%token METHOD
+%token MINUS
+%token MINUSDOT
+%token MINUSGREATER
+%token MODULE
+%token MUTABLE
+%token NEW
+%token NONREC
+%token OBJECT
+%token OF
+%token OPEN
+%token <string> OPTLABEL
+%token OR
+/* %token PARSER */
+%token PERCENT
+%token PLUS
+%token PLUSDOT
+%token PLUSEQ
+%token <string> PREFIXOP
+%token PRIVATE
+%token QUESTION
+%token QUOTE
+%token RBRACE
+%token RBRACKET
+%token REC
+%token RPAREN
+%token SEMI
+%token SEMISEMI
+%token HASH
+%token <string> HASHOP
+%token SIG
+%token STAR
+%token <string * string option> STRING
+%token STRUCT
+%token THEN
+%token TILDE
+%token TO
+%token TRUE
+%token TRY
+%token TYPE
+%token <string> UIDENT
+%token UNDERSCORE
+%token VAL
+%token VIRTUAL
+%token WHEN
+%token WHILE
+%token WITH
+%token <string * Location.t> COMMENT
+%token <Docstrings.docstring> DOCSTRING
+
+%token EOL
+
+/* Precedences and associativities.
+
+Tokens and rules have precedences.  A reduce/reduce conflict is resolved
+in favor of the first rule (in source file order).  A shift/reduce conflict
+is resolved by comparing the precedence and associativity of the token to
+be shifted with those of the rule to be reduced.
+
+By default, a rule has the precedence of its rightmost terminal (if any).
+
+When there is a shift/reduce conflict between a rule and a token that
+have the same precedence, it is resolved using the associativity:
+if the token is left-associative, the parser will reduce; if
+right-associative, the parser will shift; if non-associative,
+the parser will declare a syntax error.
+
+We will only use associativities with operators of the kind  x * x -> x
+for example, in the rules of the form    expr: expr BINOP expr
+in all other cases, we define two precedences if needed to resolve
+conflicts.
+
+The precedences must be listed from low to high.
+*/
+
+%nonassoc IN
+%nonassoc below_SEMI
+%nonassoc SEMI                          /* below EQUAL ({lbl=...; lbl=...}) */
+%nonassoc LET                           /* above SEMI ( ...; let ... in ...) */
+%nonassoc below_WITH
+%nonassoc FUNCTION WITH                 /* below BAR  (match ... with ...) */
+%nonassoc AND             /* above WITH (module rec A: SIG with ... and ...) */
+%nonassoc THEN                          /* below ELSE (if ... then ...) */
+%nonassoc ELSE                          /* (if ... then ... else ...) */
+%nonassoc LESSMINUS                     /* below COLONEQUAL (lbl <- x := e) */
+%right    COLONEQUAL                    /* expr (e := e := e) */
+%nonassoc AS
+%left     BAR                           /* pattern (p|p|p) */
+%nonassoc below_COMMA
+%left     COMMA                         /* expr/expr_comma_list (e,e,e) */
+%right    MINUSGREATER                  /* core_type2 (t -> t -> t) */
+%right    OR BARBAR                     /* expr (e || e || e) */
+%right    AMPERSAND AMPERAMPER          /* expr (e && e && e) */
+%nonassoc below_EQUAL
+%left     INFIXOP0 EQUAL LESS GREATER   /* expr (e OP e OP e) */
+%right    INFIXOP1                      /* expr (e OP e OP e) */
+%nonassoc below_LBRACKETAT
+%nonassoc LBRACKETAT
+%nonassoc LBRACKETATAT
+%right    COLONCOLON                    /* expr (e :: e :: e) */
+%left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ /* expr (e OP e OP e) */
+%left     PERCENT INFIXOP3 STAR                 /* expr (e OP e OP e) */
+%right    INFIXOP4                      /* expr (e OP e OP e) */
+%nonassoc prec_unary_minus prec_unary_plus /* unary - */
+%nonassoc prec_constant_constructor     /* cf. simple_expr (C versus C x) */
+%nonassoc prec_constr_appl              /* above AS BAR COLONCOLON COMMA */
+%nonassoc below_HASH
+%nonassoc HASH                         /* simple_expr/toplevel_directive */
+%left     HASHOP
+%nonassoc below_DOT
+%nonassoc DOT
+/* Finally, the first tokens of simple_expr are above everything else. */
+%nonassoc BACKQUOTE BANG BEGIN CHAR FALSE FLOAT INT
+          LBRACE LBRACELESS LBRACKET LBRACKETBAR LIDENT LPAREN
+          NEW PREFIXOP STRING TRUE UIDENT
+          LBRACKETPERCENT LBRACKETPERCENTPERCENT
+
+
+/* Entry points */
+
+%start implementation                   /* for implementation files */
+%type <Parsetree.structure> implementation
+%start interface                        /* for interface files */
+%type <Parsetree.signature> interface
+%start toplevel_phrase                  /* for interactive use */
+%type <Parsetree.toplevel_phrase> toplevel_phrase
+%start use_file                         /* for the #use directive */
+%type <Parsetree.toplevel_phrase list> use_file
+%start parse_core_type
+%type <Parsetree.core_type> parse_core_type
+%start parse_expression
+%type <Parsetree.expression> parse_expression
+%start parse_pattern
+%type <Parsetree.pattern> parse_pattern
+%%
+
+/* Entry points */
+
+implementation:
+    structure EOF                        { extra_str 1 $1 }
+;
+interface:
+    signature EOF                        { extra_sig 1 $1 }
+;
+toplevel_phrase:
+    top_structure SEMISEMI               { Ptop_def (extra_str 1 $1) }
+  | toplevel_directive SEMISEMI          { $1 }
+  | EOF                                  { raise End_of_file }
+;
+top_structure:
+    seq_expr post_item_attributes
+      { (text_str 1) @ [mkstrexp $1 $2] }
+  | top_structure_tail
+      { $1 }
+;
+top_structure_tail:
+    /* empty */                          { [] }
+  | structure_item top_structure_tail    { (text_str 1) @ $1 :: $2 }
+;
+use_file:
+    use_file_body                        { extra_def 1 $1 }
+;
+use_file_body:
+    use_file_tail                        { $1 }
+  | seq_expr post_item_attributes use_file_tail
+      { (text_def 1) @ Ptop_def[mkstrexp $1 $2] :: $3 }
+;
+use_file_tail:
+    EOF
+      { [] }
+  | SEMISEMI EOF
+      { text_def 1 }
+  | SEMISEMI seq_expr post_item_attributes use_file_tail
+      {  mark_rhs_docs 2 3;
+        (text_def 1) @ (text_def 2) @ Ptop_def[mkstrexp $2 $3] :: $4 }
+  | SEMISEMI structure_item use_file_tail
+      { (text_def 1) @ (text_def 2) @ Ptop_def[$2] :: $3 }
+  | SEMISEMI toplevel_directive use_file_tail
+      {  mark_rhs_docs 2 3;
+        (text_def 1) @ (text_def 2) @ $2 :: $3 }
+  | structure_item use_file_tail
+      { (text_def 1) @ Ptop_def[$1] :: $2 }
+  | toplevel_directive use_file_tail
+      { mark_rhs_docs 1 1;
+        (text_def 1) @ $1 :: $2 }
+;
+parse_core_type:
+    core_type EOF { $1 }
+;
+parse_expression:
+    seq_expr EOF { $1 }
+;
+parse_pattern:
+    pattern EOF { $1 }
+;
+
+/* Module expressions */
+
+functor_arg:
+    LPAREN RPAREN
+      { mkrhs "*" 2, None }
+  | LPAREN functor_arg_name COLON module_type RPAREN
+      { mkrhs $2 2, Some $4 }
+;
+
+functor_arg_name:
+    UIDENT     { $1 }
+  | UNDERSCORE { "_" }
+;
+
+functor_args:
+    functor_args functor_arg
+      { $2 :: $1 }
+  | functor_arg
+      { [ $1 ] }
+;
+
+module_expr:
+    mod_longident
+      { mkmod(Pmod_ident (mkrhs $1 1)) }
+  | STRUCT attributes structure END
+      { mkmod ~attrs:$2 (Pmod_structure(extra_str 3 $3)) }
+  | STRUCT attributes structure error
+      { unclosed "struct" 1 "end" 4 }
+  | FUNCTOR attributes functor_args MINUSGREATER module_expr
+      { let modexp =
+          List.fold_left
+            (fun acc (n, t) -> mkmod(Pmod_functor(n, t, acc)))
+            $5 $3
+        in wrap_mod_attrs modexp $2 }
+  | module_expr paren_module_expr
+      { mkmod(Pmod_apply($1, $2)) }
+  | module_expr LPAREN RPAREN
+      { mkmod(Pmod_apply($1, mkmod (Pmod_structure []))) }
+  | paren_module_expr
+      { $1 }
+  | module_expr attribute
+      { Mod.attr $1 $2 }
+  | extension
+      { mkmod(Pmod_extension $1) }
+;
+
+paren_module_expr:
+    LPAREN module_expr COLON module_type RPAREN
+      { mkmod(Pmod_constraint($2, $4)) }
+  | LPAREN module_expr COLON module_type error
+      { unclosed "(" 1 ")" 5 }
+  | LPAREN module_expr RPAREN
+      { $2 }
+  | LPAREN module_expr error
+      { unclosed "(" 1 ")" 3 }
+  | LPAREN VAL attributes expr RPAREN
+      { mkmod ~attrs:$3 (Pmod_unpack $4)}
+  | LPAREN VAL attributes expr COLON package_type RPAREN
+      { mkmod ~attrs:$3
+          (Pmod_unpack(
+               ghexp(Pexp_constraint($4, ghtyp(Ptyp_package $6))))) }
+  | LPAREN VAL attributes expr COLON package_type COLONGREATER package_type
+    RPAREN
+      { mkmod ~attrs:$3
+          (Pmod_unpack(
+               ghexp(Pexp_coerce($4, Some(ghtyp(Ptyp_package $6)),
+                                 ghtyp(Ptyp_package $8))))) }
+  | LPAREN VAL attributes expr COLONGREATER package_type RPAREN
+      { mkmod ~attrs:$3
+          (Pmod_unpack(
+               ghexp(Pexp_coerce($4, None, ghtyp(Ptyp_package $6))))) }
+  | LPAREN VAL attributes expr COLON error
+      { unclosed "(" 1 ")" 6 }
+  | LPAREN VAL attributes expr COLONGREATER error
+      { unclosed "(" 1 ")" 6 }
+  | LPAREN VAL attributes expr error
+      { unclosed "(" 1 ")" 5 }
+;
+
+structure:
+    seq_expr post_item_attributes structure_tail
+      { mark_rhs_docs 1 2;
+        (text_str 1) @ mkstrexp $1 $2 :: $3 }
+  | structure_tail { $1 }
+;
+structure_tail:
+    /* empty */          { [] }
+  | SEMISEMI structure   { (text_str 1) @ $2 }
+  | structure_item structure_tail { (text_str 1) @ $1 :: $2 }
+;
+structure_item:
+    let_bindings
+      { val_of_let_bindings $1 }
+  | primitive_declaration
+      { let (body, ext) = $1 in mkstr_ext (Pstr_primitive body) ext }
+  | value_description
+      { let (body, ext) = $1 in mkstr_ext (Pstr_primitive body) ext }
+  | type_declarations
+      { let (nr, l, ext ) = $1 in mkstr_ext (Pstr_type (nr, List.rev l)) ext }
+  | str_type_extension
+      { let (l, ext) = $1 in mkstr_ext (Pstr_typext l) ext }
+  | str_exception_declaration
+      { let (l, ext) = $1 in mkstr_ext (Pstr_exception l) ext }
+  | module_binding
+      { let (body, ext) = $1 in mkstr_ext (Pstr_module body) ext }
+  | rec_module_bindings
+      { let (l, ext) = $1 in mkstr_ext (Pstr_recmodule(List.rev l)) ext }
+  | module_type_declaration
+      { let (body, ext) = $1 in mkstr_ext (Pstr_modtype body) ext }
+  | open_statement
+      { let (body, ext) = $1 in mkstr_ext (Pstr_open body) ext }
+  | class_declarations
+      { let (l, ext) = $1 in mkstr_ext (Pstr_class (List.rev l)) ext }
+  | class_type_declarations
+      { let (l, ext) = $1 in mkstr_ext (Pstr_class_type (List.rev l)) ext }
+  | str_include_statement
+      { let (body, ext) = $1 in mkstr_ext (Pstr_include body) ext }
+  | item_extension post_item_attributes
+      { mkstr(Pstr_extension ($1, (add_docs_attrs (symbol_docs ()) $2))) }
+  | floating_attribute
+      { mark_symbol_docs ();
+        mkstr(Pstr_attribute $1) }
+;
+str_include_statement:
+    INCLUDE ext_attributes module_expr post_item_attributes
+      { let (ext, attrs) = $2 in
+        Incl.mk $3 ~attrs:(attrs@$4)
+            ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext }
+;
+module_binding_body:
+    EQUAL module_expr
+      { $2 }
+  | COLON module_type EQUAL module_expr
+      { mkmod(Pmod_constraint($4, $2)) }
+  | functor_arg module_binding_body
+      { mkmod(Pmod_functor(fst $1, snd $1, $2)) }
+;
+module_binding:
+    MODULE ext_attributes UIDENT module_binding_body post_item_attributes
+      { let (ext, attrs) = $2 in
+        Mb.mk (mkrhs $3 3) $4 ~attrs:(attrs@$5)
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext }
+;
+rec_module_bindings:
+    rec_module_binding                     { let (b, ext) = $1 in ([b], ext) }
+  | rec_module_bindings and_module_binding
+      { let (l, ext) = $1 in ($2 :: l, ext) }
+;
+rec_module_binding:
+    MODULE ext_attributes REC UIDENT module_binding_body post_item_attributes
+      { let (ext, attrs) = $2 in
+        Mb.mk (mkrhs $4 4) $5 ~attrs:(attrs@$6)
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext }
+;
+and_module_binding:
+    AND attributes UIDENT module_binding_body post_item_attributes
+      { Mb.mk (mkrhs $3 3) $4 ~attrs:($2@$5) ~loc:(symbol_rloc ())
+               ~text:(symbol_text ()) ~docs:(symbol_docs ()) }
+;
+
+/* Module types */
+
+module_type:
+    mty_longident
+      { mkmty(Pmty_ident (mkrhs $1 1)) }
+  | SIG attributes signature END
+      { mkmty ~attrs:$2 (Pmty_signature (extra_sig 3 $3)) }
+  | SIG attributes signature error
+      { unclosed "sig" 1 "end" 4 }
+  | FUNCTOR attributes functor_args MINUSGREATER module_type
+      %prec below_WITH
+      { let mty =
+          List.fold_left
+            (fun acc (n, t) -> mkmty(Pmty_functor(n, t, acc)))
+            $5 $3
+        in wrap_mty_attrs mty $2 }
+  | module_type MINUSGREATER module_type
+      %prec below_WITH
+      { mkmty(Pmty_functor(mknoloc "_", Some $1, $3)) }
+  | module_type WITH with_constraints
+      { mkmty(Pmty_with($1, List.rev $3)) }
+  | MODULE TYPE OF attributes module_expr %prec below_LBRACKETAT
+      { mkmty ~attrs:$4 (Pmty_typeof $5) }
+/*  | LPAREN MODULE mod_longident RPAREN
+      { mkmty (Pmty_alias (mkrhs $3 3)) } */
+  | LPAREN module_type RPAREN
+      { $2 }
+  | LPAREN module_type error
+      { unclosed "(" 1 ")" 3 }
+  | extension
+      { mkmty(Pmty_extension $1) }
+  | module_type attribute
+      { Mty.attr $1 $2 }
+;
+signature:
+    /* empty */          { [] }
+  | SEMISEMI signature   { (text_sig 1) @ $2 }
+  | signature_item signature { (text_sig 1) @ $1 :: $2 }
+;
+signature_item:
+    value_description
+      { let (body, ext) = $1 in mksig_ext (Psig_value body) ext }
+  | primitive_declaration
+      { let (body, ext) = $1 in mksig_ext (Psig_value body) ext}
+  | type_declarations
+      { let (nr, l, ext) = $1 in mksig_ext (Psig_type (nr, List.rev l)) ext }
+  | sig_type_extension
+      { let (l, ext) = $1 in mksig_ext (Psig_typext l) ext }
+  | sig_exception_declaration
+      { let (l, ext) = $1 in mksig_ext (Psig_exception l) ext }
+  | module_declaration
+      { let (body, ext) = $1 in mksig_ext (Psig_module body) ext }
+  | module_alias
+      { let (body, ext) = $1 in mksig_ext (Psig_module body) ext }
+  | rec_module_declarations
+      { let (l, ext) = $1 in mksig_ext (Psig_recmodule (List.rev l)) ext }
+  | module_type_declaration
+      { let (body, ext) = $1 in mksig_ext (Psig_modtype body) ext }
+  | open_statement
+      { let (body, ext) = $1 in mksig_ext (Psig_open body) ext }
+  | sig_include_statement
+      { let (body, ext) = $1 in mksig_ext (Psig_include body) ext }
+  | class_descriptions
+      { let (l, ext) = $1 in mksig_ext (Psig_class (List.rev l)) ext }
+  | class_type_declarations
+      { let (l, ext) = $1 in mksig_ext (Psig_class_type (List.rev l)) ext }
+  | item_extension post_item_attributes
+      { mksig(Psig_extension ($1, (add_docs_attrs (symbol_docs ()) $2))) }
+  | floating_attribute
+      { mark_symbol_docs ();
+        mksig(Psig_attribute $1) }
+;
+open_statement:
+  | OPEN override_flag ext_attributes mod_longident post_item_attributes
+      { let (ext, attrs) = $3 in
+        Opn.mk (mkrhs $4 4) ~override:$2 ~attrs:(attrs@$5)
+          ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext}
+;
+sig_include_statement:
+    INCLUDE ext_attributes module_type post_item_attributes %prec below_WITH
+      { let (ext, attrs) = $2 in
+        Incl.mk $3 ~attrs:(attrs@$4)
+            ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext}
+;
+module_declaration_body:
+    COLON module_type
+      { $2 }
+  | LPAREN UIDENT COLON module_type RPAREN module_declaration_body
+      { mkmty(Pmty_functor(mkrhs $2 2, Some $4, $6)) }
+  | LPAREN RPAREN module_declaration_body
+      { mkmty(Pmty_functor(mkrhs "*" 1, None, $3)) }
+;
+module_declaration:
+    MODULE ext_attributes UIDENT module_declaration_body post_item_attributes
+      { let (ext, attrs) = $2 in
+        Md.mk (mkrhs $3 3) $4 ~attrs:(attrs@$5)
+          ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext }
+;
+module_alias:
+    MODULE ext_attributes UIDENT EQUAL mod_longident post_item_attributes
+      { let (ext, attrs) = $2 in
+        Md.mk (mkrhs $3 3)
+          (Mty.alias ~loc:(rhs_loc 5) (mkrhs $5 5)) ~attrs:(attrs@$6)
+             ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext }
+;
+rec_module_declarations:
+    rec_module_declaration
+      { let (body, ext) = $1 in ([body], ext) }
+  | rec_module_declarations and_module_declaration
+      { let (l, ext) = $1 in ($2 :: l, ext) }
+;
+rec_module_declaration:
+    MODULE ext_attributes REC UIDENT COLON module_type post_item_attributes
+      { let (ext, attrs) = $2 in
+        Md.mk (mkrhs $4 4) $6 ~attrs:(attrs@$7)
+            ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext}
+;
+and_module_declaration:
+    AND attributes UIDENT COLON module_type post_item_attributes
+      { Md.mk (mkrhs $3 3) $5 ~attrs:($2@$6) ~loc:(symbol_rloc())
+              ~text:(symbol_text()) ~docs:(symbol_docs()) }
+;
+module_type_declaration_body:
+    /* empty */               { None }
+  | EQUAL module_type         { Some $2 }
+;
+module_type_declaration:
+    MODULE TYPE ext_attributes ident module_type_declaration_body
+    post_item_attributes
+      { let (ext, attrs) = $3 in
+        Mtd.mk (mkrhs $4 4) ?typ:$5 ~attrs:(attrs@$6)
+          ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext }
+;
+/* Class expressions */
+
+class_declarations:
+    class_declaration
+      { let (body, ext) = $1 in ([body], ext) }
+  | class_declarations and_class_declaration
+      { let (l, ext) = $1 in ($2 :: l, ext) }
+;
+class_declaration:
+    CLASS ext_attributes virtual_flag class_type_parameters LIDENT
+    class_fun_binding post_item_attributes
+      { let (ext, attrs) = $2 in
+        Ci.mk (mkrhs $5 5) $6 ~virt:$3 ~params:$4 ~attrs:(attrs@$7)
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext }
+;
+and_class_declaration:
+    AND attributes virtual_flag class_type_parameters LIDENT class_fun_binding
+    post_item_attributes
+      { Ci.mk (mkrhs $5 5) $6 ~virt:$3 ~params:$4
+         ~attrs:($2@$7) ~loc:(symbol_rloc ())
+         ~text:(symbol_text ()) ~docs:(symbol_docs ()) }
+;
+class_fun_binding:
+    EQUAL class_expr
+      { $2 }
+  | COLON class_type EQUAL class_expr
+      { mkclass(Pcl_constraint($4, $2)) }
+  | labeled_simple_pattern class_fun_binding
+      { let (l,o,p) = $1 in mkclass(Pcl_fun(l, o, p, $2)) }
+;
+class_type_parameters:
+    /*empty*/                                   { [] }
+  | LBRACKET type_parameter_list RBRACKET       { List.rev $2 }
+;
+class_fun_def:
+    labeled_simple_pattern MINUSGREATER class_expr
+      { let (l,o,p) = $1 in mkclass(Pcl_fun(l, o, p, $3)) }
+  | labeled_simple_pattern class_fun_def
+      { let (l,o,p) = $1 in mkclass(Pcl_fun(l, o, p, $2)) }
+;
+class_expr:
+    class_simple_expr
+      { $1 }
+  | FUN attributes class_fun_def
+      { wrap_class_attrs $3 $2 }
+  | class_simple_expr simple_labeled_expr_list
+      { mkclass(Pcl_apply($1, List.rev $2)) }
+  | let_bindings IN class_expr
+      { class_of_let_bindings $1 $3 }
+  | class_expr attribute
+      { Cl.attr $1 $2 }
+  | extension
+      { mkclass(Pcl_extension $1) }
+;
+class_simple_expr:
+    LBRACKET core_type_comma_list RBRACKET class_longident
+      { mkclass(Pcl_constr(mkloc $4 (rhs_loc 4), List.rev $2)) }
+  | class_longident
+      { mkclass(Pcl_constr(mkrhs $1 1, [])) }
+  | OBJECT attributes class_structure END
+      { mkclass ~attrs:$2 (Pcl_structure $3) }
+  | OBJECT attributes class_structure error
+      { unclosed "object" 1 "end" 4 }
+  | LPAREN class_expr COLON class_type RPAREN
+      { mkclass(Pcl_constraint($2, $4)) }
+  | LPAREN class_expr COLON class_type error
+      { unclosed "(" 1 ")" 5 }
+  | LPAREN class_expr RPAREN
+      { $2 }
+  | LPAREN class_expr error
+      { unclosed "(" 1 ")" 3 }
+;
+class_structure:
+  |  class_self_pattern class_fields
+       { Cstr.mk $1 (extra_cstr 2 (List.rev $2)) }
+;
+class_self_pattern:
+    LPAREN pattern RPAREN
+      { reloc_pat $2 }
+  | LPAREN pattern COLON core_type RPAREN
+      { mkpat(Ppat_constraint($2, $4)) }
+  | /* empty */
+      { ghpat(Ppat_any) }
+;
+class_fields:
+    /* empty */
+      { [] }
+  | class_fields class_field
+      { $2 :: (text_cstr 2) @ $1 }
+;
+class_field:
+  | INHERIT override_flag attributes class_expr parent_binder
+    post_item_attributes
+      { mkcf (Pcf_inherit ($2, $4, $5)) ~attrs:($3@$6) ~docs:(symbol_docs ()) }
+  | VAL value post_item_attributes
+      { let v, attrs = $2 in
+        mkcf (Pcf_val v) ~attrs:(attrs@$3) ~docs:(symbol_docs ()) }
+  | METHOD method_ post_item_attributes
+      { let meth, attrs = $2 in
+        mkcf (Pcf_method meth) ~attrs:(attrs@$3) ~docs:(symbol_docs ()) }
+  | CONSTRAINT attributes constrain_field post_item_attributes
+      { mkcf (Pcf_constraint $3) ~attrs:($2@$4) ~docs:(symbol_docs ()) }
+  | INITIALIZER attributes seq_expr post_item_attributes
+      { mkcf (Pcf_initializer $3) ~attrs:($2@$4) ~docs:(symbol_docs ()) }
+  | item_extension post_item_attributes
+      { mkcf (Pcf_extension $1) ~attrs:$2 ~docs:(symbol_docs ()) }
+  | floating_attribute
+      { mark_symbol_docs ();
+        mkcf (Pcf_attribute $1) }
+;
+parent_binder:
+    AS LIDENT
+          { Some (mkrhs $2 2) }
+  | /* empty */
+          { None }
+;
+value:
+/* TODO: factorize these rules (also with method): */
+    override_flag attributes MUTABLE VIRTUAL label COLON core_type
+      { if $1 = Override then syntax_error ();
+        (mkloc $5 (rhs_loc 5), Mutable, Cfk_virtual $7), $2 }
+  | override_flag attributes VIRTUAL mutable_flag label COLON core_type
+      { if $1 = Override then syntax_error ();
+        (mkrhs $5 5, $4, Cfk_virtual $7), $2 }
+  | override_flag attributes mutable_flag label EQUAL seq_expr
+      { (mkrhs $4 4, $3, Cfk_concrete ($1, $6)), $2 }
+  | override_flag attributes mutable_flag label type_constraint EQUAL seq_expr
+      {
+       let e = mkexp_constraint $7 $5 in
+       (mkrhs $4 4, $3, Cfk_concrete ($1, e)), $2
+      }
+;
+method_:
+/* TODO: factorize those rules... */
+    override_flag attributes PRIVATE VIRTUAL label COLON poly_type
+      { if $1 = Override then syntax_error ();
+        (mkloc $5 (rhs_loc 5), Private, Cfk_virtual $7), $2 }
+  | override_flag attributes VIRTUAL private_flag label COLON poly_type
+      { if $1 = Override then syntax_error ();
+        (mkloc $5 (rhs_loc 5), $4, Cfk_virtual $7), $2 }
+  | override_flag attributes private_flag label strict_binding
+      { (mkloc $4 (rhs_loc 4), $3,
+        Cfk_concrete ($1, ghexp(Pexp_poly ($5, None)))), $2 }
+  | override_flag attributes private_flag label COLON poly_type EQUAL seq_expr
+      { (mkloc $4 (rhs_loc 4), $3,
+        Cfk_concrete ($1, ghexp(Pexp_poly($8, Some $6)))), $2 }
+  | override_flag attributes private_flag label COLON TYPE lident_list
+    DOT core_type EQUAL seq_expr
+      { let exp, poly = wrap_type_annotation $7 $9 $11 in
+        (mkloc $4 (rhs_loc 4), $3,
+        Cfk_concrete ($1, ghexp(Pexp_poly(exp, Some poly)))), $2 }
+;
+
+/* Class types */
+
+class_type:
+    class_signature
+      { $1 }
+  | QUESTION LIDENT COLON simple_core_type_or_tuple MINUSGREATER
+    class_type
+      { mkcty(Pcty_arrow(Optional $2 , $4, $6)) }
+  | OPTLABEL simple_core_type_or_tuple MINUSGREATER class_type
+      { mkcty(Pcty_arrow(Optional $1, $2, $4)) }
+  | LIDENT COLON simple_core_type_or_tuple MINUSGREATER class_type
+      { mkcty(Pcty_arrow(Labelled $1, $3, $5)) }
+  | simple_core_type_or_tuple MINUSGREATER class_type
+      { mkcty(Pcty_arrow(Nolabel, $1, $3)) }
+ ;
+class_signature:
+    LBRACKET core_type_comma_list RBRACKET clty_longident
+      { mkcty(Pcty_constr (mkloc $4 (rhs_loc 4), List.rev $2)) }
+  | clty_longident
+      { mkcty(Pcty_constr (mkrhs $1 1, [])) }
+  | OBJECT attributes class_sig_body END
+      { mkcty ~attrs:$2 (Pcty_signature $3) }
+  | OBJECT attributes class_sig_body error
+      { unclosed "object" 1 "end" 4 }
+  | class_signature attribute
+      { Cty.attr $1 $2 }
+  | extension
+      { mkcty(Pcty_extension $1) }
+;
+class_sig_body:
+    class_self_type class_sig_fields
+      { Csig.mk $1 (extra_csig 2 (List.rev $2)) }
+;
+class_self_type:
+    LPAREN core_type RPAREN
+      { $2 }
+  | /* empty */
+      { mktyp(Ptyp_any) }
+;
+class_sig_fields:
+    /* empty */                                 { [] }
+| class_sig_fields class_sig_field     { $2 :: (text_csig 2) @ $1 }
+;
+class_sig_field:
+    INHERIT attributes class_signature post_item_attributes
+      { mkctf (Pctf_inherit $3) ~attrs:($2@$4) ~docs:(symbol_docs ()) }
+  | VAL attributes value_type post_item_attributes
+      { mkctf (Pctf_val $3) ~attrs:($2@$4) ~docs:(symbol_docs ()) }
+  | METHOD attributes private_virtual_flags label COLON poly_type
+    post_item_attributes
+      {
+       let (p, v) = $3 in
+       mkctf (Pctf_method (mkrhs $4 4, p, v, $6)) ~attrs:($2@$7) ~docs:(symbol_docs ())
+      }
+  | CONSTRAINT attributes constrain_field post_item_attributes
+      { mkctf (Pctf_constraint $3) ~attrs:($2@$4) ~docs:(symbol_docs ()) }
+  | item_extension post_item_attributes
+      { mkctf (Pctf_extension $1) ~attrs:$2 ~docs:(symbol_docs ()) }
+  | floating_attribute
+      { mark_symbol_docs ();
+        mkctf(Pctf_attribute $1) }
+;
+value_type:
+    VIRTUAL mutable_flag label COLON core_type
+      { mkrhs $3 3, $2, Virtual, $5 }
+  | MUTABLE virtual_flag label COLON core_type
+      { mkrhs $3 3, Mutable, $2, $5 }
+  | label COLON core_type
+      { mkrhs $1 1, Immutable, Concrete, $3 }
+;
+constrain:
+        core_type EQUAL core_type          { $1, $3, symbol_rloc() }
+;
+constrain_field:
+        core_type EQUAL core_type          { $1, $3 }
+;
+class_descriptions:
+    class_description
+      { let (body, ext) = $1 in ([body],ext) }
+  | class_descriptions and_class_description
+      { let (l, ext) = $1 in ($2 :: l, ext) }
+;
+class_description:
+    CLASS ext_attributes virtual_flag class_type_parameters LIDENT COLON
+    class_type post_item_attributes
+      { let (ext, attrs) = $2 in
+        Ci.mk (mkrhs $5 5) $7 ~virt:$3 ~params:$4 ~attrs:(attrs @ $8)
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext }
+;
+and_class_description:
+    AND attributes virtual_flag class_type_parameters LIDENT COLON class_type
+    post_item_attributes
+      { Ci.mk (mkrhs $5 5) $7 ~virt:$3 ~params:$4
+              ~attrs:($2@$8) ~loc:(symbol_rloc ())
+              ~text:(symbol_text ()) ~docs:(symbol_docs ()) }
+;
+class_type_declarations:
+    class_type_declaration
+      { let (body, ext) = $1 in ([body],ext) }
+  | class_type_declarations and_class_type_declaration
+      { let (l, ext) = $1 in ($2 :: l, ext) }
+;
+class_type_declaration:
+    CLASS TYPE ext_attributes virtual_flag class_type_parameters LIDENT EQUAL
+    class_signature post_item_attributes
+      { let (ext, attrs) = $3 in
+        Ci.mk (mkrhs $6 6) $8 ~virt:$4 ~params:$5 ~attrs:(attrs@$9)
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext}
+;
+and_class_type_declaration:
+    AND attributes virtual_flag class_type_parameters LIDENT EQUAL
+    class_signature post_item_attributes
+      { Ci.mk (mkrhs $5 5) $7 ~virt:$3 ~params:$4
+         ~attrs:($2@$8) ~loc:(symbol_rloc ())
+         ~text:(symbol_text ()) ~docs:(symbol_docs ()) }
+;
+
+/* Core expressions */
+
+seq_expr:
+  | expr        %prec below_SEMI  { $1 }
+  | expr SEMI                     { reloc_exp $1 }
+  | expr SEMI seq_expr            { mkexp(Pexp_sequence($1, $3)) }
+  | expr SEMI PERCENT attr_id seq_expr
+      { let seq = mkexp(Pexp_sequence ($1, $5)) in
+        let payload = PStr [mkstrexp seq []] in
+        mkexp (Pexp_extension ($4, payload)) }
+;
+labeled_simple_pattern:
+    QUESTION LPAREN label_let_pattern opt_default RPAREN
+      { (Optional (fst $3), $4, snd $3) }
+  | QUESTION label_var
+      { (Optional (fst $2), None, snd $2) }
+  | OPTLABEL LPAREN let_pattern opt_default RPAREN
+      { (Optional $1, $4, $3) }
+  | OPTLABEL pattern_var
+      { (Optional $1, None, $2) }
+  | TILDE LPAREN label_let_pattern RPAREN
+      { (Labelled (fst $3), None, snd $3) }
+  | TILDE label_var
+      { (Labelled (fst $2), None, snd $2) }
+  | LABEL simple_pattern
+      { (Labelled $1, None, $2) }
+  | simple_pattern
+      { (Nolabel, None, $1) }
+;
+pattern_var:
+    LIDENT            { mkpat(Ppat_var (mkrhs $1 1)) }
+  | UNDERSCORE        { mkpat Ppat_any }
+;
+opt_default:
+    /* empty */                         { None }
+  | EQUAL seq_expr                      { Some $2 }
+;
+label_let_pattern:
+    label_var
+      { $1 }
+  | label_var COLON core_type
+      { let (lab, pat) = $1 in (lab, mkpat(Ppat_constraint(pat, $3))) }
+;
+label_var:
+    LIDENT    { ($1, mkpat(Ppat_var (mkrhs $1 1))) }
+;
+let_pattern:
+    pattern
+      { $1 }
+  | pattern COLON core_type
+      { mkpat(Ppat_constraint($1, $3)) }
+;
+expr:
+    simple_expr %prec below_HASH
+      { $1 }
+  | simple_expr simple_labeled_expr_list
+      { mkexp(Pexp_apply($1, List.rev $2)) }
+  | let_bindings IN seq_expr
+      { expr_of_let_bindings $1 $3 }
+  | LET MODULE ext_attributes UIDENT module_binding_body IN seq_expr
+      { mkexp_attrs (Pexp_letmodule(mkrhs $4 4, $5, $7)) $3 }
+  | LET EXCEPTION ext_attributes let_exception_declaration IN seq_expr
+      { mkexp_attrs (Pexp_letexception($4, $6)) $3 }
+  | LET OPEN override_flag ext_attributes mod_longident IN seq_expr
+      { mkexp_attrs (Pexp_open($3, mkrhs $5 5, $7)) $4 }
+  | FUNCTION ext_attributes opt_bar match_cases
+      { mkexp_attrs (Pexp_function(List.rev $4)) $2 }
+  | FUN ext_attributes labeled_simple_pattern fun_def
+      { let (l,o,p) = $3 in
+        mkexp_attrs (Pexp_fun(l, o, p, $4)) $2 }
+  | FUN ext_attributes LPAREN TYPE lident_list RPAREN fun_def
+      { mkexp_attrs (mk_newtypes $5 $7).pexp_desc $2 }
+  | MATCH ext_attributes seq_expr WITH opt_bar match_cases
+      { mkexp_attrs (Pexp_match($3, List.rev $6)) $2 }
+  | TRY ext_attributes seq_expr WITH opt_bar match_cases
+      { mkexp_attrs (Pexp_try($3, List.rev $6)) $2 }
+  | TRY ext_attributes seq_expr WITH error
+      { syntax_error() }
+  | expr_comma_list %prec below_COMMA
+      { mkexp(Pexp_tuple(List.rev $1)) }
+  | constr_longident simple_expr %prec below_HASH
+      { mkexp(Pexp_construct(mkrhs $1 1, Some $2)) }
+  | name_tag simple_expr %prec below_HASH
+      { mkexp(Pexp_variant($1, Some $2)) }
+  | IF ext_attributes seq_expr THEN expr ELSE expr
+      { mkexp_attrs(Pexp_ifthenelse($3, $5, Some $7)) $2 }
+  | IF ext_attributes seq_expr THEN expr
+      { mkexp_attrs (Pexp_ifthenelse($3, $5, None)) $2 }
+  | WHILE ext_attributes seq_expr DO seq_expr DONE
+      { mkexp_attrs (Pexp_while($3, $5)) $2 }
+  | FOR ext_attributes pattern EQUAL seq_expr direction_flag seq_expr DO
+    seq_expr DONE
+      { mkexp_attrs(Pexp_for($3, $5, $7, $6, $9)) $2 }
+  | expr COLONCOLON expr
+      { mkexp_cons (rhs_loc 2) (ghexp(Pexp_tuple[$1;$3])) (symbol_rloc()) }
+  | LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN
+      { mkexp_cons (rhs_loc 2) (ghexp(Pexp_tuple[$5;$7])) (symbol_rloc()) }
+  | expr INFIXOP0 expr
+      { mkinfix $1 $2 $3 }
+  | expr INFIXOP1 expr
+      { mkinfix $1 $2 $3 }
+  | expr INFIXOP2 expr
+      { mkinfix $1 $2 $3 }
+  | expr INFIXOP3 expr
+      { mkinfix $1 $2 $3 }
+  | expr INFIXOP4 expr
+      { mkinfix $1 $2 $3 }
+  | expr PLUS expr
+      { mkinfix $1 "+" $3 }
+  | expr PLUSDOT expr
+      { mkinfix $1 "+." $3 }
+  | expr PLUSEQ expr
+      { mkinfix $1 "+=" $3 }
+  | expr MINUS expr
+      { mkinfix $1 "-" $3 }
+  | expr MINUSDOT expr
+      { mkinfix $1 "-." $3 }
+  | expr STAR expr
+      { mkinfix $1 "*" $3 }
+  | expr PERCENT expr
+      { mkinfix $1 "%" $3 }
+  | expr EQUAL expr
+      { mkinfix $1 "=" $3 }
+  | expr LESS expr
+    { mkinfix $1 "<" $3 }
+  | expr GREATER expr
+      { mkinfix $1 ">" $3 }
+  | expr OR expr
+      { mkinfix $1 "or" $3 }
+  | expr BARBAR expr
+      { mkinfix $1 "||" $3 }
+  | expr AMPERSAND expr
+      { mkinfix $1 "&" $3 }
+  | expr AMPERAMPER expr
+      { mkinfix $1 "&&" $3 }
+  | expr COLONEQUAL expr
+      { mkinfix $1 ":=" $3 }
+  | subtractive expr %prec prec_unary_minus
+      { mkuminus $1 $2 }
+  | additive expr %prec prec_unary_plus
+      { mkuplus $1 $2 }
+  | simple_expr DOT label_longident LESSMINUS expr
+      { mkexp(Pexp_setfield($1, mkrhs $3 3, $5)) }
+  | simple_expr DOT LPAREN seq_expr RPAREN LESSMINUS expr
+      { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "Array" "set")),
+                         [Nolabel,$1; Nolabel,$4; Nolabel,$7])) }
+  | simple_expr DOT LBRACKET seq_expr RBRACKET LESSMINUS expr
+      { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "String" "set")),
+                         [Nolabel,$1; Nolabel,$4; Nolabel,$7])) }
+  | simple_expr DOT LBRACE expr RBRACE LESSMINUS expr
+      { bigarray_set $1 $4 $7 }
+  | label LESSMINUS expr
+      { mkexp(Pexp_setinstvar(mkrhs $1 1, $3)) }
+  | ASSERT ext_attributes simple_expr %prec below_HASH
+      { mkexp_attrs (Pexp_assert $3) $2 }
+  | LAZY ext_attributes simple_expr %prec below_HASH
+      { mkexp_attrs (Pexp_lazy $3) $2 }
+  | OBJECT ext_attributes class_structure END
+      { mkexp_attrs (Pexp_object $3) $2 }
+  | OBJECT ext_attributes class_structure error
+      { unclosed "object" 1 "end" 4 }
+  | expr attribute
+      { Exp.attr $1 $2 }
+  | UNDERSCORE
+     { not_expecting 1 "wildcard \"_\"" }
+;
+simple_expr:
+    val_longident
+      { mkexp(Pexp_ident (mkrhs $1 1)) }
+  | constant
+      { mkexp(Pexp_constant $1) }
+  | constr_longident %prec prec_constant_constructor
+      { mkexp(Pexp_construct(mkrhs $1 1, None)) }
+  | name_tag %prec prec_constant_constructor
+      { mkexp(Pexp_variant($1, None)) }
+  | LPAREN seq_expr RPAREN
+      { reloc_exp $2 }
+  | LPAREN seq_expr error
+      { unclosed "(" 1 ")" 3 }
+  | BEGIN ext_attributes seq_expr END
+      { wrap_exp_attrs (reloc_exp $3) $2 (* check location *) }
+  | BEGIN ext_attributes END
+      { mkexp_attrs (Pexp_construct (mkloc (Lident "()") (symbol_rloc ()),
+                               None)) $2 }
+  | BEGIN ext_attributes seq_expr error
+      { unclosed "begin" 1 "end" 4 }
+  | LPAREN seq_expr type_constraint RPAREN
+      { mkexp_constraint $2 $3 }
+  | simple_expr DOT label_longident
+      { mkexp(Pexp_field($1, mkrhs $3 3)) }
+  | mod_longident DOT LPAREN seq_expr RPAREN
+      { mkexp(Pexp_open(Fresh, mkrhs $1 1, $4)) }
+  | mod_longident DOT LPAREN RPAREN
+      { mkexp(Pexp_open(Fresh, mkrhs $1 1,
+                        mkexp(Pexp_construct(mkrhs (Lident "()") 1, None)))) }
+  | mod_longident DOT LPAREN seq_expr error
+      { unclosed "(" 3 ")" 5 }
+  | simple_expr DOT LPAREN seq_expr RPAREN
+      { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "Array" "get")),
+                         [Nolabel,$1; Nolabel,$4])) }
+  | simple_expr DOT LPAREN seq_expr error
+      { unclosed "(" 3 ")" 5 }
+  | simple_expr DOT LBRACKET seq_expr RBRACKET
+      { mkexp(Pexp_apply(ghexp(Pexp_ident(array_function "String" "get")),
+                         [Nolabel,$1; Nolabel,$4])) }
+  | simple_expr DOT LBRACKET seq_expr error
+      { unclosed "[" 3 "]" 5 }
+  | simple_expr DOT LBRACE expr RBRACE
+      { bigarray_get $1 $4 }
+  | simple_expr DOT LBRACE expr_comma_list error
+      { unclosed "{" 3 "}" 5 }
+  | LBRACE record_expr RBRACE
+      { let (exten, fields) = $2 in mkexp (Pexp_record(fields, exten)) }
+  | LBRACE record_expr error
+      { unclosed "{" 1 "}" 3 }
+  | mod_longident DOT LBRACE record_expr RBRACE
+      { let (exten, fields) = $4 in
+        let rec_exp = mkexp(Pexp_record(fields, exten)) in
+        mkexp(Pexp_open(Fresh, mkrhs $1 1, rec_exp)) }
+  | mod_longident DOT LBRACE record_expr error
+      { unclosed "{" 3 "}" 5 }
+  | LBRACKETBAR expr_semi_list opt_semi BARRBRACKET
+      { mkexp (Pexp_array(List.rev $2)) }
+  | LBRACKETBAR expr_semi_list opt_semi error
+      { unclosed "[|" 1 "|]" 4 }
+  | LBRACKETBAR BARRBRACKET
+      { mkexp (Pexp_array []) }
+  | mod_longident DOT LBRACKETBAR expr_semi_list opt_semi BARRBRACKET
+      { mkexp(Pexp_open(Fresh, mkrhs $1 1, mkexp(Pexp_array(List.rev $4)))) }
+  | mod_longident DOT LBRACKETBAR BARRBRACKET
+      { mkexp(Pexp_open(Fresh, mkrhs $1 1, mkexp(Pexp_array []))) }
+  | mod_longident DOT LBRACKETBAR expr_semi_list opt_semi error
+      { unclosed "[|" 3 "|]" 6 }
+  | LBRACKET expr_semi_list opt_semi RBRACKET
+      { reloc_exp (mktailexp (rhs_loc 4) (List.rev $2)) }
+  | LBRACKET expr_semi_list opt_semi error
+      { unclosed "[" 1 "]" 4 }
+  | mod_longident DOT LBRACKET expr_semi_list opt_semi RBRACKET
+      { let list_exp = reloc_exp (mktailexp (rhs_loc 6) (List.rev $4)) in
+        mkexp(Pexp_open(Fresh, mkrhs $1 1, list_exp)) }
+  | mod_longident DOT LBRACKET RBRACKET
+      { mkexp(Pexp_open(Fresh, mkrhs $1 1,
+                        mkexp(Pexp_construct(mkrhs (Lident "[]") 1, None)))) }
+  | mod_longident DOT LBRACKET expr_semi_list opt_semi error
+      { unclosed "[" 3 "]" 6 }
+  | PREFIXOP simple_expr
+      { mkexp(Pexp_apply(mkoperator $1 1, [Nolabel,$2])) }
+  | BANG simple_expr
+      { mkexp(Pexp_apply(mkoperator "!" 1, [Nolabel,$2])) }
+  | NEW ext_attributes class_longident
+      { mkexp_attrs (Pexp_new(mkrhs $3 3)) $2 }
+  | LBRACELESS field_expr_list GREATERRBRACE
+      { mkexp (Pexp_override $2) }
+  | LBRACELESS field_expr_list error
+      { unclosed "{<" 1 ">}" 3 }
+  | LBRACELESS GREATERRBRACE
+      { mkexp (Pexp_override [])}
+  | mod_longident DOT LBRACELESS field_expr_list GREATERRBRACE
+      { mkexp(Pexp_open(Fresh, mkrhs $1 1, mkexp (Pexp_override $4)))}
+  | mod_longident DOT LBRACELESS GREATERRBRACE
+      { mkexp(Pexp_open(Fresh, mkrhs $1 1, mkexp (Pexp_override [])))}
+  | mod_longident DOT LBRACELESS field_expr_list error
+      { unclosed "{<" 3 ">}" 5 }
+  | simple_expr HASH label
+      { mkexp(Pexp_send($1, mkrhs $3 3)) }
+  | simple_expr HASHOP simple_expr
+      { mkinfix $1 $2 $3 }
+  | LPAREN MODULE ext_attributes module_expr RPAREN
+      { mkexp_attrs (Pexp_pack $4) $3 }
+  | LPAREN MODULE ext_attributes module_expr COLON package_type RPAREN
+      { mkexp_attrs (Pexp_constraint (ghexp (Pexp_pack $4),
+                                      ghtyp (Ptyp_package $6)))
+                    $3 }
+  | LPAREN MODULE ext_attributes module_expr COLON error
+      { unclosed "(" 1 ")" 6 }
+  | mod_longident DOT LPAREN MODULE ext_attributes module_expr COLON
+    package_type RPAREN
+      { mkexp(Pexp_open(Fresh, mkrhs $1 1,
+        mkexp_attrs (Pexp_constraint (ghexp (Pexp_pack $6),
+                                ghtyp (Ptyp_package $8)))
+                    $5 )) }
+  | mod_longident DOT LPAREN MODULE ext_attributes module_expr COLON error
+      { unclosed "(" 3 ")" 8 }
+  | extension
+      { mkexp (Pexp_extension $1) }
+;
+simple_labeled_expr_list:
+    labeled_simple_expr
+      { [$1] }
+  | simple_labeled_expr_list labeled_simple_expr
+      { $2 :: $1 }
+;
+labeled_simple_expr:
+    simple_expr %prec below_HASH
+      { (Nolabel, $1) }
+  | label_expr
+      { $1 }
+;
+label_expr:
+    LABEL simple_expr %prec below_HASH
+      { (Labelled $1, $2) }
+  | TILDE label_ident
+      { (Labelled (fst $2), snd $2) }
+  | QUESTION label_ident
+      { (Optional (fst $2), snd $2) }
+  | OPTLABEL simple_expr %prec below_HASH
+      { (Optional $1, $2) }
+;
+label_ident:
+    LIDENT   { ($1, mkexp(Pexp_ident(mkrhs (Lident $1) 1))) }
+;
+lident_list:
+    LIDENT                            { [mkrhs $1 1] }
+  | LIDENT lident_list                { mkrhs $1 1 :: $2 }
+;
+let_binding_body:
+    val_ident fun_binding
+      { (mkpatvar $1 1, $2) }
+  | val_ident COLON typevar_list DOT core_type EQUAL seq_expr
+      { (ghpat(Ppat_constraint(mkpatvar $1 1,
+                               ghtyp(Ptyp_poly(List.rev $3,$5)))),
+         $7) }
+  | val_ident COLON TYPE lident_list DOT core_type EQUAL seq_expr
+      { let exp, poly = wrap_type_annotation $4 $6 $8 in
+        (ghpat(Ppat_constraint(mkpatvar $1 1, poly)), exp) }
+  | pattern_no_exn EQUAL seq_expr
+      { ($1, $3) }
+  | simple_pattern_not_ident COLON core_type EQUAL seq_expr
+      { (ghpat(Ppat_constraint($1, $3)), $5) }
+;
+let_bindings:
+    let_binding                                 { $1 }
+  | let_bindings and_let_binding                { addlb $1 $2 }
+;
+let_binding:
+    LET ext_attributes rec_flag let_binding_body post_item_attributes
+      { let (ext, attr) = $2 in
+        mklbs ext $3 (mklb true $4 (attr@$5)) }
+;
+and_let_binding:
+    AND attributes let_binding_body post_item_attributes
+      { mklb false $3 ($2@$4) }
+;
+fun_binding:
+    strict_binding
+      { $1 }
+  | type_constraint EQUAL seq_expr
+      { mkexp_constraint $3 $1 }
+;
+strict_binding:
+    EQUAL seq_expr
+      { $2 }
+  | labeled_simple_pattern fun_binding
+      { let (l, o, p) = $1 in ghexp(Pexp_fun(l, o, p, $2)) }
+  | LPAREN TYPE lident_list RPAREN fun_binding
+      { mk_newtypes $3 $5 }
+;
+match_cases:
+    match_case { [$1] }
+  | match_cases BAR match_case { $3 :: $1 }
+;
+match_case:
+    pattern MINUSGREATER seq_expr
+      { Exp.case $1 $3 }
+  | pattern WHEN seq_expr MINUSGREATER seq_expr
+      { Exp.case $1 ~guard:$3 $5 }
+  | pattern MINUSGREATER DOT
+      { Exp.case $1 (Exp.unreachable ~loc:(rhs_loc 3) ())}
+;
+fun_def:
+    MINUSGREATER seq_expr
+      { $2 }
+  | COLON simple_core_type MINUSGREATER seq_expr
+      { mkexp (Pexp_constraint ($4, $2)) }
+/* Cf #5939: we used to accept (fun p when e0 -> e) */
+  | labeled_simple_pattern fun_def
+      {
+       let (l,o,p) = $1 in
+       ghexp(Pexp_fun(l, o, p, $2))
+      }
+  | LPAREN TYPE lident_list RPAREN fun_def
+      { mk_newtypes $3 $5 }
+;
+expr_comma_list:
+    expr_comma_list COMMA expr                  { $3 :: $1 }
+  | expr COMMA expr                             { [$3; $1] }
+;
+record_expr:
+    simple_expr WITH lbl_expr_list              { (Some $1, $3) }
+  | lbl_expr_list                               { (None, $1) }
+;
+lbl_expr_list:
+     lbl_expr { [$1] }
+  |  lbl_expr SEMI lbl_expr_list { $1 :: $3 }
+  |  lbl_expr SEMI { [$1] }
+;
+lbl_expr:
+    label_longident opt_type_constraint EQUAL expr
+      { (mkrhs $1 1, mkexp_opt_constraint $4 $2) }
+  | label_longident opt_type_constraint
+      { (mkrhs $1 1, mkexp_opt_constraint (exp_of_label $1 1) $2) }
+;
+field_expr_list:
+    field_expr opt_semi { [$1] }
+  | field_expr SEMI field_expr_list { $1 :: $3 }
+;
+field_expr:
+    label EQUAL expr
+      { (mkrhs $1 1, $3) }
+  | label
+      { (mkrhs $1 1, exp_of_label (Lident $1) 1) }
+;
+expr_semi_list:
+    expr                                        { [$1] }
+  | expr_semi_list SEMI expr                    { $3 :: $1 }
+;
+type_constraint:
+    COLON core_type                             { (Some $2, None) }
+  | COLON core_type COLONGREATER core_type      { (Some $2, Some $4) }
+  | COLONGREATER core_type                      { (None, Some $2) }
+  | COLON error                                 { syntax_error() }
+  | COLONGREATER error                          { syntax_error() }
+;
+opt_type_constraint:
+    type_constraint { Some $1 }
+  | /* empty */ { None }
+;
+
+/* Patterns */
+
+pattern:
+  | pattern AS val_ident
+      { mkpat(Ppat_alias($1, mkrhs $3 3)) }
+  | pattern AS error
+      { expecting 3 "identifier" }
+  | pattern_comma_list  %prec below_COMMA
+      { mkpat(Ppat_tuple(List.rev $1)) }
+  | pattern COLONCOLON pattern
+      { mkpat_cons (rhs_loc 2) (ghpat(Ppat_tuple[$1;$3])) (symbol_rloc()) }
+  | pattern COLONCOLON error
+      { expecting 3 "pattern" }
+  | pattern BAR pattern
+      { mkpat(Ppat_or($1, $3)) }
+  | pattern BAR error
+      { expecting 3 "pattern" }
+  | EXCEPTION ext_attributes pattern %prec prec_constr_appl
+      { mkpat_attrs (Ppat_exception $3) $2}
+  | pattern attribute
+      { Pat.attr $1 $2 }
+  | pattern_gen { $1 }
+;
+pattern_no_exn:
+  | pattern_no_exn AS val_ident
+      { mkpat(Ppat_alias($1, mkrhs $3 3)) }
+  | pattern_no_exn AS error
+      { expecting 3 "identifier" }
+  | pattern_no_exn_comma_list  %prec below_COMMA
+      { mkpat(Ppat_tuple(List.rev $1)) }
+  | pattern_no_exn COLONCOLON pattern
+      { mkpat_cons (rhs_loc 2) (ghpat(Ppat_tuple[$1;$3])) (symbol_rloc()) }
+  | pattern_no_exn COLONCOLON error
+      { expecting 3 "pattern" }
+  | pattern_no_exn BAR pattern
+      { mkpat(Ppat_or($1, $3)) }
+  | pattern_no_exn BAR error
+      { expecting 3 "pattern" }
+  | pattern_no_exn attribute
+      { Pat.attr $1 $2 }
+  | pattern_gen { $1 }
+;
+pattern_gen:
+    simple_pattern
+      { $1 }
+  | constr_longident pattern %prec prec_constr_appl
+      { mkpat(Ppat_construct(mkrhs $1 1, Some $2)) }
+  | name_tag pattern %prec prec_constr_appl
+      { mkpat(Ppat_variant($1, Some $2)) }
+  | LPAREN COLONCOLON RPAREN LPAREN pattern COMMA pattern RPAREN
+      { mkpat_cons (rhs_loc 2) (ghpat(Ppat_tuple[$5;$7])) (symbol_rloc()) }
+  | LPAREN COLONCOLON RPAREN LPAREN pattern COMMA pattern error
+      { unclosed "(" 4 ")" 8 }
+  | LAZY ext_attributes simple_pattern
+      { mkpat_attrs (Ppat_lazy $3) $2}
+;
+simple_pattern:
+    val_ident %prec below_EQUAL
+      { mkpat(Ppat_var (mkrhs $1 1)) }
+  | simple_pattern_not_ident { $1 }
+;
+simple_pattern_not_ident:
+  | UNDERSCORE
+      { mkpat(Ppat_any) }
+  | signed_constant
+      { mkpat(Ppat_constant $1) }
+  | signed_constant DOTDOT signed_constant
+      { mkpat(Ppat_interval ($1, $3)) }
+  | constr_longident
+      { mkpat(Ppat_construct(mkrhs $1 1, None)) }
+  | name_tag
+      { mkpat(Ppat_variant($1, None)) }
+  | HASH type_longident
+      { mkpat(Ppat_type (mkrhs $2 2)) }
+  | simple_delimited_pattern
+      { $1 }
+  | mod_longident DOT simple_delimited_pattern
+      { mkpat @@ Ppat_open(mkrhs $1 1, $3) }
+  | mod_longident DOT LBRACKET RBRACKET
+    { mkpat @@ Ppat_open(mkrhs $1 1, mkpat @@
+               Ppat_construct ( mkrhs (Lident "[]") 4, None)) }
+  | mod_longident DOT LPAREN RPAREN
+      { mkpat @@ Ppat_open( mkrhs $1 1, mkpat @@
+                 Ppat_construct ( mkrhs (Lident "()") 4, None) ) }
+  | mod_longident DOT LPAREN pattern RPAREN
+      { mkpat @@ Ppat_open (mkrhs $1 1, $4)}
+  | mod_longident DOT LPAREN pattern error
+      {unclosed "(" 3 ")" 5  }
+  | mod_longident DOT LPAREN error
+      { expecting 4 "pattern" }
+  | LPAREN pattern RPAREN
+      { reloc_pat $2 }
+  | LPAREN pattern error
+      { unclosed "(" 1 ")" 3 }
+  | LPAREN pattern COLON core_type RPAREN
+      { mkpat(Ppat_constraint($2, $4)) }
+  | LPAREN pattern COLON core_type error
+      { unclosed "(" 1 ")" 5 }
+  | LPAREN pattern COLON error
+      { expecting 4 "type" }
+  | LPAREN MODULE ext_attributes UIDENT RPAREN
+      { mkpat_attrs (Ppat_unpack (mkrhs $4 4)) $3 }
+  | LPAREN MODULE ext_attributes UIDENT COLON package_type RPAREN
+      { mkpat_attrs
+          (Ppat_constraint(mkpat(Ppat_unpack (mkrhs $4 4)),
+                           ghtyp(Ptyp_package $6)))
+          $3 }
+  | LPAREN MODULE ext_attributes UIDENT COLON package_type error
+      { unclosed "(" 1 ")" 7 }
+  | extension
+      { mkpat(Ppat_extension $1) }
+;
+
+simple_delimited_pattern:
+  | LBRACE lbl_pattern_list RBRACE
+    { let (fields, closed) = $2 in mkpat(Ppat_record(fields, closed)) }
+  | LBRACE lbl_pattern_list error
+    { unclosed "{" 1 "}" 3 }
+  | LBRACKET pattern_semi_list opt_semi RBRACKET
+    { reloc_pat (mktailpat (rhs_loc 4) (List.rev $2)) }
+  | LBRACKET pattern_semi_list opt_semi error
+    { unclosed "[" 1 "]" 4 }
+  | LBRACKETBAR pattern_semi_list opt_semi BARRBRACKET
+    { mkpat(Ppat_array(List.rev $2)) }
+  | LBRACKETBAR BARRBRACKET
+    { mkpat(Ppat_array []) }
+  | LBRACKETBAR pattern_semi_list opt_semi error
+    { unclosed "[|" 1 "|]" 4 }
+
+pattern_comma_list:
+    pattern_comma_list COMMA pattern            { $3 :: $1 }
+  | pattern COMMA pattern                       { [$3; $1] }
+  | pattern COMMA error                         { expecting 3 "pattern" }
+;
+pattern_no_exn_comma_list:
+    pattern_no_exn_comma_list COMMA pattern     { $3 :: $1 }
+  | pattern_no_exn COMMA pattern                { [$3; $1] }
+  | pattern_no_exn COMMA error                  { expecting 3 "pattern" }
+;
+pattern_semi_list:
+    pattern                                     { [$1] }
+  | pattern_semi_list SEMI pattern              { $3 :: $1 }
+;
+lbl_pattern_list:
+    lbl_pattern { [$1], Closed }
+  | lbl_pattern SEMI { [$1], Closed }
+  | lbl_pattern SEMI UNDERSCORE opt_semi { [$1], Open }
+  | lbl_pattern SEMI lbl_pattern_list
+      { let (fields, closed) = $3 in $1 :: fields, closed }
+;
+lbl_pattern:
+    label_longident opt_pattern_type_constraint EQUAL pattern
+     { (mkrhs $1 1, mkpat_opt_constraint $4 $2) }
+  | label_longident opt_pattern_type_constraint
+     { (mkrhs $1 1, mkpat_opt_constraint (pat_of_label $1 1) $2) }
+;
+opt_pattern_type_constraint:
+    COLON core_type { Some $2 }
+  | /* empty */ { None }
+;
+
+/* Value descriptions */
+
+value_description:
+    VAL ext_attributes val_ident COLON core_type post_item_attributes
+      { let (ext, attrs) = $2 in
+        Val.mk (mkrhs $3 3) $5 ~attrs:(attrs@$6)
+              ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+      , ext }
+;
+
+/* Primitive declarations */
+
+primitive_declaration_body:
+    STRING                                      { [fst $1] }
+  | STRING primitive_declaration_body           { fst $1 :: $2 }
+;
+primitive_declaration:
+    EXTERNAL ext_attributes val_ident COLON core_type EQUAL
+    primitive_declaration_body post_item_attributes
+      { let (ext, attrs) = $2 in
+        Val.mk (mkrhs $3 3) $5 ~prim:$7 ~attrs:(attrs@$8)
+              ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+      , ext }
+;
+
+/* Type declarations */
+
+type_declarations:
+    type_declaration
+      { let (nonrec_flag, ty, ext) = $1 in (nonrec_flag, [ty], ext) }
+  | type_declarations and_type_declaration
+      { let (nonrec_flag, tys, ext) = $1 in (nonrec_flag, $2 :: tys, ext) }
+;
+
+type_declaration:
+    TYPE ext_attributes nonrec_flag optional_type_parameters LIDENT
+    type_kind constraints post_item_attributes
+      { let (kind, priv, manifest) = $6 in
+        let (ext, attrs) = $2 in
+        let ty =
+          Type.mk (mkrhs $5 5) ~params:$4 ~cstrs:(List.rev $7) ~kind
+            ~priv ?manifest ~attrs:(attrs@$8)
+            ~loc:(symbol_rloc ()) ~docs:(symbol_docs ())
+        in
+          ($3, ty, ext) }
+;
+and_type_declaration:
+    AND attributes optional_type_parameters LIDENT type_kind constraints
+    post_item_attributes
+      { let (kind, priv, manifest) = $5 in
+          Type.mk (mkrhs $4 4) ~params:$3 ~cstrs:(List.rev $6)
+            ~kind ~priv ?manifest ~attrs:($2@$7) ~loc:(symbol_rloc ())
+            ~text:(symbol_text ()) ~docs:(symbol_docs ()) }
+;
+constraints:
+        constraints CONSTRAINT constrain        { $3 :: $1 }
+      | /* empty */                             { [] }
+;
+type_kind:
+    /*empty*/
+      { (Ptype_abstract, Public, None) }
+  | EQUAL core_type
+      { (Ptype_abstract, Public, Some $2) }
+  | EQUAL PRIVATE core_type
+      { (Ptype_abstract, Private, Some $3) }
+  | EQUAL constructor_declarations
+      { (Ptype_variant(List.rev $2), Public, None) }
+  | EQUAL PRIVATE constructor_declarations
+      { (Ptype_variant(List.rev $3), Private, None) }
+  | EQUAL DOTDOT
+      { (Ptype_open, Public, None) }
+  | EQUAL private_flag LBRACE label_declarations RBRACE
+      { (Ptype_record $4, $2, None) }
+  | EQUAL core_type EQUAL private_flag constructor_declarations
+      { (Ptype_variant(List.rev $5), $4, Some $2) }
+  | EQUAL core_type EQUAL DOTDOT
+      { (Ptype_open, Public, Some $2) }
+  | EQUAL core_type EQUAL private_flag LBRACE label_declarations RBRACE
+      { (Ptype_record $6, $4, Some $2) }
+;
+optional_type_parameters:
+    /*empty*/                                   { [] }
+  | optional_type_parameter                     { [$1] }
+  | LPAREN optional_type_parameter_list RPAREN  { List.rev $2 }
+;
+optional_type_parameter:
+    type_variance optional_type_variable        { $2, $1 }
+;
+optional_type_parameter_list:
+    optional_type_parameter                              { [$1] }
+  | optional_type_parameter_list COMMA optional_type_parameter    { $3 :: $1 }
+;
+optional_type_variable:
+    QUOTE ident                                 { mktyp(Ptyp_var $2) }
+  | UNDERSCORE                                  { mktyp(Ptyp_any) }
+;
+
+
+type_parameters:
+    /*empty*/                                   { [] }
+  | type_parameter                              { [$1] }
+  | LPAREN type_parameter_list RPAREN           { List.rev $2 }
+;
+type_parameter:
+    type_variance type_variable                   { $2, $1 }
+;
+type_variance:
+    /* empty */                                 { Invariant }
+  | PLUS                                        { Covariant }
+  | MINUS                                       { Contravariant }
+;
+type_variable:
+    QUOTE ident                                 { mktyp(Ptyp_var $2) }
+;
+type_parameter_list:
+    type_parameter                              { [$1] }
+  | type_parameter_list COMMA type_parameter    { $3 :: $1 }
+;
+constructor_declarations:
+    constructor_declaration                              { [$1] }
+  | bar_constructor_declaration                          { [$1] }
+  | constructor_declarations bar_constructor_declaration { $2 :: $1 }
+;
+constructor_declaration:
+  | constr_ident generalized_constructor_arguments attributes
+      {
+       let args,res = $2 in
+       Type.constructor (mkrhs $1 1) ~args ?res ~attrs:$3
+         ~loc:(symbol_rloc()) ~info:(symbol_info ())
+      }
+;
+bar_constructor_declaration:
+  | BAR constr_ident generalized_constructor_arguments attributes
+      {
+       let args,res = $3 in
+       Type.constructor (mkrhs $2 2) ~args ?res ~attrs:$4
+         ~loc:(symbol_rloc()) ~info:(symbol_info ())
+      }
+;
+str_exception_declaration:
+  | sig_exception_declaration                    { $1 }
+  | EXCEPTION ext_attributes constr_ident EQUAL constr_longident attributes
+    post_item_attributes
+      { let (ext,attrs) = $2 in
+        Te.rebind (mkrhs $3 3) (mkrhs $5 5) ~attrs:(attrs @ $6 @ $7)
+          ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+        , ext }
+;
+sig_exception_declaration:
+  | EXCEPTION ext_attributes constr_ident generalized_constructor_arguments
+    attributes post_item_attributes
+      { let args, res = $4 in
+        let (ext,attrs) = $2 in
+          Te.decl (mkrhs $3 3) ~args ?res ~attrs:(attrs @ $5 @ $6)
+            ~loc:(symbol_rloc()) ~docs:(symbol_docs ())
+        , ext }
+;
+let_exception_declaration:
+    constr_ident generalized_constructor_arguments attributes
+      { let args, res = $2 in
+        Te.decl (mkrhs $1 1) ~args ?res ~attrs:$3 ~loc:(symbol_rloc()) }
+;
+generalized_constructor_arguments:
+    /*empty*/                     { (Pcstr_tuple [],None) }
+  | OF constructor_arguments      { ($2,None) }
+  | COLON constructor_arguments MINUSGREATER simple_core_type
+                                  { ($2,Some $4) }
+  | COLON simple_core_type
+                                  { (Pcstr_tuple [],Some $2) }
+;
+
+constructor_arguments:
+  | core_type_list                   { Pcstr_tuple (List.rev $1) }
+  | LBRACE label_declarations RBRACE { Pcstr_record $2 }
+;
+label_declarations:
+    label_declaration                           { [$1] }
+  | label_declaration_semi                      { [$1] }
+  | label_declaration_semi label_declarations   { $1 :: $2 }
+;
+label_declaration:
+    mutable_flag label COLON poly_type_no_attr attributes
+      {
+       Type.field (mkrhs $2 2) $4 ~mut:$1 ~attrs:$5
+         ~loc:(symbol_rloc()) ~info:(symbol_info ())
+      }
+;
+label_declaration_semi:
+    mutable_flag label COLON poly_type_no_attr attributes SEMI attributes
+      {
+       let info =
+         match rhs_info 5 with
+         | Some _ as info_before_semi -> info_before_semi
+         | None -> symbol_info ()
+       in
+       Type.field (mkrhs $2 2) $4 ~mut:$1 ~attrs:($5 @ $7)
+         ~loc:(symbol_rloc()) ~info
+      }
+;
+
+/* Type Extensions */
+
+str_type_extension:
+  TYPE ext_attributes nonrec_flag optional_type_parameters type_longident
+  PLUSEQ private_flag str_extension_constructors post_item_attributes
+      { let (ext, attrs) = $2 in
+        if $3 <> Recursive then not_expecting 3 "nonrec flag";
+        Te.mk (mkrhs $5 5) (List.rev $8) ~params:$4 ~priv:$7
+          ~attrs:(attrs@$9) ~docs:(symbol_docs ())
+        , ext }
+;
+sig_type_extension:
+  TYPE ext_attributes nonrec_flag optional_type_parameters type_longident
+  PLUSEQ private_flag sig_extension_constructors post_item_attributes
+      { let (ext, attrs) = $2 in
+        if $3 <> Recursive then not_expecting 3 "nonrec flag";
+        Te.mk (mkrhs $5 5) (List.rev $8) ~params:$4 ~priv:$7
+          ~attrs:(attrs @ $9) ~docs:(symbol_docs ())
+        , ext }
+;
+str_extension_constructors:
+    extension_constructor_declaration                     { [$1] }
+  | bar_extension_constructor_declaration                 { [$1] }
+  | extension_constructor_rebind                          { [$1] }
+  | bar_extension_constructor_rebind                      { [$1] }
+  | str_extension_constructors bar_extension_constructor_declaration
+      { $2 :: $1 }
+  | str_extension_constructors bar_extension_constructor_rebind
+      { $2 :: $1 }
+;
+sig_extension_constructors:
+    extension_constructor_declaration                     { [$1] }
+  | bar_extension_constructor_declaration                 { [$1] }
+  | sig_extension_constructors bar_extension_constructor_declaration
+      { $2 :: $1 }
+;
+extension_constructor_declaration:
+  | constr_ident generalized_constructor_arguments attributes
+      { let args, res = $2 in
+        Te.decl (mkrhs $1 1) ~args ?res ~attrs:$3
+          ~loc:(symbol_rloc()) ~info:(symbol_info ()) }
+;
+bar_extension_constructor_declaration:
+  | BAR constr_ident generalized_constructor_arguments attributes
+      { let args, res = $3 in
+        Te.decl (mkrhs $2 2) ~args ?res ~attrs:$4
+           ~loc:(symbol_rloc()) ~info:(symbol_info ()) }
+;
+extension_constructor_rebind:
+  | constr_ident EQUAL constr_longident attributes
+      { Te.rebind (mkrhs $1 1) (mkrhs $3 3) ~attrs:$4
+          ~loc:(symbol_rloc()) ~info:(symbol_info ()) }
+;
+bar_extension_constructor_rebind:
+  | BAR constr_ident EQUAL constr_longident attributes
+      { Te.rebind (mkrhs $2 2) (mkrhs $4 4) ~attrs:$5
+          ~loc:(symbol_rloc()) ~info:(symbol_info ()) }
+;
+
+/* "with" constraints (additional type equations over signature components) */
+
+with_constraints:
+    with_constraint                             { [$1] }
+  | with_constraints AND with_constraint        { $3 :: $1 }
+;
+with_constraint:
+    TYPE type_parameters label_longident with_type_binder core_type_no_attr
+    constraints
+      { Pwith_type
+          (mkrhs $3 3,
+           (Type.mk (mkrhs (Longident.last $3) 3)
+              ~params:$2
+              ~cstrs:(List.rev $6)
+              ~manifest:$5
+              ~priv:$4
+              ~loc:(symbol_rloc()))) }
+    /* used label_longident instead of type_longident to disallow
+       functor applications in type path */
+  | TYPE type_parameters label COLONEQUAL core_type_no_attr
+      { Pwith_typesubst
+          (Type.mk (mkrhs $3 3)
+             ~params:$2
+             ~manifest:$5
+             ~loc:(symbol_rloc())) }
+  | MODULE mod_longident EQUAL mod_ext_longident
+      { Pwith_module (mkrhs $2 2, mkrhs $4 4) }
+  | MODULE UIDENT COLONEQUAL mod_ext_longident
+      { Pwith_modsubst (mkrhs $2 2, mkrhs $4 4) }
+;
+with_type_binder:
+    EQUAL          { Public }
+  | EQUAL PRIVATE  { Private }
+;
+
+/* Polymorphic types */
+
+typevar_list:
+        QUOTE ident                             { [mkrhs $2 2] }
+      | typevar_list QUOTE ident                { mkrhs $3 3 :: $1 }
+;
+poly_type:
+        core_type
+          { $1 }
+      | typevar_list DOT core_type
+          { mktyp(Ptyp_poly(List.rev $1, $3)) }
+;
+poly_type_no_attr:
+        core_type_no_attr
+          { $1 }
+      | typevar_list DOT core_type_no_attr
+          { mktyp(Ptyp_poly(List.rev $1, $3)) }
+;
+
+/* Core types */
+
+core_type:
+    core_type_no_attr
+      { $1 }
+  | core_type attribute
+      { Typ.attr $1 $2 }
+;
+core_type_no_attr:
+    core_type2 %prec MINUSGREATER
+      { $1 }
+  | core_type2 AS QUOTE ident
+      { mktyp(Ptyp_alias($1, $4)) }
+;
+core_type2:
+    simple_core_type_or_tuple
+      { $1 }
+  | QUESTION LIDENT COLON core_type2 MINUSGREATER core_type2
+      { let param = extra_rhs_core_type $4 ~pos:4 in
+        mktyp (Ptyp_arrow(Optional $2 , param, $6)) }
+  | OPTLABEL core_type2 MINUSGREATER core_type2
+      { let param = extra_rhs_core_type $2 ~pos:2 in
+        mktyp(Ptyp_arrow(Optional $1 , param, $4))
+      }
+  | LIDENT COLON core_type2 MINUSGREATER core_type2
+      { let param = extra_rhs_core_type $3 ~pos:3 in
+        mktyp(Ptyp_arrow(Labelled $1, param, $5)) }
+  | core_type2 MINUSGREATER core_type2
+      { let param = extra_rhs_core_type $1 ~pos:1 in
+        mktyp(Ptyp_arrow(Nolabel, param, $3)) }
+;
+
+simple_core_type:
+    simple_core_type2  %prec below_HASH
+      { $1 }
+  | LPAREN core_type_comma_list RPAREN %prec below_HASH
+      { match $2 with [sty] -> sty | _ -> raise Parse_error }
+;
+
+simple_core_type2:
+    QUOTE ident
+      { mktyp(Ptyp_var $2) }
+  | UNDERSCORE
+      { mktyp(Ptyp_any) }
+  | type_longident
+      { mktyp(Ptyp_constr(mkrhs $1 1, [])) }
+  | simple_core_type2 type_longident
+      { mktyp(Ptyp_constr(mkrhs $2 2, [$1])) }
+  | LPAREN core_type_comma_list RPAREN type_longident
+      { mktyp(Ptyp_constr(mkrhs $4 4, List.rev $2)) }
+  | LESS meth_list GREATER
+      { let (f, c) = $2 in mktyp(Ptyp_object (f, c)) }
+  | LESS GREATER
+      { mktyp(Ptyp_object ([], Closed)) }
+  | HASH class_longident
+      { mktyp(Ptyp_class(mkrhs $2 2, [])) }
+  | simple_core_type2 HASH class_longident
+      { mktyp(Ptyp_class(mkrhs $3 3, [$1])) }
+  | LPAREN core_type_comma_list RPAREN HASH class_longident
+      { mktyp(Ptyp_class(mkrhs $5 5, List.rev $2)) }
+  | LBRACKET tag_field RBRACKET
+      { mktyp(Ptyp_variant([$2], Closed, None)) }
+/* PR#3835: this is not LR(1), would need lookahead=2
+  | LBRACKET simple_core_type RBRACKET
+      { mktyp(Ptyp_variant([$2], Closed, None)) }
+*/
+  | LBRACKET BAR row_field_list RBRACKET
+      { mktyp(Ptyp_variant(List.rev $3, Closed, None)) }
+  | LBRACKET row_field BAR row_field_list RBRACKET
+      { mktyp(Ptyp_variant($2 :: List.rev $4, Closed, None)) }
+  | LBRACKETGREATER opt_bar row_field_list RBRACKET
+      { mktyp(Ptyp_variant(List.rev $3, Open, None)) }
+  | LBRACKETGREATER RBRACKET
+      { mktyp(Ptyp_variant([], Open, None)) }
+  | LBRACKETLESS opt_bar row_field_list RBRACKET
+      { mktyp(Ptyp_variant(List.rev $3, Closed, Some [])) }
+  | LBRACKETLESS opt_bar row_field_list GREATER name_tag_list RBRACKET
+      { mktyp(Ptyp_variant(List.rev $3, Closed, Some (List.rev $5))) }
+  | LPAREN MODULE ext_attributes package_type RPAREN
+      { mktyp_attrs (Ptyp_package $4) $3 }
+  | extension
+      { mktyp (Ptyp_extension $1) }
+;
+package_type:
+    module_type { package_type_of_module_type $1 }
+;
+row_field_list:
+    row_field                                   { [$1] }
+  | row_field_list BAR row_field                { $3 :: $1 }
+;
+row_field:
+    tag_field                                   { $1 }
+  | simple_core_type                            { Rinherit $1 }
+;
+tag_field:
+    name_tag OF opt_ampersand amper_type_list attributes
+      { Rtag ($1, add_info_attrs (symbol_info ()) $5, $3, List.rev $4) }
+  | name_tag attributes
+      { Rtag ($1, add_info_attrs (symbol_info ()) $2, true, []) }
+;
+opt_ampersand:
+    AMPERSAND                                   { true }
+  | /* empty */                                 { false }
+;
+amper_type_list:
+    core_type_no_attr                           { [$1] }
+  | amper_type_list AMPERSAND core_type_no_attr { $3 :: $1 }
+;
+name_tag_list:
+    name_tag                                    { [$1] }
+  | name_tag_list name_tag                      { $2 :: $1 }
+;
+simple_core_type_or_tuple:
+    simple_core_type { $1 }
+  | simple_core_type STAR core_type_list
+      { mktyp(Ptyp_tuple($1 :: List.rev $3)) }
+;
+core_type_comma_list:
+    core_type                                   { [$1] }
+  | core_type_comma_list COMMA core_type        { $3 :: $1 }
+;
+core_type_list:
+    simple_core_type                            { [$1] }
+  | core_type_list STAR simple_core_type        { $3 :: $1 }
+;
+meth_list:
+    field_semi meth_list                     { let (f, c) = $2 in ($1 :: f, c) }
+  | field_semi                                  { [$1], Closed }
+  | field                                       { [$1], Closed }
+  | DOTDOT                                      { [], Open }
+;
+field:
+  label COLON poly_type_no_attr attributes
+    { (mkrhs $1 1, add_info_attrs (symbol_info ()) $4, $3) }
+;
+
+field_semi:
+  label COLON poly_type_no_attr attributes SEMI attributes
+    { let info =
+        match rhs_info 4 with
+        | Some _ as info_before_semi -> info_before_semi
+        | None -> symbol_info ()
+      in
+      (mkrhs $1 1, add_info_attrs info ($4 @ $6), $3) }
+;
+
+label:
+    LIDENT                                      { $1 }
+;
+
+/* Constants */
+
+constant:
+  | INT          { let (n, m) = $1 in Pconst_integer (n, m) }
+  | CHAR         { Pconst_char $1 }
+  | STRING       { let (s, d) = $1 in Pconst_string (s, d) }
+  | FLOAT        { let (f, m) = $1 in Pconst_float (f, m) }
+;
+signed_constant:
+    constant     { $1 }
+  | MINUS INT    { let (n, m) = $2 in Pconst_integer("-" ^ n, m) }
+  | MINUS FLOAT  { let (f, m) = $2 in Pconst_float("-" ^ f, m) }
+  | PLUS INT     { let (n, m) = $2 in Pconst_integer (n, m) }
+  | PLUS FLOAT   { let (f, m) = $2 in Pconst_float(f, m) }
+;
+
+/* Identifiers and long identifiers */
+
+ident:
+    UIDENT                                      { $1 }
+  | LIDENT                                      { $1 }
+;
+val_ident:
+    LIDENT                                      { $1 }
+  | LPAREN operator RPAREN                      { $2 }
+  | LPAREN operator error                       { unclosed "(" 1 ")" 3 }
+  | LPAREN error                                { expecting 2 "operator" }
+  | LPAREN MODULE error                         { expecting 3 "module-expr" }
+;
+operator:
+    PREFIXOP                                    { $1 }
+  | INFIXOP0                                    { $1 }
+  | INFIXOP1                                    { $1 }
+  | INFIXOP2                                    { $1 }
+  | INFIXOP3                                    { $1 }
+  | INFIXOP4                                    { $1 }
+  | HASHOP                                     { $1 }
+  | BANG                                        { "!" }
+  | PLUS                                        { "+" }
+  | PLUSDOT                                     { "+." }
+  | MINUS                                       { "-" }
+  | MINUSDOT                                    { "-." }
+  | STAR                                        { "*" }
+  | EQUAL                                       { "=" }
+  | LESS                                        { "<" }
+  | GREATER                                     { ">" }
+  | OR                                          { "or" }
+  | BARBAR                                      { "||" }
+  | AMPERSAND                                   { "&" }
+  | AMPERAMPER                                  { "&&" }
+  | COLONEQUAL                                  { ":=" }
+  | PLUSEQ                                      { "+=" }
+  | PERCENT                                     { "%" }
+;
+constr_ident:
+    UIDENT                                      { $1 }
+  | LBRACKET RBRACKET                           { "[]" }
+  | LPAREN RPAREN                               { "()" }
+  /* | COLONCOLON                               { "::" } */
+  | LPAREN COLONCOLON RPAREN                    { "::" }
+  | FALSE                                       { "false" }
+  | TRUE                                        { "true" }
+;
+
+val_longident:
+    val_ident                                   { Lident $1 }
+  | mod_longident DOT val_ident                 { Ldot($1, $3) }
+;
+constr_longident:
+    mod_longident       %prec below_DOT         { $1 }
+  | LBRACKET RBRACKET                           { Lident "[]" }
+  | LPAREN RPAREN                               { Lident "()" }
+  | FALSE                                       { Lident "false" }
+  | TRUE                                        { Lident "true" }
+;
+label_longident:
+    LIDENT                                      { Lident $1 }
+  | mod_longident DOT LIDENT                    { Ldot($1, $3) }
+;
+type_longident:
+    LIDENT                                      { Lident $1 }
+  | mod_ext_longident DOT LIDENT                { Ldot($1, $3) }
+;
+mod_longident:
+    UIDENT                                      { Lident $1 }
+  | mod_longident DOT UIDENT                    { Ldot($1, $3) }
+;
+mod_ext_longident:
+    UIDENT                                      { Lident $1 }
+  | mod_ext_longident DOT UIDENT                { Ldot($1, $3) }
+  | mod_ext_longident LPAREN mod_ext_longident RPAREN { lapply $1 $3 }
+;
+mty_longident:
+    ident                                       { Lident $1 }
+  | mod_ext_longident DOT ident                 { Ldot($1, $3) }
+;
+clty_longident:
+    LIDENT                                      { Lident $1 }
+  | mod_ext_longident DOT LIDENT                { Ldot($1, $3) }
+;
+class_longident:
+    LIDENT                                      { Lident $1 }
+  | mod_longident DOT LIDENT                    { Ldot($1, $3) }
+;
+
+/* Toplevel directives */
+
+toplevel_directive:
+    HASH ident                 { Ptop_dir($2, Pdir_none) }
+  | HASH ident STRING          { Ptop_dir($2, Pdir_string (fst $3)) }
+  | HASH ident INT             { let (n, m) = $3 in
+                                  Ptop_dir($2, Pdir_int (n ,m)) }
+  | HASH ident val_longident   { Ptop_dir($2, Pdir_ident $3) }
+  | HASH ident mod_longident   { Ptop_dir($2, Pdir_ident $3) }
+  | HASH ident FALSE           { Ptop_dir($2, Pdir_bool false) }
+  | HASH ident TRUE            { Ptop_dir($2, Pdir_bool true) }
+;
+
+/* Miscellaneous */
+
+name_tag:
+    BACKQUOTE ident                             { $2 }
+;
+rec_flag:
+    /* empty */                                 { Nonrecursive }
+  | REC                                         { Recursive }
+;
+nonrec_flag:
+    /* empty */                                 { Recursive }
+  | NONREC                                      { Nonrecursive }
+;
+direction_flag:
+    TO                                          { Upto }
+  | DOWNTO                                      { Downto }
+;
+private_flag:
+    /* empty */                                 { Public }
+  | PRIVATE                                     { Private }
+;
+mutable_flag:
+    /* empty */                                 { Immutable }
+  | MUTABLE                                     { Mutable }
+;
+virtual_flag:
+    /* empty */                                 { Concrete }
+  | VIRTUAL                                     { Virtual }
+;
+private_virtual_flags:
+    /* empty */  { Public, Concrete }
+  | PRIVATE { Private, Concrete }
+  | VIRTUAL { Public, Virtual }
+  | PRIVATE VIRTUAL { Private, Virtual }
+  | VIRTUAL PRIVATE { Private, Virtual }
+;
+override_flag:
+    /* empty */                                 { Fresh }
+  | BANG                                        { Override }
+;
+opt_bar:
+    /* empty */                                 { () }
+  | BAR                                         { () }
+;
+opt_semi:
+  | /* empty */                                 { () }
+  | SEMI                                        { () }
+;
+subtractive:
+  | MINUS                                       { "-" }
+  | MINUSDOT                                    { "-." }
+;
+additive:
+  | PLUS                                        { "+" }
+  | PLUSDOT                                     { "+." }
+;
+
+/* Attributes and extensions */
+
+single_attr_id:
+    LIDENT { $1 }
+  | UIDENT { $1 }
+  | AND { "and" }
+  | AS { "as" }
+  | ASSERT { "assert" }
+  | BEGIN { "begin" }
+  | CLASS { "class" }
+  | CONSTRAINT { "constraint" }
+  | DO { "do" }
+  | DONE { "done" }
+  | DOWNTO { "downto" }
+  | ELSE { "else" }
+  | END { "end" }
+  | EXCEPTION { "exception" }
+  | EXTERNAL { "external" }
+  | FALSE { "false" }
+  | FOR { "for" }
+  | FUN { "fun" }
+  | FUNCTION { "function" }
+  | FUNCTOR { "functor" }
+  | IF { "if" }
+  | IN { "in" }
+  | INCLUDE { "include" }
+  | INHERIT { "inherit" }
+  | INITIALIZER { "initializer" }
+  | LAZY { "lazy" }
+  | LET { "let" }
+  | MATCH { "match" }
+  | METHOD { "method" }
+  | MODULE { "module" }
+  | MUTABLE { "mutable" }
+  | NEW { "new" }
+  | NONREC { "nonrec" }
+  | OBJECT { "object" }
+  | OF { "of" }
+  | OPEN { "open" }
+  | OR { "or" }
+  | PRIVATE { "private" }
+  | REC { "rec" }
+  | SIG { "sig" }
+  | STRUCT { "struct" }
+  | THEN { "then" }
+  | TO { "to" }
+  | TRUE { "true" }
+  | TRY { "try" }
+  | TYPE { "type" }
+  | VAL { "val" }
+  | VIRTUAL { "virtual" }
+  | WHEN { "when" }
+  | WHILE { "while" }
+  | WITH { "with" }
+/* mod/land/lor/lxor/lsl/lsr/asr are not supported for now */
+;
+
+attr_id:
+    single_attr_id { mkloc $1 (symbol_rloc()) }
+  | single_attr_id DOT attr_id { mkloc ($1 ^ "." ^ $3.txt) (symbol_rloc())}
+;
+attribute:
+  LBRACKETAT attr_id payload RBRACKET { ($2, $3) }
+;
+post_item_attribute:
+  LBRACKETATAT attr_id payload RBRACKET { ($2, $3) }
+;
+floating_attribute:
+  LBRACKETATATAT attr_id payload RBRACKET { ($2, $3) }
+;
+post_item_attributes:
+    /* empty */  { [] }
+  | post_item_attribute post_item_attributes { $1 :: $2 }
+;
+attributes:
+    /* empty */{ [] }
+  | attribute attributes { $1 :: $2 }
+;
+ext_attributes:
+    /* empty */  { None, [] }
+  | attribute attributes { None, $1 :: $2 }
+  | PERCENT attr_id attributes { Some $2, $3 }
+;
+extension:
+  LBRACKETPERCENT attr_id payload RBRACKET { ($2, $3) }
+;
+item_extension:
+  LBRACKETPERCENTPERCENT attr_id payload RBRACKET { ($2, $3) }
+;
+payload:
+    structure { PStr $1 }
+  | COLON signature { PSig $2 }
+  | COLON core_type { PTyp $2 }
+  | QUESTION pattern { PPat ($2, None) }
+  | QUESTION pattern WHEN seq_expr { PPat ($2, Some $4) }
+;
+%%

--- a/tools/liquidity/ocaml/liquidOCamlPrinter.ml
+++ b/tools/liquidity/ocaml/liquidOCamlPrinter.ml
@@ -1567,10 +1567,14 @@ let string_of_expression x =
   expression f x;
   flush_str_formatter ()
 
-let string_of_structure x =
+let string_of_structure str =
   ignore (flush_str_formatter ());
-  let f = str_formatter in
-  structure reset_ctxt f x;
+  let ppf = str_formatter in
+  if !LiquidOptions.ocaml_syntax then
+    structure reset_ctxt ppf str
+  else
+    Reason_toolchain.RE.print_implementation_with_comments ppf
+      (Reason_toolchain.From_current.copy_structure str,[]);
   flush_str_formatter ()
 
 let top_phrase f x =

--- a/tools/liquidity/ocaml/liquidOCamlPrinter.mli
+++ b/tools/liquidity/ocaml/liquidOCamlPrinter.mli
@@ -1,0 +1,4 @@
+
+val contract_ast : Parsetree.structure -> string
+val string_of_structure : Parsetree.structure -> string
+val string_of_expression : Parsetree.expression -> string

--- a/tools/liquidity/reason/lexer_warning.ml
+++ b/tools/liquidity/reason/lexer_warning.ml
@@ -1,0 +1,5 @@
+let warn_latin1 lexbuf =
+  let loc = Location.curr lexbuf in
+  Location.prerr_warning loc
+  (Warnings.Deprecated ("ISO-Latin1 characters in identifiers",loc,loc) )
+;;

--- a/tools/liquidity/reason/reason_attributes.ml
+++ b/tools/liquidity/reason/reason_attributes.ml
@@ -1,0 +1,84 @@
+open Ast_404
+open Location
+open Parsetree
+
+(** Kinds of attributes *)
+type attributesPartition = {
+  arityAttrs : attributes;
+  docAttrs : attributes;
+  stdAttrs : attributes;
+  jsxAttrs : attributes;
+  stylisticAttrs : attributes;
+  uncurried : bool
+}
+
+(** Partition attributes into kinds *)
+let rec partitionAttributes ?(partDoc=false) ?(allowUncurry=true) attrs : attributesPartition =
+  match attrs with
+  | [] ->
+    {arityAttrs=[]; docAttrs=[]; stdAttrs=[]; jsxAttrs=[]; stylisticAttrs=[]; uncurried = false}
+  | (({txt = "bs"}, PStr []) as attr)::atTl ->
+    let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
+    if allowUncurry then
+      {partition with uncurried = true}
+    else {partition with stdAttrs=attr::partition.stdAttrs}
+  | (({txt="JSX"}, _) as jsx)::atTl ->
+    let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
+    {partition with jsxAttrs=jsx::partition.jsxAttrs}
+  | (({txt="explicit_arity"}, _) as arity_attr)::atTl
+  | (({txt="implicit_arity"}, _) as arity_attr)::atTl ->
+    let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
+    {partition with arityAttrs=arity_attr::partition.arityAttrs}
+  | (({txt="ocaml.text"}, _) as doc)::atTl when partDoc = true ->
+    let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
+    {partition with docAttrs=doc::partition.docAttrs}
+  | (({txt="ocaml.doc"}, _) as doc)::atTl when partDoc = true ->
+    let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
+    {partition with docAttrs=doc::partition.docAttrs}
+  | (({txt="reason.raw_literal"}, _) as attr) :: atTl ->
+    let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
+    {partition with stylisticAttrs=attr::partition.stylisticAttrs}
+  | (({txt="reason.preserve_braces"}, _) as attr) :: atTl ->
+    let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
+    {partition with stylisticAttrs=attr::partition.stylisticAttrs}
+  | atHd :: atTl ->
+    let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
+    {partition with stdAttrs=atHd::partition.stdAttrs}
+
+let extractStdAttrs attrs =
+  (partitionAttributes attrs).stdAttrs
+
+let extract_raw_literal attrs =
+  let rec loop acc = function
+    | ({txt="reason.raw_literal"},
+       PStr [{pstr_desc = Pstr_eval({pexp_desc = Pexp_constant(Pconst_string(text, None))}, _)}])
+      :: rest ->
+      (Some text, List.rev_append acc rest)
+    | [] -> (None, List.rev acc)
+    | attr :: rest -> loop (attr :: acc) rest
+  in
+  loop [] attrs
+
+let without_stylistic_attrs attrs =
+  let rec loop acc = function
+    | attr :: rest when (partitionAttributes [attr]).stylisticAttrs != [] ->
+        loop acc rest
+    | [] -> List.rev acc
+    | attr :: rest -> loop (attr :: acc) rest
+  in
+  loop [] attrs
+
+let is_preserve_braces_attr ({txt}, _) =
+  txt = "reason.preserve_braces"
+
+let has_preserve_braces_attrs stylisticAttrs =
+  (List.filter is_preserve_braces_attr stylisticAttrs) != []
+
+let maybe_remove_stylistic_attrs attrs should_preserve =
+  if should_preserve then
+    attrs
+  else
+    List.filter (function
+      | ({txt="reason.raw_literal"}, _) -> true
+      | _ -> false)
+      attrs

--- a/tools/liquidity/reason/reason_comment.ml
+++ b/tools/liquidity/reason/reason_comment.ml
@@ -1,0 +1,56 @@
+open Location
+
+type category =
+  | EndOfLine
+  | SingleLine
+  | Regular
+
+let string_of_category = function
+  | Regular -> "Regular"
+  | EndOfLine -> "End of Line"
+  | SingleLine -> "SingleLine"
+
+type t = {
+  location: Location.t;
+  category: category;
+  text: string;
+}
+
+let category t = t.category
+
+let location t = t.location
+
+let dump ppf t =
+  Format.fprintf ppf "%d (%d:%d)-%d (%d:%d) -- %s:||%s||"
+    t.location.loc_start.pos_cnum
+    t.location.loc_start.pos_lnum
+    (t.location.loc_start.pos_cnum - t.location.loc_start.pos_bol)
+    t.location.loc_end.pos_cnum
+    t.location.loc_end.pos_lnum
+    (t.location.loc_end.pos_cnum - t.location.loc_end.pos_bol)
+    (string_of_category t.category)
+    t.text
+
+let dump_list ppf list =
+  List.iter (Format.fprintf ppf "%a\n" dump) list
+
+let wrap t =
+  match t.text with
+  | "" | "*" -> "/***/"
+  | txt when Reason_syntax_util.isLineComment txt ->
+    "//"
+    (* single line comments of the form `// comment` have a `\n` at the end *)
+    ^ (String.sub txt 0 (String.length txt - 1))
+    ^ Reason_syntax_util.EOLMarker.string
+  | txt when txt.[0] = '*' && txt.[1] <> '*' -> "/**" ^ txt ^ "*/"
+  | txt -> "/*" ^ txt ^ "*/"
+
+let is_doc t =
+  String.length t.text > 0 && t.text.[0] == '*'
+
+let make ~location category text =
+  { text; category; location }
+
+let isLineComment {category; text} = match category with
+  | SingleLine -> Reason_syntax_util.isLineComment text
+  | EndOfLine | Regular -> false

--- a/tools/liquidity/reason/reason_config.ml
+++ b/tools/liquidity/reason/reason_config.ml
@@ -1,0 +1,12 @@
+(**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *)
+ 
+let recoverable = ref false
+
+let configure ~r = (
+  recoverable := r;
+)

--- a/tools/liquidity/reason/reason_heuristics.ml
+++ b/tools/liquidity/reason/reason_heuristics.ml
@@ -1,0 +1,138 @@
+let is_punned_labelled_expression e lbl =
+  let open Ast_404.Parsetree in
+  match e.pexp_desc with
+  | Pexp_ident { txt }
+  | Pexp_constraint ({pexp_desc = Pexp_ident { txt }}, _)
+  | Pexp_coerce ({pexp_desc = Pexp_ident { txt }}, _, _)
+    -> txt = Longident.parse lbl
+  | _ -> false
+
+(* We manually check the length of `Thing.map(foo, bar, baz`,
+ * in `Thing.map(foo, bar, baz, (a) => doStuff(a))`
+ * because Easyformat doesn't have a hook to change printing when a list breaks
+ *
+ * we check if all arguments aside from the final one are either strings or identifiers,
+ * where the sum of the string contents and identifier names are less than the print width
+ *)
+let funAppCallbackExceedsWidth ~printWidth ~args ~funExpr () =
+  let open Ast_404.Parsetree in
+  let open Ast_404.Asttypes in
+  let funLen = begin match funExpr.pexp_desc with
+    | Pexp_ident ident ->
+       let identList = Longident.flatten ident.txt in
+       let lengthOfDots = List.length identList - 1 in
+       let len = List.fold_left (fun acc curr ->
+         acc + (String.length curr)) lengthOfDots identList in
+       len
+    | _ -> -1
+  end in
+  (* eats an argument & substract its length from the printWidth
+   * as soon as the print width reaches a sub-zero value,
+   * we know the print width is exceeded & returns *)
+  let rec aux len = function
+    | _ when len < 0 -> true
+    | [] -> false
+    | arg::args ->
+      begin match arg with
+      | (label, ({ pexp_desc = Pexp_ident ident } as e)) ->
+        let identLen = List.fold_left (fun acc curr ->
+          acc + (String.length curr)
+        ) len (Longident.flatten ident.txt) in
+        begin match label with
+        | Nolabel -> aux (len - identLen) args
+        | Labelled s when is_punned_labelled_expression e s ->
+            aux (len - (identLen + 1)) args
+        | Labelled s ->
+            aux (len - (identLen + 2 + String.length s)) args
+        | Optional s ->
+            aux (len - (identLen + 3 + String.length s)) args
+        end
+      | (label, {pexp_desc = Pexp_constant (Pconst_string (str, _))}) ->
+        let strLen = String.length str in
+        begin match label with
+        | Nolabel -> aux (len - strLen) args
+        | Labelled s ->
+            aux (len - (strLen + 2 + String.length s)) args
+        | Optional s ->
+            aux (len - (strLen + 3 + String.length s)) args
+        end
+      | _ ->
+        (* if we encounter a non-string or non-identifier argument exit *)
+          true
+    end
+  in
+  aux (printWidth - funLen) args
+
+(*
+ * Whether or not an identiier is small enough to justify omitting the
+ * trailing comma for single identifier patterns. For single identifier
+ * patterns, usually the identifier is not "far right" in the document, and
+ * is one of the last things to require breaking. We can omit the trailing comma
+ * in these cases because it likely will never render anyways and therefore the
+ * space taken up by the trailing comma doesn't disrupt wrapping length calculations.
+ *
+ * For example, the `X` hardly ever benefits from a trailing comma.
+ * | X(y) =>
+ *)
+let singleTokenPatternOmmitTrail txt = String.length txt < 4
+
+(* Indicates whether an expression can be printed with the uncurried
+ * dot notation. At the moment uncurried function application & definition
+ * only makes sense in the context of a Pexp_apply or Pexp_fun
+ *
+ * Examples:
+ * [@bs] add(2, 3); -> add(. 2, 3);   (* Pexp_apply *)
+ * setTimeout([@bs] () => Js.log("hola"), 1000);  (* Pexp_fun *)
+ *  -> setTimeout((.) => Js.log("hola"), 1000);
+ *)
+let bsExprCanBeUncurried expr =
+  match Ast_404.Parsetree.(expr.pexp_desc) with
+  | Pexp_fun _
+  | Pexp_apply _ -> true
+  | _ -> false
+
+let isUnderscoreIdent expr =
+  match Ast_404.Parsetree.(expr.pexp_desc) with
+  | Pexp_ident ({txt = Lident "_"}) -> true
+  | _ -> false
+
+let isPipeFirst e = match Ast_404.Parsetree.(e.pexp_desc) with
+  | Pexp_ident({txt = Longident.Lident("|.")}) -> true
+  | Pexp_apply(
+    {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+      _
+    ) -> true
+  | _ -> false
+
+let isUnderscoreApplication expr =
+  let open Ast_404.Parsetree in
+  match expr with
+  | {pexp_attributes = []; pexp_desc = Pexp_fun(
+        Nolabel,
+        None,
+        {
+          ppat_desc = Ppat_var({txt = "__x"});
+          ppat_attributes = []
+        },
+        _
+      )
+    } -> true
+  | _ -> false
+
+(* <div> {items->Belt.Array.map(ReasonReact.string)->ReasonReact.array} </div>;
+ * An application with pipe first inside jsx children requires special treatment.
+ * Jsx children don't allow expression application, hence we need the braces
+ * preserved in this case. *)
+let isPipeFirstWithNonSimpleJSXChild e = match Ast_404.Parsetree.(e.pexp_desc) with
+  | Pexp_apply(
+    {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+      [Nolabel, {pexp_desc = Pexp_apply(_)}; _]
+    ) -> true
+
+  (* Handle <div> {url->a(b, _)} </div>;
+   * underscore sugar needs protection *)
+  | Pexp_apply(
+    {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+      [_; Nolabel, fe]
+    ) when isUnderscoreApplication fe -> true
+  | _ -> false

--- a/tools/liquidity/reason/reason_layout.ml
+++ b/tools/liquidity/reason/reason_layout.ml
@@ -1,0 +1,292 @@
+module Comment = Reason_comment
+module Range = Reason_location.Range
+
+type break_criterion =
+  | Never
+  | IfNeed
+  | Always
+  (* Always_rec not only will break, it will break recursively up to the root *)
+  | Always_rec
+
+(*
+ Modeling separators:
+  Special ability to render the final separator distinctly. This is so we can
+  replace them when they do/don't occur next to newlines.
+
+    If sepLeft:true
+    {
+      final item1
+      sep   item2
+      sep   item3
+    }
+
+    If sepLeft:false
+    {
+      item1 sep
+      item2 sep
+      item3 final
+    }
+*)
+(* You can't determine the final separator unless you specify a separator *)
+type separator =
+  | NoSep
+  | Sep of string
+  | SepFinal of string * string
+
+(**
+ * Module concerning info to correctly interleave whitespace above a layout node.
+ *)
+module WhitespaceRegion = struct
+  type t = {
+    (* range of the region *)
+    range: Range.t;
+    (* inserted comments into the whitespace region *)
+    comments: Comment.t list;
+    (* amount of newlines to be interleaved *)
+    newlines: int;
+  }
+
+  let make ~range ~newlines () = {
+    range;
+    comments = [];
+    newlines;
+  }
+
+  let newlines t = t.newlines
+  let range t = t.range
+  let comments t = t.comments
+
+  let addComment t comment = { t with
+    comments = comment::t.comments
+  }
+
+  let modifyNewlines t newNewlines = { t with
+    newlines = newNewlines
+  }
+end
+
+(**
+ * These represent "intent to format" the AST, with some parts being annotated
+ * with original source location. The benefit of tracking this in an
+ * intermediate structure, is that we can then interleave comments throughout
+ * the tree before generating the final representation. That prevents the
+ * formatting code from having to thread comments everywhere.
+ *
+ * The final representation is rendered using Easy_format.
+ *)
+type t =
+  | SourceMap of Location.t * t (* a layout with location info *)
+  | Sequence of config * (t list)
+  | Label of (Easy_format.t -> Easy_format.t -> Easy_format.t) * t * t
+  | Easy of Easy_format.t
+  (* Extra variant representing "intent to interleave whitespace" above a
+   * layout node. Why the extra representation?
+   * Since comments get interleaved after formatting the ast,
+   * the inserting of actual newlines has to happen after the comments
+   * have been formatted/inserted. *)
+  | Whitespace of WhitespaceRegion.t * t
+
+and config = {
+  break: break_criterion;
+  (* Break setting that becomes activated if a comment becomes interleaved into
+   * this list. Typically, if not specified, the behavior from [break] will be
+   * used.
+   *)
+  wrap: string * string;
+  inline: bool * bool;
+  sep: separator;
+  indent: int;
+  sepLeft: bool;
+  preSpace: bool;
+  (* Really means space_after_separator *)
+  postSpace: bool;
+  pad: bool * bool;
+  (* A function, because the system might rearrange your previous settings, and
+   * a function allows you to not be locked into some configuration that is made
+   * out of date by the formatting system (suppose it removes the separator
+   * token etc.) Having a function allows you to instruct our formatter how to
+   * extend the "freshest" notion of the list config when comments are
+   * interleaved. *)
+  listConfigIfCommentsInterleaved: (config -> config) option;
+
+  (* Formatting to use if an item in a list had an end-of-line comment appended *)
+  listConfigIfEolCommentsInterleaved: (config -> config) option;
+}
+
+let string_of_easy = function
+  | Easy_format.Atom (s,_) -> s
+  | Easy_format.List (_,_) -> "list"
+  | Easy_format.Label (_,_) -> "label"
+  | Easy_format.Custom _ -> "custom"
+
+let indent_more indent = "  " ^ indent
+
+let dump_easy ppf easy =
+  let printf fmt = Format.fprintf ppf fmt in
+  let rec traverse indent = function
+    | Easy_format.Atom (s,_) ->
+      printf "%s Atom:'%s'\n" indent s
+    | Easy_format.List ((opening, sep, closing, config), items) ->
+      let break = (match config.wrap_body with
+          | `No_breaks -> "No_breaks"
+          | `Wrap_atoms -> "Wrap_atoms"
+          | `Never_wrap -> "Never_wrap"
+          | `Force_breaks -> "Force_breaks"
+          | `Force_breaks_rec -> "Force_breaks_rec"
+          | `Always_wrap -> "Always_wrap") in
+      printf "%s List: open %s close %s sep %s break %s \n"
+        indent opening closing sep break;
+      let _ = List.map (traverse (indent_more indent)) items in
+      ()
+    | Easy_format.Label ((left, config), right) ->
+      let break = match config.label_break with
+        | `Never -> "Never"
+        | `Always_rec -> "Always_rec"
+        | `Auto -> "Auto"
+        | `Always -> "Always" in
+      printf "%s Label (break = %s): \n" indent break;
+      printf "  %s left \n" indent;
+      let indent' = indent_more indent in
+      traverse indent' left;
+      printf "  %s right \n" indent;
+      traverse indent' right;
+    | Easy_format.Custom _ ->
+      printf "custom \n"
+  in
+  traverse "" easy
+
+let dump ppf layout =
+  let printf fmt = Format.fprintf ppf fmt in
+  let rec traverse indent = function
+    | SourceMap (loc, layout) ->
+      printf "%s SourceMap [(%d:%d)-(%d:%d)]\n" indent
+        loc.loc_start.Lexing.pos_lnum
+        (loc.loc_start.Lexing.pos_cnum - loc.loc_start.Lexing.pos_bol)
+        loc.loc_end.Lexing.pos_lnum
+        (loc.loc_end.Lexing.pos_cnum - loc.loc_end.Lexing.pos_bol);
+      traverse (indent_more indent) layout
+    | Sequence (config, layout_list) ->
+      let break = match config.break with
+        | Never  -> "Never"
+        | IfNeed  -> "if need"
+        | Always  -> "Always"
+        | Always_rec  -> "Always_rec" in
+      let sep = match config.sep with
+        | NoSep -> "NoSep"
+        | Sep s -> "Sep '" ^ s ^ "'"
+        | SepFinal (s, finalSep) -> "SepFinal ('" ^ s ^ "', '" ^ finalSep ^ "')" in
+      printf "%s Sequence of %d, sep: %s, stick_to_left: %s break: %s\n"
+        indent (List.length layout_list) sep (string_of_bool config.sepLeft) break;
+      List.iter (traverse (indent_more indent)) layout_list
+    | Label (_, left, right) ->
+      printf "%s Label: \n" indent;
+      printf "  %s left \n" indent;
+      let indent' = indent_more (indent_more indent) in
+      traverse indent' left;
+      printf "  %s right \n" indent;
+      traverse indent' right;
+    | Easy e ->
+      printf "%s Easy: '%s' \n" indent (string_of_easy e)
+    | Whitespace (region, sublayout) ->
+      let open WhitespaceRegion in
+      printf" %s Whitespace (%d) [%d %d]:\n" indent region.newlines region.range.lnum_start region.range.lnum_end;
+      (traverse (indent_more indent) sublayout)
+  in
+  traverse "" layout
+
+let source_map ?(loc=Location.none) layout =
+  if loc = Location.none then layout
+  else SourceMap (loc, layout)
+
+let default_list_settings = {
+  Easy_format.space_after_opening = false;
+  space_after_separator = false;
+  space_before_separator = false;
+  separators_stick_left = true;
+  space_before_closing = false;
+  stick_to_label = true;
+  align_closing = true;
+  wrap_body = `No_breaks;
+  indent_body = 0;
+  list_style = Some "list";
+  opening_style = None;
+  body_style = None;
+  separator_style = None;
+  closing_style = None;
+}
+
+let easy_settings_from_config
+    { break; wrap; inline; indent; preSpace; postSpace; pad; sep } =
+  (* TODO: Stop handling separators in Easy_format since we handle most of
+      them before Easy_format anyways. There's just some that we still rely on
+      Easy_format for. Easy_format's sep wasn't powerful enough.
+  *)
+  let (opn, cls) = wrap in
+  let (padOpn, padCls) = pad in
+  let (inlineStart, inlineEnd) = inline in
+  let sepStr = match sep with NoSep -> "" | Sep s | SepFinal(s, _) -> s in
+  (opn, sepStr, cls,
+   { default_list_settings with
+     Easy_format.
+     wrap_body = (match break with
+         | Never -> `No_breaks
+         (* Yes, `Never_wrap is a horrible name - really means "if needed". *)
+         | IfNeed -> `Never_wrap
+         | Always -> `Force_breaks
+         | Always_rec -> `Force_breaks_rec
+       );
+     indent_body = indent;
+     space_after_separator = postSpace;
+     space_before_separator = preSpace;
+     space_after_opening = padOpn;
+     space_before_closing = padCls;
+     stick_to_label = inlineStart;
+     align_closing = not inlineEnd;
+   })
+
+let to_easy_format layout =
+  let rec traverse = function
+    | Sequence (config, sublayouts) ->
+      let items = List.map traverse sublayouts in
+      Easy_format.List (easy_settings_from_config config, items)
+    | Label (labelFormatter, left, right) ->
+      labelFormatter (traverse left) (traverse right)
+    | SourceMap (_, subLayout) ->
+      traverse subLayout
+    | Easy e -> e
+    | Whitespace (_, subLayout) ->
+      traverse subLayout
+  in
+  traverse layout
+
+(** [getLocFromLayout] recursively takes the unioned location of its children,
+ *  and returns the max one *)
+let get_location layout =
+  let union loc1 loc2 =
+    match (loc1, loc2) with
+    | None, _ -> loc2
+    | _, None -> loc1
+    | Some loc1, Some loc2  ->
+      Some {loc1 with Location.loc_end = loc2.Location.loc_end}
+  in
+  let rec traverse = function
+    | Sequence (_, subLayouts) ->
+      let locs = List.map traverse subLayouts in
+      List.fold_left union None locs
+    | Label (_, left, right) ->
+      union (traverse left) (traverse right)
+    | SourceMap (loc, _) -> Some loc
+    | Whitespace(_, sub) -> traverse sub
+    | _ -> None
+  in
+  traverse layout
+
+let is_before ~location layout =
+  match get_location layout with
+  | None -> true
+  | Some loc -> Reason_syntax_util.location_is_before loc location
+
+let contains_location layout ~location =
+  match get_location layout with
+  | None -> false
+  | Some layout_loc -> Reason_syntax_util.location_contains layout_loc location

--- a/tools/liquidity/reason/reason_lexer.mll
+++ b/tools/liquidity/reason/reason_lexer.mll
@@ -1,0 +1,1219 @@
+(*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *  Forked from OCaml, which is provided under the license below:
+ *
+ *  Xavier Leroy, projet Cristal, INRIA Rocquencourt
+ *
+ *  Copyright © 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006 Inria
+ *
+ *  Permission is hereby granted, free of charge, to the Licensee obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense
+ *  under any license of the Licensee's choice, and/or sell copies of the
+ *  Software, subject to the following conditions:
+ *
+ *  1.	Redistributions of source code must retain the above copyright notice
+ *  and the following disclaimer.
+ *  2.	Redistributions in binary form must reproduce the above copyright
+ *  notice, the following disclaimer in the documentation and/or other
+ *  materials provided with the distribution.
+ *  3.	All advertising materials mentioning features or use of the Software
+ *  must display the following acknowledgement: This product includes all or
+ *  parts of the Caml system developed by Inria and its contributors.
+ *  4.	Other than specified in clause 3, neither the name of Inria nor the
+ *  names of its contributors may be used to endorse or promote products
+ *  derived from the Software without specific prior written permission.
+ *
+ *  Disclaimer
+ *
+ *  This software is provided by Inria and contributors “as is” and any express
+ *  or implied warranties, including, but not limited to, the implied
+ *  warranties of merchantability and fitness for a particular purpose are
+ *  disclaimed. in no event shall Inria or its contributors be liable for any
+ *  direct, indirect, incidental, special, exemplary, or consequential damages
+ *  (including, but not limited to, procurement of substitute goods or
+ *  services; loss of use, data, or profits; or business interruption) however
+ *  caused and on any theory of liability, whether in contract, strict
+ *  liability, or tort (including negligence or otherwise) arising in any way
+ *  out of the use of this software, even if advised of the possibility of such
+ *  damage.
+ *
+ *)
+
+(* This is the Reason lexer. As stated in src/README, there's a good section in
+  Real World OCaml that describes what a lexer is:
+
+  https://realworldocaml.org/v1/en/html/parsing-with-ocamllex-and-menhir.html
+
+  Basically, it uses regular expressions to first cut the big code string into
+  more meaningful chunks, called tokens. For example, it cuts the string
+
+    let foo = 1
+
+  into `let`, `foo`, `=` and `1`, massage them a bit into nice variants, then
+  send the data structures into the parser `reason_parser.mly`, which takes
+  care of the next step (turning the stream of tokens into an AST, abstract
+  syntax tree).
+
+  The file's syntax's a bit special. It's not the conventional OCaml syntax. An
+  ordinary language syntax isn't expressive/convenient enough for a lexer. This
+  mll ("ml lexer") syntax is a fine-tuned variation of the usual OCaml syntax.
+ *)
+
+{
+
+
+  (* Liquidity *)
+let tez_char = '\231'
+let timestamp_char = '\232'
+let keyhash_char = '\233'
+let key_char = '\234'
+let signature_char = '\235'
+let contract_char = '\236'
+let bytes_char = '\237'
+
+open Lexing
+open Reason_parser
+open Lexer_warning
+
+type error =
+  | Illegal_character of char
+  | Illegal_escape of string
+  | Unterminated_comment of Location.t
+  | Unterminated_string
+  | Unterminated_string_in_comment of Location.t * Location.t
+  | Keyword_as_label of string
+  | Literal_overflow of string
+  | Invalid_literal of string
+;;
+
+exception Error of error * Location.t;;
+
+(* The table of keywords *)
+
+let keyword_table, reverse_keyword_table =
+  let create_hashtable n l =
+    let t = Hashtbl.create n in
+    let rev_t = Hashtbl.create n in
+    List.iter (fun (k, v) ->
+      Hashtbl.add t k v;
+      Hashtbl.add rev_t v k;
+    ) l;
+    t, rev_t
+  in
+  create_hashtable 149 [
+    "and", AND;
+    "as", AS;
+    "assert", ASSERT;
+    "begin", BEGIN;
+    "class", CLASS;
+    "constraint", CONSTRAINT;
+    "do", DO;
+    "done", DONE;
+    "downto", DOWNTO;
+    "else", ELSE;
+    "end", END;
+    "exception", EXCEPTION;
+    "external", EXTERNAL;
+    "false", FALSE;
+    "for", FOR;
+    "fun", FUN;
+    "esfun", ES6_FUN;
+    "function", FUNCTION;
+    "functor", FUNCTOR;
+    "if", IF;
+    "in", IN;
+    "include", INCLUDE;
+    "inherit", INHERIT;
+    "initializer", INITIALIZER;
+    "lazy", LAZY;
+    "let", LET;
+    "switch", SWITCH;
+    "contract", MODULE; (* LIQUIDITY *)
+    "pub", PUB;
+    "mutable", MUTABLE;
+    "new", NEW;
+    "nonrec", NONREC;
+    "object", OBJECT;
+    "of", OF;
+    "open", OPEN;
+    "or", OR;
+(*  "parser", PARSER; *)
+    "pri", PRI;
+    "rec", REC;
+    "sig", SIG;
+    "struct", STRUCT;
+    "then", THEN;
+    "to", TO;
+    "true", TRUE;
+    "try", TRY;
+    "type", TYPE;
+    "val", VAL;
+    "virtual", VIRTUAL;
+    "when", WHEN;
+    "while", WHILE;
+    "with", WITH;
+
+    "mod", INFIXOP3("mod");
+    "land", INFIXOP3("land");
+    "lor", INFIXOP3("lor");
+    "lxor", INFIXOP3("lxor");
+    "lsl", INFIXOP4("lsl");
+    "lsr", INFIXOP4("lsr");
+    "asr", INFIXOP4("asr")
+]
+
+(* To buffer string literals *)
+
+let string_buffer = Buffer.create 256
+let raw_buffer = Buffer.create 256
+
+let reset_string_buffer () =
+  Buffer.reset string_buffer;
+  Buffer.reset raw_buffer
+
+let store_string_char c =
+  Buffer.add_char string_buffer c
+
+let store_string s =
+  Buffer.add_string string_buffer s
+
+let store_lexeme buffer lexbuf =
+  Buffer.add_string buffer (Lexing.lexeme lexbuf)
+
+let get_stored_string () =
+  let str = Buffer.contents string_buffer in
+  let raw =
+    if Buffer.length raw_buffer = 0
+    then None
+    else Some (Buffer.contents raw_buffer)
+  in
+  Buffer.reset string_buffer;
+  Buffer.reset raw_buffer;
+  (str, raw)
+
+(* To store the position of the beginning of a string and comment *)
+let string_start_loc = ref Location.none;;
+let comment_start_loc = ref [];;
+let in_comment () = !comment_start_loc <> [];;
+let is_in_string = ref false
+let in_string () = !is_in_string
+let print_warnings = ref true
+
+(* To "unlex" a few characters *)
+let set_lexeme_length buf n = (
+  let open Lexing in
+  if n < 0 then
+    invalid_arg "set_lexeme_length: offset should be positive";
+  if n > buf.lex_curr_pos - buf.lex_start_pos then
+    invalid_arg "set_lexeme_length: offset larger than lexeme";
+  buf.lex_curr_pos <- buf.lex_start_pos + n;
+  buf.lex_curr_p <- {buf.lex_start_p
+                     with pos_cnum = buf.lex_abs_pos + buf.lex_curr_pos};
+)
+
+(* This cut comment characters of the current buffer.
+ * Operators (including "/*" and "//") are lexed with the same rule, and this
+ * function cuts the lexeme at the beginning of an operator. *)
+let lexeme_without_comment buf = (
+  let lexeme = Lexing.lexeme buf in
+  let i = ref 0 and len = String.length lexeme - 1 in
+  let found = ref (-1) in
+  while !i < len && !found = -1 do
+    begin match lexeme.[!i], lexeme.[!i+1] with
+      | ('/', '*') | ('/', '/') | ('*', '/') ->
+        found := !i;
+      | _ -> ()
+    end;
+    incr i
+  done;
+  match !found with
+  | -1 -> lexeme
+  | n ->
+      set_lexeme_length buf n;
+      String.sub lexeme 0 n
+)
+
+(* Operators that could conflict with comments (those containing /*, */ and //)
+ * are escaped in the source. The lexer removes the escapes so that the
+ * identifier looks like OCaml ones.
+ * An escape in first position is kept to distinguish "verbatim" operators
+ * (\=== for instance). *)
+let unescape_operator str =
+  if (str <> "" && String.contains_from str 1 '\\') then (
+    let b = Buffer.create (String.length str) in
+    Buffer.add_char b str.[0];
+    for i = 1 to String.length str - 1 do
+      let c = str.[i] in
+      if c <> '\\' then Buffer.add_char b c
+    done;
+    Buffer.contents b
+  ) else str
+
+let lexeme_operator lexbuf =
+  unescape_operator (lexeme_without_comment lexbuf)
+
+(* To translate escape sequences *)
+
+let char_for_backslash = function
+  | 'n' -> '\010'
+  | 'r' -> '\013'
+  | 'b' -> '\008'
+  | 't' -> '\009'
+  | c   -> c
+
+let char_for_decimal_code lexbuf i =
+  let c = 100 * (Char.code(Lexing.lexeme_char lexbuf i) - 48) +
+           10 * (Char.code(Lexing.lexeme_char lexbuf (i+1)) - 48) +
+                (Char.code(Lexing.lexeme_char lexbuf (i+2)) - 48) in
+  if (c < 0 || c > 255) then
+    if in_comment ()
+    then 'x'
+    else raise (Error(Illegal_escape (Lexing.lexeme lexbuf),
+                      Location.curr lexbuf))
+  else Char.chr c
+
+let char_for_hexadecimal_code lexbuf i =
+  let d1 = Char.code (Lexing.lexeme_char lexbuf i) in
+  let val1 = if d1 >= 97 then d1 - 87
+             else if d1 >= 65 then d1 - 55
+             else d1 - 48
+  in
+  let d2 = Char.code (Lexing.lexeme_char lexbuf (i+1)) in
+  let val2 = if d2 >= 97 then d2 - 87
+             else if d2 >= 65 then d2 - 55
+             else d2 - 48
+  in
+  Char.chr (val1 * 16 + val2)
+
+(* To convert integer literals, allowing max_int + 1 (PR#4210) *)
+
+let cvt_int_literal s =
+  - int_of_string ("-" ^ s)
+let cvt_int32_literal s =
+  Int32.neg (Int32.of_string ("-" ^ String.sub s 0 (String.length s - 1)))
+let cvt_int64_literal s =
+  Int64.neg (Int64.of_string ("-" ^ String.sub s 0 (String.length s - 1)))
+let cvt_nativeint_literal s =
+  Nativeint.neg (Nativeint.of_string ("-" ^ String.sub s 0
+                                                       (String.length s - 1)))
+
+(* Remove underscores from float literals *)
+
+let remove_underscores s =
+  let l = String.length s in
+  let b = Bytes.create l in
+  let rec remove src dst =
+    if src >= l then
+      if dst >= l then s else Bytes.sub_string b 0 dst
+    else
+      match s.[src] with
+        '_' -> remove (src + 1) dst
+      |  c  -> Bytes.set b dst c; remove (src + 1) (dst + 1)
+  in remove 0 0
+
+(* Update the current location with file name and line number. *)
+
+let update_loc lexbuf file line absolute chars =
+  let pos = lexbuf.lex_curr_p in
+  let new_file = match file with
+                 | None -> pos.pos_fname
+                 | Some s -> s
+  in
+  lexbuf.lex_curr_p <- { pos with
+    pos_fname = new_file;
+    pos_lnum = if absolute then line else pos.pos_lnum + line;
+    pos_bol = pos.pos_cnum - chars;
+  }
+;;
+
+let preprocessor = ref None
+
+(* Error report *)
+
+open Format
+
+let report_error ppf = function
+  | Illegal_character c ->
+      fprintf ppf "Illegal character (%s)" (Char.escaped c)
+  | Illegal_escape s ->
+      fprintf ppf "Illegal backslash escape in string or character (%s)" s
+  | Unterminated_comment _ ->
+      fprintf ppf "Comment not terminated"
+  | Unterminated_string ->
+      fprintf ppf "String literal not terminated"
+  | Unterminated_string_in_comment (_, loc) ->
+      fprintf ppf "This comment contains an unterminated string literal@.\
+                   %aString literal begins here"
+              Location.print_error loc
+  | Keyword_as_label kwd ->
+      fprintf ppf "`%s' is a keyword, it cannot be used as label name" kwd
+  | Literal_overflow ty ->
+      fprintf ppf "Integer literal exceeds the range of representable \
+                   integers of type %s" ty
+  | Invalid_literal s ->
+      fprintf ppf "Invalid literal %s" s
+
+let () =
+  Location.register_error_of_exn
+    (function
+      | Error (err, loc) ->
+          Some (Location.error_of_printer loc report_error err)
+      | _ ->
+          None
+    )
+
+}
+
+
+let newline = ('\013'* '\010')
+let blank = [' ' '\009' '\012']
+let lowercase = ['a'-'z' '_']
+let uppercase = ['A'-'Z']
+let uppercase_or_lowercase = lowercase | uppercase
+let identchar = ['A'-'Z' 'a'-'z' '_' '\'' '0'-'9']
+let lowercase_latin1 = ['a'-'z' '\223'-'\246' '\248'-'\255' '_']
+let uppercase_latin1 = ['A'-'Z' '\192'-'\214' '\216'-'\222']
+let identchar_latin1 =
+  ['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255' '\'' '0'-'9']
+
+let operator_chars =
+  ['!' '$' '%' '&' '+' '-' ':' '<' '=' '>' '?' '@' '^' '|' '~' '#' '.'] |
+  ( '\\'? ['/' '*'] )
+
+let decimal_literal = ['0'-'9'] ['0'-'9' '_']*
+
+let hex_literal =
+  '0' ['x' 'X'] ['0'-'9' 'A'-'F' 'a'-'f']['0'-'9' 'A'-'F' 'a'-'f' '_']*
+let oct_literal =
+  '0' ['o' 'O'] ['0'-'7'] ['0'-'7' '_']*
+let bin_literal =
+  '0' ['b' 'B'] ['0'-'1'] ['0'-'1' '_']*
+
+let int_literal =
+  decimal_literal | hex_literal | oct_literal | bin_literal
+
+(* liquidity *)
+let base58_char =
+  ['1'-'9' 'A'-'H' 'J'-'N' 'P'-'Z' 'a'-'k' 'm'-'z' ]
+let keyhash_literal =
+  ("tz1" | "tz2" | "tz3") base58_char* (* 36 *)
+let contract_literal =
+  "KT1" base58_char* (* 36 *)
+let key_literal =
+  ("edpk" | "sppk" | "p2pk")  base58_char* (* 54 *)
+let signature_literal =
+  ("edsig" | "spsig1") base58_char* (* 99 *)
+let p2_signature_literal =
+  "p2sig" base58_char* (* 98 *)
+let hex_byte_literal = ['0'-'9' 'A'-'F' 'a'-'f'] ['0'-'9' 'A'-'F' 'a'-'f']
+let bytes_literal = "0x" hex_byte_literal*
+let hex_signature_literal = '`' hex_byte_literal+
+let digit = [ '0'-'9']
+let day_literal =
+  digit digit digit digit '-' digit digit '-' digit digit
+let hour_literal =
+  digit digit ':' digit digit ( ':' digit digit )?
+let timezone_literal =
+  ('+' digit digit ':' digit digit | 'Z')
+let date_literal =
+  day_literal ('T' hour_literal ( timezone_literal )?)?
+
+let float_literal =
+  ['0'-'9'] ['0'-'9' '_']*
+  ('.' ['0'-'9' '_']* )?
+  (['e' 'E'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']*)?
+
+let hex_float_literal =
+  '0' ['x' 'X']
+  ['0'-'9' 'A'-'F' 'a'-'f'] ['0'-'9' 'A'-'F' 'a'-'f' '_']*
+  ('.' ['0'-'9' 'A'-'F' 'a'-'f' '_']* )?
+  (['p' 'P'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
+
+let literal_modifier = ['G'-'Z' 'g'-'z']
+
+rule token = parse
+  | "\\" newline {
+      match !preprocessor with
+      | None ->
+        raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
+                     Location.curr lexbuf))
+      | Some _ ->
+        update_loc lexbuf None 1 false 0;
+        token lexbuf }
+  | newline
+      { update_loc lexbuf None 1 false 0;
+        match !preprocessor with
+        | None -> token lexbuf
+        | Some _ -> EOL
+      }
+  | blank +
+      { token lexbuf }
+  | "_"
+      { UNDERSCORE }
+  | "~"
+      { TILDE }
+  | "?"
+      { QUESTION }
+  | "=?"
+      { set_lexeme_length lexbuf 1; EQUAL }
+  | keyhash_literal
+      {
+        let s = Lexing.lexeme lexbuf in
+        if String.length s = 36 then
+          INT (s, Some keyhash_char)
+        else begin
+            (* TODO warning *)
+            LIDENT s
+          end
+      }
+  | contract_literal
+      {
+        let s = Lexing.lexeme lexbuf in
+        if String.length s = 36 then
+          INT (s, Some contract_char)
+        else begin
+          (* TODO warning *)
+          UIDENT s
+        end
+      }
+  | key_literal
+      {
+        let s = Lexing.lexeme lexbuf in
+        if String.length s = 54 then
+          INT (s, Some key_char)
+        else begin
+            (* TODO warning *)
+            LIDENT s
+          end
+      }
+  | signature_literal
+      {
+        let s = Lexing.lexeme lexbuf in
+        if String.length s = 99 then
+          INT (s, Some signature_char)
+        else begin
+            (* TODO warning *)
+            LIDENT s
+          end
+      }
+  | p2_signature_literal
+      {
+        let s = Lexing.lexeme lexbuf in
+        if String.length s = 98 then
+          INT (s, Some signature_char)
+        else begin
+            (* TODO warning *)
+            LIDENT s
+          end
+      }
+  | bytes_literal
+      {
+        let s = Lexing.lexeme lexbuf in
+        INT (s, Some bytes_char)
+      }
+  | date_literal
+      { let date = Lexing.lexeme lexbuf in
+        INT(date, Some timestamp_char) }
+  | lowercase identchar *
+      { let s = Lexing.lexeme lexbuf in
+        try Hashtbl.find keyword_table s
+        with Not_found -> LIDENT s }
+  | lowercase_latin1 identchar_latin1 *
+      { warn_latin1 lexbuf; LIDENT (Lexing.lexeme lexbuf) }
+  | uppercase identchar *
+      { UIDENT(Lexing.lexeme lexbuf) }       (* No capitalized keywords *)
+  | uppercase_latin1 identchar_latin1 *
+      { warn_latin1 lexbuf; UIDENT(Lexing.lexeme lexbuf) }
+  | int_literal { INT (Lexing.lexeme lexbuf, None) }
+  | (int_literal as lit) "tz" (* Liquidity *)
+      { INT (lit, Some tez_char) }
+  | (int_literal as lit) (literal_modifier as modif)
+      { INT (lit, Some modif) }
+  | float_literal | hex_float_literal
+      { FLOAT (Lexing.lexeme lexbuf, None) }
+  | ((float_literal) as lit) "tz" (* Liquidity *)
+      { FLOAT (lit, Some tez_char) }
+  | ((float_literal | hex_float_literal) as lit) (literal_modifier as modif)
+      { FLOAT (lit, Some modif) }
+  | (float_literal | hex_float_literal | int_literal) identchar+
+      { raise (Error(Invalid_literal (Lexing.lexeme lexbuf),
+                     Location.curr lexbuf)) }
+  | "\""
+      { reset_string_buffer();
+        is_in_string := true;
+        let string_start = lexbuf.lex_start_p in
+        string_start_loc := Location.curr lexbuf;
+        string raw_buffer lexbuf;
+        is_in_string := false;
+        lexbuf.lex_start_p <- string_start;
+        let text, raw = get_stored_string() in
+        STRING (text, raw, None) }
+  | "{" lowercase* "|"
+      { reset_string_buffer();
+        let delim = Lexing.lexeme lexbuf in
+        let delim = String.sub delim 1 (String.length delim - 2) in
+        is_in_string := true;
+        let string_start = lexbuf.lex_start_p in
+        string_start_loc := Location.curr lexbuf;
+        quoted_string delim lexbuf;
+        is_in_string := false;
+        lexbuf.lex_start_p <- string_start;
+        STRING (fst (get_stored_string()), None, Some delim) }
+  | "'" newline "'"
+      { update_loc lexbuf None 1 false 1;
+        CHAR (Lexing.lexeme_char lexbuf 1) }
+  | "'" [^ '\\' '\'' '\010' '\013'] "'"
+      { CHAR(Lexing.lexeme_char lexbuf 1) }
+  | "'\\" ['\\' '\'' '"' 'n' 't' 'b' 'r' ' '] "'"
+      { CHAR(char_for_backslash (Lexing.lexeme_char lexbuf 2)) }
+  | "'\\" ['0'-'9'] ['0'-'9'] ['0'-'9'] "'"
+      { CHAR(char_for_decimal_code lexbuf 2) }
+  | "'\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] "'"
+      { CHAR(char_for_hexadecimal_code lexbuf 3) }
+  | "'\\" _
+      { let l = Lexing.lexeme lexbuf in
+        let esc = String.sub l 1 (String.length l - 1) in
+        raise (Error(Illegal_escape esc, Location.curr lexbuf))
+      }
+  | "#=<" {
+    (* Allow parsing of foo#=<bar /> *)
+    set_lexeme_length lexbuf 2;
+    SHARPEQUAL
+  }
+  | "#=" { SHARPEQUAL }
+  | "#" operator_chars+
+      { SHARPOP(lexeme_operator lexbuf) }
+  | "#" [' ' '\t']* (['0'-'9']+ as num) [' ' '\t']*
+        ("\"" ([^ '\010' '\013' '"' ] * as name) "\"")?
+        [^ '\010' '\013'] * newline
+      { update_loc lexbuf name (int_of_string num) true 0;
+        token lexbuf
+      }
+  | "&"  { AMPERSAND }
+  | "&&" { AMPERAMPER }
+  | "`"  { BACKQUOTE }
+  | "'"  { QUOTE }
+  | "("  { LPAREN }
+  | ")"  { RPAREN }
+  | "*"  { STAR }
+  | ","  { COMMA }
+  | "->" { MINUSGREATER }
+  | "=>" { EQUALGREATER }
+  (* allow lexing of | `Variant =><Component /> *)
+  | "=><" uppercase_or_lowercase (identchar | '.') * {
+    set_lexeme_length lexbuf 2;
+    EQUALGREATER
+  }
+  | "#"  { SHARP }
+  | "."  { DOT }
+  | ".." { DOTDOT }
+  | "..."{ DOTDOTDOT }
+  | ":"  { COLON }
+  | "::" { COLONCOLON }
+  | ":=" { COLONEQUAL }
+  | ":>" { COLONGREATER }
+  | ";"  { SEMI }
+  | ";;" { SEMISEMI }
+  | "<"  { LESS }
+  | "="  { EQUAL }
+  | "["  { LBRACKET }
+  | "[|" { LBRACKETBAR }
+  | "[<" { LBRACKETLESS }
+  | "[>" { LBRACKETGREATER }
+  | "<" (uppercase identchar* '.')* lowercase identchar* {
+    let buf = Lexing.lexeme lexbuf in
+    LESSIDENT (String.sub buf 1 (String.length buf - 1))
+  }
+  | ">..." { GREATERDOTDOTDOT }
+  (* Allow parsing of Pexp_override:
+   * let z = {<state: 0, x: y>};
+   *
+   * Make sure {<state is emitted as LBRACELESS.
+   * This contrasts with jsx:
+   * in a jsx context {<div needs to be LBRACE LESS (two tokens)
+   * for a valid parse.
+   *)
+  | "{<" uppercase_or_lowercase identchar* blank*  ":" {
+    set_lexeme_length lexbuf 2;
+    LBRACELESS
+  }
+  | "{<" uppercase_or_lowercase (identchar | '.') * {
+    (* allows parsing of `{<Text` in <Description term={<Text text="Age" />}> as correct jsx *)
+    set_lexeme_length lexbuf 1;
+    LBRACE
+  }
+  | "</" blank* uppercase_or_lowercase (identchar | '.') * blank* ">" {
+    let buf = Lexing.lexeme lexbuf in
+    LESSSLASHIDENTGREATER (String.trim (String.sub buf 2 (String.length buf - 2 - 1)))
+  }
+  | "]"  { RBRACKET }
+  | "{"  { LBRACE }
+  | "{<" { LBRACELESS }
+  | "|"  { BAR }
+  | "||" { BARBAR }
+  | "|]" { BARRBRACKET }
+  | ">"  { GREATER }
+  (* Having a GREATERRBRACKET makes it difficult to parse patterns such
+     as > ]. The space in between then becomes significant and must be
+     maintained when printing etc. >] isn't even needed!
+  | ">]" { GREATERRBRACKET }
+  *)
+  | "}"  { RBRACE }
+  | ">}" { GREATERRBRACE }
+  | "=<" uppercase_or_lowercase+ {
+    (* allow `let x=<div />;` *)
+    set_lexeme_length lexbuf 1;
+    EQUAL
+  }
+  (* jsx in arrays: [|<div />|]*)
+  | "/>|]" {
+    set_lexeme_length lexbuf 2;
+    SLASHGREATER
+  }
+  | "[|<" {
+    set_lexeme_length lexbuf 2;
+    LBRACKETBAR
+  }
+    (* allow parsing of <div /></Component> *)
+  | "/></" uppercase_or_lowercase+ {
+    (* allow parsing of <div asd=1></div> *)
+    set_lexeme_length lexbuf 2;
+    SLASHGREATER
+  }
+  | "></" uppercase_or_lowercase+ {
+    (* allow parsing of <div asd=1></div> *)
+    set_lexeme_length lexbuf 1;
+    GREATER
+  }
+  | "><" uppercase_or_lowercase+ {
+    (* allow parsing of <div><span> *)
+    set_lexeme_length lexbuf 1;
+    GREATER
+  }
+  | "[@" { LBRACKETAT }
+  | "[%" { LBRACKETPERCENT }
+  | "[%%" { LBRACKETPERCENTPERCENT }
+  | "!"  { BANG }
+  | "!=" { INFIXOP0 "!=" }
+  | "!==" { INFIXOP0 "!==" }
+  | "\\!=" { INFIXOP0 "!=" }
+  | "\\!==" { INFIXOP0 "!==" }
+  | "+"  { PLUS }
+  | "+." { PLUSDOT }
+  | "+=" { PLUSEQ }
+  | "-"  { MINUS }
+  | "-." { MINUSDOT }
+  | "<>" { LESSGREATER }
+  | "</>" { LESSSLASHGREATER }
+  | "<..>" { LESSDOTDOTGREATER }
+  | '\\'? ['~' '?' '!'] operator_chars+
+            { PREFIXOP(lexeme_operator lexbuf) }
+  | '\\'? ['=' '<' '>' '|' '&' '$'] operator_chars*
+            {
+              INFIXOP0(lexeme_operator lexbuf)
+            }
+  | '\\'? '@' operator_chars*
+            { INFIXOP1(lexeme_operator lexbuf) }
+  | '\\'? '^' ('\\' '.')? operator_chars*
+            { match lexeme_without_comment lexbuf with
+              | "^." -> set_lexeme_length lexbuf 1; POSTFIXOP("^")
+              | "^|" ->
+                  (* ^| is not an infix op in [|a^|] *)
+                  set_lexeme_length lexbuf 1; POSTFIXOP("^")
+              | "^" -> POSTFIXOP("^")
+              | op -> INFIXOP1(unescape_operator op) }
+  | "++" operator_chars*
+            { INFIXOP1(lexeme_operator lexbuf) }
+  | '\\'? ['+' '-'] operator_chars*
+            { INFIXOP2(lexeme_operator lexbuf) }
+  (* SLASHGREATER is an INFIXOP3 that is handled specially *)
+  | "/>" { SLASHGREATER }
+  (* The second star must be escaped so that the precedence assumptions for
+   * printing match those of parsing. (Imagine what could happen if the other
+   * rule beginning with * picked up */*, and we internally escaped it to **.
+   * Whe printing, we have an understanding of the precedence of "**", which
+   * enables us to safely print/group it, but that understanding would not
+   * match the *actual* precedence that it was parsed at thanks to the *other*
+   * rule beginning with *, picking it up instead of the special double ** rule
+   * below.
+   *)
+  | '\\'? '*' '\\'? '*' operator_chars*
+            { INFIXOP4(lexeme_operator lexbuf) }
+  | '%'     { PERCENT }
+  | '\\'? ['/' '*'] operator_chars*
+            { match lexeme_operator lexbuf with
+              | "" ->
+                  (* If the operator is empty, it means the lexeme is beginning
+                   * by a comment sequence: we let the comment lexer handle
+                   * the case. *)
+                  enter_comment lexbuf
+              | op -> INFIXOP3 op }
+  | '%' operator_chars*
+            { INFIXOP3(lexeme_operator lexbuf) }
+  | eof { EOF }
+  | _
+      { raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
+                     Location.curr lexbuf))
+      }
+
+and enter_comment = parse
+  | "//" ([^'\010']* newline as line)
+      { update_loc lexbuf None 1 false 0;
+        let physical_loc = Location.curr lexbuf in
+        let location = { physical_loc with
+          loc_end = { physical_loc.loc_end with
+            (* Don't track trailing `\n` in the location
+             * 1| // comment
+             * 2| let x = 1;
+             * By omitting the `\n` at the end of line 1, the location of the
+             * comment spans line 1. Otherwise the comment on line 1 would end
+             * on the second line. The printer looks at the closing pos_lnum
+             * location to interleave whitespace correct. It needs to align
+             * with what we visually see (i.e. it ends on line 1) *)
+            pos_lnum = physical_loc.loc_end.pos_lnum - 1;
+            pos_cnum = physical_loc.loc_end.pos_cnum + 1;
+        }} in
+        COMMENT (line, location)
+      }
+  | "/*" ("*" "*"+)?
+      { set_lexeme_length lexbuf 2;
+        let start_loc = Location.curr lexbuf  in
+        comment_start_loc := [start_loc];
+        reset_string_buffer ();
+        let {Location. loc_end; _} = comment lexbuf in
+        let s, _ = get_stored_string () in
+        reset_string_buffer ();
+        COMMENT (s, { start_loc with Location.loc_end })
+      }
+  | "/**"
+      { let start_p = lexbuf.Lexing.lex_start_p in
+        let start_loc = Location.curr lexbuf in
+        comment_start_loc := [start_loc];
+        reset_string_buffer ();
+        let _ = comment lexbuf in
+        let s, _ = get_stored_string () in
+        reset_string_buffer ();
+        lexbuf.Lexing.lex_start_p <- start_p;
+        DOCSTRING s
+      }
+  | "/**/"
+      { DOCSTRING "" }
+  | "/*/"
+      { let loc = Location.curr lexbuf  in
+        if !print_warnings then
+          Location.prerr_warning loc Warnings.Comment_start;
+        comment_start_loc := [loc];
+        reset_string_buffer ();
+        let {Location. loc_end; _} = comment lexbuf in
+        let s, _ = get_stored_string () in
+        reset_string_buffer ();
+        COMMENT (s, { loc with Location.loc_end })
+      }
+  | "*/"
+      { let loc = Location.curr lexbuf in
+        Location.prerr_warning loc Warnings.Comment_not_end;
+        set_lexeme_length lexbuf 1;
+        STAR
+      }
+  | _ { assert false }
+
+and comment = parse
+    "/*"
+      { comment_start_loc := (Location.curr lexbuf) :: !comment_start_loc;
+        store_lexeme string_buffer lexbuf;
+        comment lexbuf;
+      }
+  | "*/"
+      { match !comment_start_loc with
+        | [] -> assert false
+        | [_] -> comment_start_loc := []; Location.curr lexbuf
+        | _ :: l -> comment_start_loc := l;
+                  store_lexeme string_buffer lexbuf;
+                  comment lexbuf;
+       }
+  | "\""
+      {
+        string_start_loc := Location.curr lexbuf;
+        store_string_char '"';
+        is_in_string := true;
+        begin try string string_buffer lexbuf
+        with Error (Unterminated_string, str_start) ->
+          match !comment_start_loc with
+          | [] -> assert false
+          | loc :: _ ->
+            let start = List.hd (List.rev !comment_start_loc) in
+            comment_start_loc := [];
+            raise (Error (Unterminated_string_in_comment (start, str_start),
+                          loc))
+        end;
+        is_in_string := false;
+        store_string_char '"';
+        comment lexbuf }
+  | "{" lowercase* "|"
+      {
+        let delim = Lexing.lexeme lexbuf in
+        let delim = String.sub delim 1 (String.length delim - 2) in
+        string_start_loc := Location.curr lexbuf;
+        store_lexeme string_buffer lexbuf;
+        is_in_string := true;
+        begin try quoted_string delim lexbuf
+        with Error (Unterminated_string, str_start) ->
+          match !comment_start_loc with
+          | [] -> assert false
+          | loc :: _ ->
+            let start = List.hd (List.rev !comment_start_loc) in
+            comment_start_loc := [];
+            raise (Error (Unterminated_string_in_comment (start, str_start),
+                          loc))
+        end;
+        is_in_string := false;
+        store_string_char '|';
+        store_string delim;
+        store_string_char '}';
+        comment lexbuf }
+
+  | "''"
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+  | "'" newline "'"
+      { update_loc lexbuf None 1 false 1;
+        store_lexeme string_buffer lexbuf;
+        comment lexbuf
+      }
+  | "'" [^ '\\' '\'' '\010' '\013' ] "'"
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+  | "'\\" ['\\' '"' '\'' 'n' 't' 'b' 'r' ' '] "'"
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+  | "'\\" ['0'-'9'] ['0'-'9'] ['0'-'9'] "'"
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+  | "'\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] "'"
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+  | eof
+      { match !comment_start_loc with
+        | [] -> assert false
+        | loc :: _ ->
+          let start = List.hd (List.rev !comment_start_loc) in
+          comment_start_loc := [];
+          raise (Error (Unterminated_comment start, loc))
+      }
+  | newline
+      { update_loc lexbuf None 1 false 0;
+        store_lexeme string_buffer lexbuf;
+        comment lexbuf
+      }
+  | _
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+
+and string rawbuffer = parse
+    '"'
+      { () }
+  | '\\' newline ([' ' '\t'] * as space)
+      { update_loc lexbuf None 1 false (String.length space);
+        store_lexeme rawbuffer lexbuf;
+        string rawbuffer lexbuf
+      }
+  | '\\' ['\\' '\'' '"' 'n' 't' 'b' 'r' ' ']
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then
+          store_string_char(char_for_backslash(Lexing.lexeme_char lexbuf 1));
+        string rawbuffer lexbuf }
+  | '\\' ['0'-'9'] ['0'-'9'] ['0'-'9']
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then
+          store_string_char(char_for_decimal_code lexbuf 1);
+        string rawbuffer lexbuf }
+  | '\\' 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F']
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then
+          store_string_char(char_for_hexadecimal_code lexbuf 2);
+        string rawbuffer lexbuf }
+  | '\\' _
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then
+        begin
+(*  Should be an error, but we are very lax.
+          raise (Error (Illegal_escape (Lexing.lexeme lexbuf),
+                        Location.curr lexbuf))
+*)
+          let loc = Location.curr lexbuf in
+          Location.prerr_warning loc Warnings.Illegal_backslash;
+          store_string_char (Lexing.lexeme_char lexbuf 0);
+          store_string_char (Lexing.lexeme_char lexbuf 1);
+        end;
+        string rawbuffer lexbuf
+      }
+  | newline
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then (
+          store_lexeme string_buffer lexbuf;
+          Location.prerr_warning (Location.curr lexbuf) Warnings.Eol_in_string
+        );
+        update_loc lexbuf None 1 false 0;
+        string rawbuffer lexbuf
+      }
+  | eof
+      { is_in_string := false;
+        raise (Error (Unterminated_string, !string_start_loc)) }
+  | _
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then
+          store_string_char(Lexing.lexeme_char lexbuf 0);
+        string rawbuffer lexbuf }
+
+and quoted_string delim = parse
+  | newline
+      { update_loc lexbuf None 1 false 0;
+        store_lexeme string_buffer lexbuf;
+        quoted_string delim lexbuf
+      }
+  | eof
+      { is_in_string := false;
+        raise (Error (Unterminated_string, !string_start_loc)) }
+  | "|" lowercase* "}"
+      {
+        let edelim = Lexing.lexeme lexbuf in
+        let edelim = String.sub edelim 1 (String.length edelim - 2) in
+        if delim = edelim then ()
+        else (store_lexeme string_buffer lexbuf;
+              quoted_string delim lexbuf)
+      }
+  | _
+      { store_string_char (Lexing.lexeme_char lexbuf 0);
+        quoted_string delim lexbuf }
+
+and skip_sharp_bang = parse
+  | "#!" [^ '\n']* '\n' [^ '\n']* "\n!#\n"
+       { update_loc lexbuf None 3 false 0 }
+  | "#!" [^ '\n']* '\n'
+       { update_loc lexbuf None 1 false 0 }
+  | "" { () }
+
+{
+
+  (* Filter commnets *)
+
+  let token_with_comments lexbuf =
+    match !preprocessor with
+    | None -> token lexbuf
+    | Some (_init, preprocess) -> preprocess token lexbuf
+
+  let last_comments = ref []
+
+  let rec token lexbuf =
+    match token_with_comments lexbuf with
+        COMMENT (s, comment_loc) ->
+          last_comments := (s, comment_loc) :: !last_comments;
+          token lexbuf
+      | tok -> tok
+
+  let add_invalid_docstring text loc =
+    let open Location in
+    let rec aux = function
+      | ((_, loc') as x) :: xs
+        when loc'.loc_start.pos_cnum > loc.loc_start.pos_cnum ->
+        x :: aux xs
+      | xs -> (text, loc) :: xs
+    in
+    last_comments := aux !last_comments
+
+  let comments () = List.rev !last_comments
+
+  (* Routines for manipulating lexer state *)
+
+  let save_triple lexbuf tok =
+    (tok, lexbuf.lex_start_p, lexbuf.lex_curr_p)
+
+  let load_triple lexbuf (tok, p1, p2) = (
+    lexbuf.lex_start_p <- p1;
+    lexbuf.lex_curr_p <- p2;
+    tok
+  )
+
+  let fake_triple t (_, pos, _) =
+    (t, pos, pos)
+
+  (* insert ES6_FUN *)
+
+  exception Lex_balanced_failed of (token * position * position) list *
+                                   (exn * position * position) option
+
+  let closing_of = function
+    | LPAREN -> RPAREN
+    | LBRACE -> RBRACE
+    | _ -> assert false
+
+  let inject_es6_fun = function
+    | tok :: acc ->
+      tok :: fake_triple ES6_FUN tok :: acc
+    | _ -> assert false
+
+  let is_triggering_token = function
+    | EQUALGREATER | COLON -> true
+    | _ -> false
+
+  let rec lex_balanced_step closing lexbuf acc tok =
+    let acc = save_triple lexbuf tok :: acc in
+    match tok, closing with
+    | (RPAREN, RPAREN) | (RBRACE, RBRACE) | (RBRACKET, RBRACKET) ->
+      acc
+    | ((RPAREN | RBRACE | RBRACKET | EOF), _) ->
+      raise (Lex_balanced_failed (acc, None))
+    | (( LBRACKET | LBRACKETLESS | LBRACKETGREATER
+       | LBRACKETAT
+       | LBRACKETPERCENT | LBRACKETPERCENTPERCENT ), _) ->
+      lex_balanced closing lexbuf (lex_balanced RBRACKET lexbuf acc)
+    | ((LPAREN | LBRACE), _) ->
+      let rparen =
+        try lex_balanced (closing_of tok) lexbuf []
+        with (Lex_balanced_failed (rparen, None)) ->
+          raise (Lex_balanced_failed (rparen @ acc, None))
+      in
+      begin match token lexbuf with
+      | exception exn ->
+        raise (Lex_balanced_failed (rparen @ acc, Some (save_triple lexbuf exn)))
+      | tok' ->
+        let acc = if is_triggering_token tok' then inject_es6_fun acc else acc in
+        lex_balanced_step closing lexbuf (rparen @ acc) tok'
+      end
+    | ((LIDENT _ | UNDERSCORE), _) ->
+      begin match token lexbuf with
+      | exception exn ->
+        raise (Lex_balanced_failed (acc, Some (save_triple lexbuf exn)))
+      | tok' ->
+        let acc = if is_triggering_token tok' then inject_es6_fun acc else acc in
+        lex_balanced_step closing lexbuf acc tok'
+      end
+    (* `...` with a closing `}` indicates that we're definitely not in an es6_fun
+     * Image the following:
+     *    true ? (Update({...a, b: 1}), None) : x;
+     *    true ? ({...a, b: 1}) : a;
+     *    true ? (a, {...a, b: 1}) : a;
+     * The lookahead_esfun is triggered initiating the lex_balanced procedure.
+     * Since we now "over"-parse spread operators in pattern position (for
+     * better errors), the ... pattern in ({...a, b: 1}) is now a valid path.
+     * This means that the above expression `({...a, b: 1}) :` is seen as a pattern.
+     * I.e. the arguments of an es6 function: (pattern) :type => expr
+     * We exit here, to indicate that an expression needs to be parsed instead
+     * of a pattern.
+     *)
+    | (DOTDOTDOT, RBRACE) -> acc
+    | _ -> lex_balanced closing lexbuf acc
+
+  and lex_balanced closing lexbuf acc =
+    match token lexbuf with
+    | exception exn ->
+      raise (Lex_balanced_failed (acc, Some (save_triple lexbuf exn)))
+    | tok -> lex_balanced_step closing lexbuf acc tok
+
+  let queued_tokens = ref []
+  let queued_exn = ref None
+
+  let lookahead_esfun lexbuf (tok, _, _ as lparen) =
+    let triple =
+      match lex_balanced (closing_of tok) lexbuf [] with
+      | exception (Lex_balanced_failed (tokens, exn)) ->
+        queued_tokens := List.rev tokens;
+        queued_exn := exn;
+        lparen
+      | tokens ->
+        begin match token lexbuf with
+          | exception exn ->
+            queued_tokens := List.rev tokens;
+            queued_exn := Some (save_triple lexbuf exn);
+            lparen
+          | token ->
+            let tokens = save_triple lexbuf token :: tokens in
+            if is_triggering_token token then (
+              queued_tokens := lparen :: List.rev tokens;
+              fake_triple ES6_FUN lparen
+            ) else (
+              queued_tokens := List.rev tokens;
+              lparen
+            )
+        end
+    in
+    load_triple lexbuf triple
+
+  let token lexbuf =
+    match !queued_tokens, !queued_exn with
+    | [], Some exn ->
+      queued_exn := None;
+      raise (load_triple lexbuf exn)
+    | [(LPAREN, _, _) as lparen], None ->
+      let _ = load_triple lexbuf lparen in
+      lookahead_esfun lexbuf lparen
+    | [(LBRACE, _, _) as lparen], None ->
+      let _ = load_triple lexbuf lparen in
+      lookahead_esfun lexbuf lparen
+    | [], None ->
+      begin match token lexbuf with
+      | LPAREN | LBRACE as tok ->
+          lookahead_esfun lexbuf (save_triple lexbuf tok)
+      | (LIDENT _ | UNDERSCORE) as tok ->
+          let tok = save_triple lexbuf tok in
+          begin match token lexbuf with
+          | exception exn ->
+              queued_exn := Some (save_triple lexbuf exn);
+              load_triple lexbuf tok
+          | tok' ->
+            if is_triggering_token tok' then (
+              queued_tokens := [tok; save_triple lexbuf tok'];
+              load_triple lexbuf (fake_triple ES6_FUN tok)
+            ) else (
+              queued_tokens := [save_triple lexbuf tok'];
+              load_triple lexbuf tok
+            )
+          end
+      | token -> token
+      end
+    | x :: xs, _ -> queued_tokens := xs; load_triple lexbuf x
+
+  let completion_ident_offset = ref min_int
+  let completion_ident_pos = ref Lexing.dummy_pos
+
+  let token lexbuf =
+    let space_start = lexbuf.Lexing.lex_curr_p.Lexing.pos_cnum in
+    let token = token lexbuf in
+    let token_start = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
+    let token_stop = lexbuf.Lexing.lex_curr_p.Lexing.pos_cnum in
+    if !completion_ident_offset > min_int &&
+       space_start <= !completion_ident_offset &&
+       token_stop >= !completion_ident_offset then (
+      match token with
+      | LIDENT _ | UIDENT _ when token_start <= !completion_ident_offset ->
+          completion_ident_offset := min_int;
+          token
+      | _ ->
+        queued_tokens := save_triple lexbuf token :: !queued_tokens;
+        completion_ident_offset := min_int;
+        load_triple lexbuf
+          (LIDENT "_", !completion_ident_pos, !completion_ident_pos)
+    ) else
+      token
+
+  let init ?insert_completion_ident () =
+    is_in_string := false;
+    last_comments := [];
+    comment_start_loc := [];
+    queued_tokens := [];
+    queued_exn := None;
+    begin match insert_completion_ident with
+      | None ->
+        completion_ident_offset := min_int;
+      | Some pos ->
+        completion_ident_offset := pos.Lexing.pos_cnum;
+        completion_ident_pos := pos
+    end;
+    match !preprocessor with
+    | None -> ()
+    | Some (init, _preprocess) -> init ()
+
+  let set_preprocessor init preprocess =
+    preprocessor := Some (init, preprocess)
+
+}

--- a/tools/liquidity/reason/reason_lexer.mll-orig
+++ b/tools/liquidity/reason/reason_lexer.mll-orig
@@ -1,0 +1,1120 @@
+(*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *  Forked from OCaml, which is provided under the license below:
+ *
+ *  Xavier Leroy, projet Cristal, INRIA Rocquencourt
+ *
+ *  Copyright © 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006 Inria
+ *
+ *  Permission is hereby granted, free of charge, to the Licensee obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense
+ *  under any license of the Licensee's choice, and/or sell copies of the
+ *  Software, subject to the following conditions:
+ *
+ *  1.	Redistributions of source code must retain the above copyright notice
+ *  and the following disclaimer.
+ *  2.	Redistributions in binary form must reproduce the above copyright
+ *  notice, the following disclaimer in the documentation and/or other
+ *  materials provided with the distribution.
+ *  3.	All advertising materials mentioning features or use of the Software
+ *  must display the following acknowledgement: This product includes all or
+ *  parts of the Caml system developed by Inria and its contributors.
+ *  4.	Other than specified in clause 3, neither the name of Inria nor the
+ *  names of its contributors may be used to endorse or promote products
+ *  derived from the Software without specific prior written permission.
+ *
+ *  Disclaimer
+ *
+ *  This software is provided by Inria and contributors “as is” and any express
+ *  or implied warranties, including, but not limited to, the implied
+ *  warranties of merchantability and fitness for a particular purpose are
+ *  disclaimed. in no event shall Inria or its contributors be liable for any
+ *  direct, indirect, incidental, special, exemplary, or consequential damages
+ *  (including, but not limited to, procurement of substitute goods or
+ *  services; loss of use, data, or profits; or business interruption) however
+ *  caused and on any theory of liability, whether in contract, strict
+ *  liability, or tort (including negligence or otherwise) arising in any way
+ *  out of the use of this software, even if advised of the possibility of such
+ *  damage.
+ *
+ *)
+
+(* This is the Reason lexer. As stated in src/README, there's a good section in
+  Real World OCaml that describes what a lexer is:
+
+  https://realworldocaml.org/v1/en/html/parsing-with-ocamllex-and-menhir.html
+
+  Basically, it uses regular expressions to first cut the big code string into
+  more meaningful chunks, called tokens. For example, it cuts the string
+
+    let foo = 1
+
+  into `let`, `foo`, `=` and `1`, massage them a bit into nice variants, then
+  send the data structures into the parser `reason_parser.mly`, which takes
+  care of the next step (turning the stream of tokens into an AST, abstract
+  syntax tree).
+
+  The file's syntax's a bit special. It's not the conventional OCaml syntax. An
+  ordinary language syntax isn't expressive/convenient enough for a lexer. This
+  mll ("ml lexer") syntax is a fine-tuned variation of the usual OCaml syntax.
+ *)
+
+{
+open Lexing
+open Reason_parser
+open Lexer_warning
+
+type error =
+  | Illegal_character of char
+  | Illegal_escape of string
+  | Unterminated_comment of Location.t
+  | Unterminated_string
+  | Unterminated_string_in_comment of Location.t * Location.t
+  | Keyword_as_label of string
+  | Literal_overflow of string
+  | Invalid_literal of string
+;;
+
+exception Error of error * Location.t;;
+
+(* The table of keywords *)
+
+let keyword_table, reverse_keyword_table =
+  let create_hashtable n l =
+    let t = Hashtbl.create n in
+    let rev_t = Hashtbl.create n in
+    List.iter (fun (k, v) ->
+      Hashtbl.add t k v;
+      Hashtbl.add rev_t v k;
+    ) l;
+    t, rev_t
+  in
+  create_hashtable 149 [
+    "and", AND;
+    "as", AS;
+    "assert", ASSERT;
+    "begin", BEGIN;
+    "class", CLASS;
+    "constraint", CONSTRAINT;
+    "do", DO;
+    "done", DONE;
+    "downto", DOWNTO;
+    "else", ELSE;
+    "end", END;
+    "exception", EXCEPTION;
+    "external", EXTERNAL;
+    "false", FALSE;
+    "for", FOR;
+    "fun", FUN;
+    "esfun", ES6_FUN;
+    "function", FUNCTION;
+    "functor", FUNCTOR;
+    "if", IF;
+    "in", IN;
+    "include", INCLUDE;
+    "inherit", INHERIT;
+    "initializer", INITIALIZER;
+    "lazy", LAZY;
+    "let", LET;
+    "switch", SWITCH;
+    "module", MODULE;
+    "pub", PUB;
+    "mutable", MUTABLE;
+    "new", NEW;
+    "nonrec", NONREC;
+    "object", OBJECT;
+    "of", OF;
+    "open", OPEN;
+    "or", OR;
+(*  "parser", PARSER; *)
+    "pri", PRI;
+    "rec", REC;
+    "sig", SIG;
+    "struct", STRUCT;
+    "then", THEN;
+    "to", TO;
+    "true", TRUE;
+    "try", TRY;
+    "type", TYPE;
+    "val", VAL;
+    "virtual", VIRTUAL;
+    "when", WHEN;
+    "while", WHILE;
+    "with", WITH;
+
+    "mod", INFIXOP3("mod");
+    "land", INFIXOP3("land");
+    "lor", INFIXOP3("lor");
+    "lxor", INFIXOP3("lxor");
+    "lsl", INFIXOP4("lsl");
+    "lsr", INFIXOP4("lsr");
+    "asr", INFIXOP4("asr")
+]
+
+(* To buffer string literals *)
+
+let string_buffer = Buffer.create 256
+let raw_buffer = Buffer.create 256
+
+let reset_string_buffer () =
+  Buffer.reset string_buffer;
+  Buffer.reset raw_buffer
+
+let store_string_char c =
+  Buffer.add_char string_buffer c
+
+let store_string s =
+  Buffer.add_string string_buffer s
+
+let store_lexeme buffer lexbuf =
+  Buffer.add_string buffer (Lexing.lexeme lexbuf)
+
+let get_stored_string () =
+  let str = Buffer.contents string_buffer in
+  let raw =
+    if Buffer.length raw_buffer = 0
+    then None
+    else Some (Buffer.contents raw_buffer)
+  in
+  Buffer.reset string_buffer;
+  Buffer.reset raw_buffer;
+  (str, raw)
+
+(* To store the position of the beginning of a string and comment *)
+let string_start_loc = ref Location.none;;
+let comment_start_loc = ref [];;
+let in_comment () = !comment_start_loc <> [];;
+let is_in_string = ref false
+let in_string () = !is_in_string
+let print_warnings = ref true
+
+(* To "unlex" a few characters *)
+let set_lexeme_length buf n = (
+  let open Lexing in
+  if n < 0 then
+    invalid_arg "set_lexeme_length: offset should be positive";
+  if n > buf.lex_curr_pos - buf.lex_start_pos then
+    invalid_arg "set_lexeme_length: offset larger than lexeme";
+  buf.lex_curr_pos <- buf.lex_start_pos + n;
+  buf.lex_curr_p <- {buf.lex_start_p
+                     with pos_cnum = buf.lex_abs_pos + buf.lex_curr_pos};
+)
+
+(* This cut comment characters of the current buffer.
+ * Operators (including "/*" and "//") are lexed with the same rule, and this
+ * function cuts the lexeme at the beginning of an operator. *)
+let lexeme_without_comment buf = (
+  let lexeme = Lexing.lexeme buf in
+  let i = ref 0 and len = String.length lexeme - 1 in
+  let found = ref (-1) in
+  while !i < len && !found = -1 do
+    begin match lexeme.[!i], lexeme.[!i+1] with
+      | ('/', '*') | ('/', '/') | ('*', '/') ->
+        found := !i;
+      | _ -> ()
+    end;
+    incr i
+  done;
+  match !found with
+  | -1 -> lexeme
+  | n ->
+      set_lexeme_length buf n;
+      String.sub lexeme 0 n
+)
+
+(* Operators that could conflict with comments (those containing /*, */ and //)
+ * are escaped in the source. The lexer removes the escapes so that the
+ * identifier looks like OCaml ones.
+ * An escape in first position is kept to distinguish "verbatim" operators
+ * (\=== for instance). *)
+let unescape_operator str =
+  if (str <> "" && String.contains_from str 1 '\\') then (
+    let b = Buffer.create (String.length str) in
+    Buffer.add_char b str.[0];
+    for i = 1 to String.length str - 1 do
+      let c = str.[i] in
+      if c <> '\\' then Buffer.add_char b c
+    done;
+    Buffer.contents b
+  ) else str
+
+let lexeme_operator lexbuf =
+  unescape_operator (lexeme_without_comment lexbuf)
+
+(* To translate escape sequences *)
+
+let char_for_backslash = function
+  | 'n' -> '\010'
+  | 'r' -> '\013'
+  | 'b' -> '\008'
+  | 't' -> '\009'
+  | c   -> c
+
+let char_for_decimal_code lexbuf i =
+  let c = 100 * (Char.code(Lexing.lexeme_char lexbuf i) - 48) +
+           10 * (Char.code(Lexing.lexeme_char lexbuf (i+1)) - 48) +
+                (Char.code(Lexing.lexeme_char lexbuf (i+2)) - 48) in
+  if (c < 0 || c > 255) then
+    if in_comment ()
+    then 'x'
+    else raise (Error(Illegal_escape (Lexing.lexeme lexbuf),
+                      Location.curr lexbuf))
+  else Char.chr c
+
+let char_for_hexadecimal_code lexbuf i =
+  let d1 = Char.code (Lexing.lexeme_char lexbuf i) in
+  let val1 = if d1 >= 97 then d1 - 87
+             else if d1 >= 65 then d1 - 55
+             else d1 - 48
+  in
+  let d2 = Char.code (Lexing.lexeme_char lexbuf (i+1)) in
+  let val2 = if d2 >= 97 then d2 - 87
+             else if d2 >= 65 then d2 - 55
+             else d2 - 48
+  in
+  Char.chr (val1 * 16 + val2)
+
+(* To convert integer literals, allowing max_int + 1 (PR#4210) *)
+
+let cvt_int_literal s =
+  - int_of_string ("-" ^ s)
+let cvt_int32_literal s =
+  Int32.neg (Int32.of_string ("-" ^ String.sub s 0 (String.length s - 1)))
+let cvt_int64_literal s =
+  Int64.neg (Int64.of_string ("-" ^ String.sub s 0 (String.length s - 1)))
+let cvt_nativeint_literal s =
+  Nativeint.neg (Nativeint.of_string ("-" ^ String.sub s 0
+                                                       (String.length s - 1)))
+
+(* Remove underscores from float literals *)
+
+let remove_underscores s =
+  let l = String.length s in
+  let b = Bytes.create l in
+  let rec remove src dst =
+    if src >= l then
+      if dst >= l then s else Bytes.sub_string b 0 dst
+    else
+      match s.[src] with
+        '_' -> remove (src + 1) dst
+      |  c  -> Bytes.set b dst c; remove (src + 1) (dst + 1)
+  in remove 0 0
+
+(* Update the current location with file name and line number. *)
+
+let update_loc lexbuf file line absolute chars =
+  let pos = lexbuf.lex_curr_p in
+  let new_file = match file with
+                 | None -> pos.pos_fname
+                 | Some s -> s
+  in
+  lexbuf.lex_curr_p <- { pos with
+    pos_fname = new_file;
+    pos_lnum = if absolute then line else pos.pos_lnum + line;
+    pos_bol = pos.pos_cnum - chars;
+  }
+;;
+
+let preprocessor = ref None
+
+(* Error report *)
+
+open Format
+
+let report_error ppf = function
+  | Illegal_character c ->
+      fprintf ppf "Illegal character (%s)" (Char.escaped c)
+  | Illegal_escape s ->
+      fprintf ppf "Illegal backslash escape in string or character (%s)" s
+  | Unterminated_comment _ ->
+      fprintf ppf "Comment not terminated"
+  | Unterminated_string ->
+      fprintf ppf "String literal not terminated"
+  | Unterminated_string_in_comment (_, loc) ->
+      fprintf ppf "This comment contains an unterminated string literal@.\
+                   %aString literal begins here"
+              Location.print_error loc
+  | Keyword_as_label kwd ->
+      fprintf ppf "`%s' is a keyword, it cannot be used as label name" kwd
+  | Literal_overflow ty ->
+      fprintf ppf "Integer literal exceeds the range of representable \
+                   integers of type %s" ty
+  | Invalid_literal s ->
+      fprintf ppf "Invalid literal %s" s
+
+let () =
+  Location.register_error_of_exn
+    (function
+      | Error (err, loc) ->
+          Some (Location.error_of_printer loc report_error err)
+      | _ ->
+          None
+    )
+
+}
+
+
+let newline = ('\013'* '\010')
+let blank = [' ' '\009' '\012']
+let lowercase = ['a'-'z' '_']
+let uppercase = ['A'-'Z']
+let uppercase_or_lowercase = lowercase | uppercase
+let identchar = ['A'-'Z' 'a'-'z' '_' '\'' '0'-'9']
+let lowercase_latin1 = ['a'-'z' '\223'-'\246' '\248'-'\255' '_']
+let uppercase_latin1 = ['A'-'Z' '\192'-'\214' '\216'-'\222']
+let identchar_latin1 =
+  ['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255' '\'' '0'-'9']
+
+let operator_chars =
+  ['!' '$' '%' '&' '+' '-' ':' '<' '=' '>' '?' '@' '^' '|' '~' '#' '.'] |
+  ( '\\'? ['/' '*'] )
+
+let decimal_literal = ['0'-'9'] ['0'-'9' '_']*
+
+let hex_literal =
+  '0' ['x' 'X'] ['0'-'9' 'A'-'F' 'a'-'f']['0'-'9' 'A'-'F' 'a'-'f' '_']*
+let oct_literal =
+  '0' ['o' 'O'] ['0'-'7'] ['0'-'7' '_']*
+let bin_literal =
+  '0' ['b' 'B'] ['0'-'1'] ['0'-'1' '_']*
+
+let int_literal =
+  decimal_literal | hex_literal | oct_literal | bin_literal
+
+let float_literal =
+  ['0'-'9'] ['0'-'9' '_']*
+  ('.' ['0'-'9' '_']* )?
+  (['e' 'E'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']*)?
+
+let hex_float_literal =
+  '0' ['x' 'X']
+  ['0'-'9' 'A'-'F' 'a'-'f'] ['0'-'9' 'A'-'F' 'a'-'f' '_']*
+  ('.' ['0'-'9' 'A'-'F' 'a'-'f' '_']* )?
+  (['p' 'P'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
+
+let literal_modifier = ['G'-'Z' 'g'-'z']
+
+rule token = parse
+  | "\\" newline {
+      match !preprocessor with
+      | None ->
+        raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
+                     Location.curr lexbuf))
+      | Some _ ->
+        update_loc lexbuf None 1 false 0;
+        token lexbuf }
+  | newline
+      { update_loc lexbuf None 1 false 0;
+        match !preprocessor with
+        | None -> token lexbuf
+        | Some _ -> EOL
+      }
+  | blank +
+      { token lexbuf }
+  | "_"
+      { UNDERSCORE }
+  | "~"
+      { TILDE }
+  | "?"
+      { QUESTION }
+  | "=?"
+      { set_lexeme_length lexbuf 1; EQUAL }
+  | lowercase identchar *
+      { let s = Lexing.lexeme lexbuf in
+        try Hashtbl.find keyword_table s
+        with Not_found -> LIDENT s }
+  | lowercase_latin1 identchar_latin1 *
+      { warn_latin1 lexbuf; LIDENT (Lexing.lexeme lexbuf) }
+  | uppercase identchar *
+      { UIDENT(Lexing.lexeme lexbuf) }       (* No capitalized keywords *)
+  | uppercase_latin1 identchar_latin1 *
+      { warn_latin1 lexbuf; UIDENT(Lexing.lexeme lexbuf) }
+  | int_literal { INT (Lexing.lexeme lexbuf, None) }
+  | (int_literal as lit) (literal_modifier as modif)
+      { INT (lit, Some modif) }
+  | float_literal | hex_float_literal
+      { FLOAT (Lexing.lexeme lexbuf, None) }
+  | ((float_literal | hex_float_literal) as lit) (literal_modifier as modif)
+      { FLOAT (lit, Some modif) }
+  | (float_literal | hex_float_literal | int_literal) identchar+
+      { raise (Error(Invalid_literal (Lexing.lexeme lexbuf),
+                     Location.curr lexbuf)) }
+  | "\""
+      { reset_string_buffer();
+        is_in_string := true;
+        let string_start = lexbuf.lex_start_p in
+        string_start_loc := Location.curr lexbuf;
+        string raw_buffer lexbuf;
+        is_in_string := false;
+        lexbuf.lex_start_p <- string_start;
+        let text, raw = get_stored_string() in
+        STRING (text, raw, None) }
+  | "{" lowercase* "|"
+      { reset_string_buffer();
+        let delim = Lexing.lexeme lexbuf in
+        let delim = String.sub delim 1 (String.length delim - 2) in
+        is_in_string := true;
+        let string_start = lexbuf.lex_start_p in
+        string_start_loc := Location.curr lexbuf;
+        quoted_string delim lexbuf;
+        is_in_string := false;
+        lexbuf.lex_start_p <- string_start;
+        STRING (fst (get_stored_string()), None, Some delim) }
+  | "'" newline "'"
+      { update_loc lexbuf None 1 false 1;
+        CHAR (Lexing.lexeme_char lexbuf 1) }
+  | "'" [^ '\\' '\'' '\010' '\013'] "'"
+      { CHAR(Lexing.lexeme_char lexbuf 1) }
+  | "'\\" ['\\' '\'' '"' 'n' 't' 'b' 'r' ' '] "'"
+      { CHAR(char_for_backslash (Lexing.lexeme_char lexbuf 2)) }
+  | "'\\" ['0'-'9'] ['0'-'9'] ['0'-'9'] "'"
+      { CHAR(char_for_decimal_code lexbuf 2) }
+  | "'\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] "'"
+      { CHAR(char_for_hexadecimal_code lexbuf 3) }
+  | "'\\" _
+      { let l = Lexing.lexeme lexbuf in
+        let esc = String.sub l 1 (String.length l - 1) in
+        raise (Error(Illegal_escape esc, Location.curr lexbuf))
+      }
+  | "#=<" {
+    (* Allow parsing of foo#=<bar /> *)
+    set_lexeme_length lexbuf 2;
+    SHARPEQUAL
+  }
+  | "#=" { SHARPEQUAL }
+  | "#" operator_chars+
+      { SHARPOP(lexeme_operator lexbuf) }
+  | "#" [' ' '\t']* (['0'-'9']+ as num) [' ' '\t']*
+        ("\"" ([^ '\010' '\013' '"' ] * as name) "\"")?
+        [^ '\010' '\013'] * newline
+      { update_loc lexbuf name (int_of_string num) true 0;
+        token lexbuf
+      }
+  | "&"  { AMPERSAND }
+  | "&&" { AMPERAMPER }
+  | "`"  { BACKQUOTE }
+  | "'"  { QUOTE }
+  | "("  { LPAREN }
+  | ")"  { RPAREN }
+  | "*"  { STAR }
+  | ","  { COMMA }
+  | "->" { MINUSGREATER }
+  | "=>" { EQUALGREATER }
+  (* allow lexing of | `Variant =><Component /> *)
+  | "=><" uppercase_or_lowercase (identchar | '.') * {
+    set_lexeme_length lexbuf 2;
+    EQUALGREATER
+  }
+  | "#"  { SHARP }
+  | "."  { DOT }
+  | ".." { DOTDOT }
+  | "..."{ DOTDOTDOT }
+  | ":"  { COLON }
+  | "::" { COLONCOLON }
+  | ":=" { COLONEQUAL }
+  | ":>" { COLONGREATER }
+  | ";"  { SEMI }
+  | ";;" { SEMISEMI }
+  | "<"  { LESS }
+  | "="  { EQUAL }
+  | "["  { LBRACKET }
+  | "[|" { LBRACKETBAR }
+  | "[<" { LBRACKETLESS }
+  | "[>" { LBRACKETGREATER }
+  | "<" (uppercase identchar* '.')* lowercase identchar* {
+    let buf = Lexing.lexeme lexbuf in
+    LESSIDENT (String.sub buf 1 (String.length buf - 1))
+  }
+  | ">..." { GREATERDOTDOTDOT }
+  (* Allow parsing of Pexp_override:
+   * let z = {<state: 0, x: y>};
+   *
+   * Make sure {<state is emitted as LBRACELESS.
+   * This contrasts with jsx:
+   * in a jsx context {<div needs to be LBRACE LESS (two tokens)
+   * for a valid parse.
+   *)
+  | "{<" uppercase_or_lowercase identchar* blank*  ":" {
+    set_lexeme_length lexbuf 2;
+    LBRACELESS
+  }
+  | "{<" uppercase_or_lowercase (identchar | '.') * {
+    (* allows parsing of `{<Text` in <Description term={<Text text="Age" />}> as correct jsx *)
+    set_lexeme_length lexbuf 1;
+    LBRACE
+  }
+  | "</" blank* uppercase_or_lowercase (identchar | '.') * blank* ">" {
+    let buf = Lexing.lexeme lexbuf in
+    LESSSLASHIDENTGREATER (String.trim (String.sub buf 2 (String.length buf - 2 - 1)))
+  }
+  | "]"  { RBRACKET }
+  | "{"  { LBRACE }
+  | "{<" { LBRACELESS }
+  | "|"  { BAR }
+  | "||" { BARBAR }
+  | "|]" { BARRBRACKET }
+  | ">"  { GREATER }
+  (* Having a GREATERRBRACKET makes it difficult to parse patterns such
+     as > ]. The space in between then becomes significant and must be
+     maintained when printing etc. >] isn't even needed!
+  | ">]" { GREATERRBRACKET }
+  *)
+  | "}"  { RBRACE }
+  | ">}" { GREATERRBRACE }
+  | "=<" uppercase_or_lowercase+ {
+    (* allow `let x=<div />;` *)
+    set_lexeme_length lexbuf 1;
+    EQUAL
+  }
+  (* jsx in arrays: [|<div />|]*)
+  | "/>|]" {
+    set_lexeme_length lexbuf 2;
+    SLASHGREATER
+  }
+  | "[|<" {
+    set_lexeme_length lexbuf 2;
+    LBRACKETBAR
+  }
+    (* allow parsing of <div /></Component> *)
+  | "/></" uppercase_or_lowercase+ {
+    (* allow parsing of <div asd=1></div> *)
+    set_lexeme_length lexbuf 2;
+    SLASHGREATER
+  }
+  | "></" uppercase_or_lowercase+ {
+    (* allow parsing of <div asd=1></div> *)
+    set_lexeme_length lexbuf 1;
+    GREATER
+  }
+  | "><" uppercase_or_lowercase+ {
+    (* allow parsing of <div><span> *)
+    set_lexeme_length lexbuf 1;
+    GREATER
+  }
+  | "[@" { LBRACKETAT }
+  | "[%" { LBRACKETPERCENT }
+  | "[%%" { LBRACKETPERCENTPERCENT }
+  | "!"  { BANG }
+  | "!=" { INFIXOP0 "!=" }
+  | "!==" { INFIXOP0 "!==" }
+  | "\\!=" { INFIXOP0 "!=" }
+  | "\\!==" { INFIXOP0 "!==" }
+  | "+"  { PLUS }
+  | "+." { PLUSDOT }
+  | "+=" { PLUSEQ }
+  | "-"  { MINUS }
+  | "-." { MINUSDOT }
+  | "<>" { LESSGREATER }
+  | "</>" { LESSSLASHGREATER }
+  | "<..>" { LESSDOTDOTGREATER }
+  | '\\'? ['~' '?' '!'] operator_chars+
+            { PREFIXOP(lexeme_operator lexbuf) }
+  | '\\'? ['=' '<' '>' '|' '&' '$'] operator_chars*
+            {
+              INFIXOP0(lexeme_operator lexbuf)
+            }
+  | '\\'? '@' operator_chars*
+            { INFIXOP1(lexeme_operator lexbuf) }
+  | '\\'? '^' ('\\' '.')? operator_chars*
+            { match lexeme_without_comment lexbuf with
+              | "^." -> set_lexeme_length lexbuf 1; POSTFIXOP("^")
+              | "^|" ->
+                  (* ^| is not an infix op in [|a^|] *)
+                  set_lexeme_length lexbuf 1; POSTFIXOP("^")
+              | "^" -> POSTFIXOP("^")
+              | op -> INFIXOP1(unescape_operator op) }
+  | "++" operator_chars*
+            { INFIXOP1(lexeme_operator lexbuf) }
+  | '\\'? ['+' '-'] operator_chars*
+            { INFIXOP2(lexeme_operator lexbuf) }
+  (* SLASHGREATER is an INFIXOP3 that is handled specially *)
+  | "/>" { SLASHGREATER }
+  (* The second star must be escaped so that the precedence assumptions for
+   * printing match those of parsing. (Imagine what could happen if the other
+   * rule beginning with * picked up */*, and we internally escaped it to **.
+   * Whe printing, we have an understanding of the precedence of "**", which
+   * enables us to safely print/group it, but that understanding would not
+   * match the *actual* precedence that it was parsed at thanks to the *other*
+   * rule beginning with *, picking it up instead of the special double ** rule
+   * below.
+   *)
+  | '\\'? '*' '\\'? '*' operator_chars*
+            { INFIXOP4(lexeme_operator lexbuf) }
+  | '%'     { PERCENT }
+  | '\\'? ['/' '*'] operator_chars*
+            { match lexeme_operator lexbuf with
+              | "" ->
+                  (* If the operator is empty, it means the lexeme is beginning
+                   * by a comment sequence: we let the comment lexer handle
+                   * the case. *)
+                  enter_comment lexbuf
+              | op -> INFIXOP3 op }
+  | '%' operator_chars*
+            { INFIXOP3(lexeme_operator lexbuf) }
+  | eof { EOF }
+  | _
+      { raise (Error(Illegal_character (Lexing.lexeme_char lexbuf 0),
+                     Location.curr lexbuf))
+      }
+
+and enter_comment = parse
+  | "//" ([^'\010']* newline as line)
+      { update_loc lexbuf None 1 false 0;
+        let physical_loc = Location.curr lexbuf in
+        let location = { physical_loc with
+          loc_end = { physical_loc.loc_end with
+            (* Don't track trailing `\n` in the location
+             * 1| // comment
+             * 2| let x = 1;
+             * By omitting the `\n` at the end of line 1, the location of the
+             * comment spans line 1. Otherwise the comment on line 1 would end
+             * on the second line. The printer looks at the closing pos_lnum
+             * location to interleave whitespace correct. It needs to align
+             * with what we visually see (i.e. it ends on line 1) *)
+            pos_lnum = physical_loc.loc_end.pos_lnum - 1;
+            pos_cnum = physical_loc.loc_end.pos_cnum + 1;
+        }} in
+        COMMENT (line, location)
+      }
+  | "/*" ("*" "*"+)?
+      { set_lexeme_length lexbuf 2;
+        let start_loc = Location.curr lexbuf  in
+        comment_start_loc := [start_loc];
+        reset_string_buffer ();
+        let {Location. loc_end; _} = comment lexbuf in
+        let s, _ = get_stored_string () in
+        reset_string_buffer ();
+        COMMENT (s, { start_loc with Location.loc_end })
+      }
+  | "/**"
+      { let start_p = lexbuf.Lexing.lex_start_p in
+        let start_loc = Location.curr lexbuf in
+        comment_start_loc := [start_loc];
+        reset_string_buffer ();
+        let _ = comment lexbuf in
+        let s, _ = get_stored_string () in
+        reset_string_buffer ();
+        lexbuf.Lexing.lex_start_p <- start_p;
+        DOCSTRING s
+      }
+  | "/**/"
+      { DOCSTRING "" }
+  | "/*/"
+      { let loc = Location.curr lexbuf  in
+        if !print_warnings then
+          Location.prerr_warning loc Warnings.Comment_start;
+        comment_start_loc := [loc];
+        reset_string_buffer ();
+        let {Location. loc_end; _} = comment lexbuf in
+        let s, _ = get_stored_string () in
+        reset_string_buffer ();
+        COMMENT (s, { loc with Location.loc_end })
+      }
+  | "*/"
+      { let loc = Location.curr lexbuf in
+        Location.prerr_warning loc Warnings.Comment_not_end;
+        set_lexeme_length lexbuf 1;
+        STAR
+      }
+  | _ { assert false }
+
+and comment = parse
+    "/*"
+      { comment_start_loc := (Location.curr lexbuf) :: !comment_start_loc;
+        store_lexeme string_buffer lexbuf;
+        comment lexbuf;
+      }
+  | "*/"
+      { match !comment_start_loc with
+        | [] -> assert false
+        | [_] -> comment_start_loc := []; Location.curr lexbuf
+        | _ :: l -> comment_start_loc := l;
+                  store_lexeme string_buffer lexbuf;
+                  comment lexbuf;
+       }
+  | "\""
+      {
+        string_start_loc := Location.curr lexbuf;
+        store_string_char '"';
+        is_in_string := true;
+        begin try string string_buffer lexbuf
+        with Error (Unterminated_string, str_start) ->
+          match !comment_start_loc with
+          | [] -> assert false
+          | loc :: _ ->
+            let start = List.hd (List.rev !comment_start_loc) in
+            comment_start_loc := [];
+            raise (Error (Unterminated_string_in_comment (start, str_start),
+                          loc))
+        end;
+        is_in_string := false;
+        store_string_char '"';
+        comment lexbuf }
+  | "{" lowercase* "|"
+      {
+        let delim = Lexing.lexeme lexbuf in
+        let delim = String.sub delim 1 (String.length delim - 2) in
+        string_start_loc := Location.curr lexbuf;
+        store_lexeme string_buffer lexbuf;
+        is_in_string := true;
+        begin try quoted_string delim lexbuf
+        with Error (Unterminated_string, str_start) ->
+          match !comment_start_loc with
+          | [] -> assert false
+          | loc :: _ ->
+            let start = List.hd (List.rev !comment_start_loc) in
+            comment_start_loc := [];
+            raise (Error (Unterminated_string_in_comment (start, str_start),
+                          loc))
+        end;
+        is_in_string := false;
+        store_string_char '|';
+        store_string delim;
+        store_string_char '}';
+        comment lexbuf }
+
+  | "''"
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+  | "'" newline "'"
+      { update_loc lexbuf None 1 false 1;
+        store_lexeme string_buffer lexbuf;
+        comment lexbuf
+      }
+  | "'" [^ '\\' '\'' '\010' '\013' ] "'"
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+  | "'\\" ['\\' '"' '\'' 'n' 't' 'b' 'r' ' '] "'"
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+  | "'\\" ['0'-'9'] ['0'-'9'] ['0'-'9'] "'"
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+  | "'\\" 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F'] "'"
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+  | eof
+      { match !comment_start_loc with
+        | [] -> assert false
+        | loc :: _ ->
+          let start = List.hd (List.rev !comment_start_loc) in
+          comment_start_loc := [];
+          raise (Error (Unterminated_comment start, loc))
+      }
+  | newline
+      { update_loc lexbuf None 1 false 0;
+        store_lexeme string_buffer lexbuf;
+        comment lexbuf
+      }
+  | _
+      { store_lexeme string_buffer lexbuf; comment lexbuf }
+
+and string rawbuffer = parse
+    '"'
+      { () }
+  | '\\' newline ([' ' '\t'] * as space)
+      { update_loc lexbuf None 1 false (String.length space);
+        store_lexeme rawbuffer lexbuf;
+        string rawbuffer lexbuf
+      }
+  | '\\' ['\\' '\'' '"' 'n' 't' 'b' 'r' ' ']
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then
+          store_string_char(char_for_backslash(Lexing.lexeme_char lexbuf 1));
+        string rawbuffer lexbuf }
+  | '\\' ['0'-'9'] ['0'-'9'] ['0'-'9']
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then
+          store_string_char(char_for_decimal_code lexbuf 1);
+        string rawbuffer lexbuf }
+  | '\\' 'x' ['0'-'9' 'a'-'f' 'A'-'F'] ['0'-'9' 'a'-'f' 'A'-'F']
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then
+          store_string_char(char_for_hexadecimal_code lexbuf 2);
+        string rawbuffer lexbuf }
+  | '\\' _
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then
+        begin
+(*  Should be an error, but we are very lax.
+          raise (Error (Illegal_escape (Lexing.lexeme lexbuf),
+                        Location.curr lexbuf))
+*)
+          let loc = Location.curr lexbuf in
+          Location.prerr_warning loc Warnings.Illegal_backslash;
+          store_string_char (Lexing.lexeme_char lexbuf 0);
+          store_string_char (Lexing.lexeme_char lexbuf 1);
+        end;
+        string rawbuffer lexbuf
+      }
+  | newline
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then (
+          store_lexeme string_buffer lexbuf;
+          Location.prerr_warning (Location.curr lexbuf) Warnings.Eol_in_string
+        );
+        update_loc lexbuf None 1 false 0;
+        string rawbuffer lexbuf
+      }
+  | eof
+      { is_in_string := false;
+        raise (Error (Unterminated_string, !string_start_loc)) }
+  | _
+      { store_lexeme rawbuffer lexbuf;
+        if not (in_comment ()) then
+          store_string_char(Lexing.lexeme_char lexbuf 0);
+        string rawbuffer lexbuf }
+
+and quoted_string delim = parse
+  | newline
+      { update_loc lexbuf None 1 false 0;
+        store_lexeme string_buffer lexbuf;
+        quoted_string delim lexbuf
+      }
+  | eof
+      { is_in_string := false;
+        raise (Error (Unterminated_string, !string_start_loc)) }
+  | "|" lowercase* "}"
+      {
+        let edelim = Lexing.lexeme lexbuf in
+        let edelim = String.sub edelim 1 (String.length edelim - 2) in
+        if delim = edelim then ()
+        else (store_lexeme string_buffer lexbuf;
+              quoted_string delim lexbuf)
+      }
+  | _
+      { store_string_char (Lexing.lexeme_char lexbuf 0);
+        quoted_string delim lexbuf }
+
+and skip_sharp_bang = parse
+  | "#!" [^ '\n']* '\n' [^ '\n']* "\n!#\n"
+       { update_loc lexbuf None 3 false 0 }
+  | "#!" [^ '\n']* '\n'
+       { update_loc lexbuf None 1 false 0 }
+  | "" { () }
+
+{
+
+  (* Filter commnets *)
+
+  let token_with_comments lexbuf =
+    match !preprocessor with
+    | None -> token lexbuf
+    | Some (_init, preprocess) -> preprocess token lexbuf
+
+  let last_comments = ref []
+
+  let rec token lexbuf =
+    match token_with_comments lexbuf with
+        COMMENT (s, comment_loc) ->
+          last_comments := (s, comment_loc) :: !last_comments;
+          token lexbuf
+      | tok -> tok
+
+  let add_invalid_docstring text loc =
+    let open Location in
+    let rec aux = function
+      | ((_, loc') as x) :: xs
+        when loc'.loc_start.pos_cnum > loc.loc_start.pos_cnum ->
+        x :: aux xs
+      | xs -> (text, loc) :: xs
+    in
+    last_comments := aux !last_comments
+
+  let comments () = List.rev !last_comments
+
+  (* Routines for manipulating lexer state *)
+
+  let save_triple lexbuf tok =
+    (tok, lexbuf.lex_start_p, lexbuf.lex_curr_p)
+
+  let load_triple lexbuf (tok, p1, p2) = (
+    lexbuf.lex_start_p <- p1;
+    lexbuf.lex_curr_p <- p2;
+    tok
+  )
+
+  let fake_triple t (_, pos, _) =
+    (t, pos, pos)
+
+  (* insert ES6_FUN *)
+
+  exception Lex_balanced_failed of (token * position * position) list *
+                                   (exn * position * position) option
+
+  let closing_of = function
+    | LPAREN -> RPAREN
+    | LBRACE -> RBRACE
+    | _ -> assert false
+
+  let inject_es6_fun = function
+    | tok :: acc ->
+      tok :: fake_triple ES6_FUN tok :: acc
+    | _ -> assert false
+
+  let is_triggering_token = function
+    | EQUALGREATER | COLON -> true
+    | _ -> false
+
+  let rec lex_balanced_step closing lexbuf acc tok =
+    let acc = save_triple lexbuf tok :: acc in
+    match tok, closing with
+    | (RPAREN, RPAREN) | (RBRACE, RBRACE) | (RBRACKET, RBRACKET) ->
+      acc
+    | ((RPAREN | RBRACE | RBRACKET | EOF), _) ->
+      raise (Lex_balanced_failed (acc, None))
+    | (( LBRACKET | LBRACKETLESS | LBRACKETGREATER
+       | LBRACKETAT
+       | LBRACKETPERCENT | LBRACKETPERCENTPERCENT ), _) ->
+      lex_balanced closing lexbuf (lex_balanced RBRACKET lexbuf acc)
+    | ((LPAREN | LBRACE), _) ->
+      let rparen =
+        try lex_balanced (closing_of tok) lexbuf []
+        with (Lex_balanced_failed (rparen, None)) ->
+          raise (Lex_balanced_failed (rparen @ acc, None))
+      in
+      begin match token lexbuf with
+      | exception exn ->
+        raise (Lex_balanced_failed (rparen @ acc, Some (save_triple lexbuf exn)))
+      | tok' ->
+        let acc = if is_triggering_token tok' then inject_es6_fun acc else acc in
+        lex_balanced_step closing lexbuf (rparen @ acc) tok'
+      end
+    | ((LIDENT _ | UNDERSCORE), _) ->
+      begin match token lexbuf with
+      | exception exn ->
+        raise (Lex_balanced_failed (acc, Some (save_triple lexbuf exn)))
+      | tok' ->
+        let acc = if is_triggering_token tok' then inject_es6_fun acc else acc in
+        lex_balanced_step closing lexbuf acc tok'
+      end
+    (* `...` with a closing `}` indicates that we're definitely not in an es6_fun
+     * Image the following:
+     *    true ? (Update({...a, b: 1}), None) : x;
+     *    true ? ({...a, b: 1}) : a;
+     *    true ? (a, {...a, b: 1}) : a;
+     * The lookahead_esfun is triggered initiating the lex_balanced procedure.
+     * Since we now "over"-parse spread operators in pattern position (for
+     * better errors), the ... pattern in ({...a, b: 1}) is now a valid path.
+     * This means that the above expression `({...a, b: 1}) :` is seen as a pattern.
+     * I.e. the arguments of an es6 function: (pattern) :type => expr
+     * We exit here, to indicate that an expression needs to be parsed instead
+     * of a pattern.
+     *)
+    | (DOTDOTDOT, RBRACE) -> acc
+    | _ -> lex_balanced closing lexbuf acc
+
+  and lex_balanced closing lexbuf acc =
+    match token lexbuf with
+    | exception exn ->
+      raise (Lex_balanced_failed (acc, Some (save_triple lexbuf exn)))
+    | tok -> lex_balanced_step closing lexbuf acc tok
+
+  let queued_tokens = ref []
+  let queued_exn = ref None
+
+  let lookahead_esfun lexbuf (tok, _, _ as lparen) =
+    let triple =
+      match lex_balanced (closing_of tok) lexbuf [] with
+      | exception (Lex_balanced_failed (tokens, exn)) ->
+        queued_tokens := List.rev tokens;
+        queued_exn := exn;
+        lparen
+      | tokens ->
+        begin match token lexbuf with
+          | exception exn ->
+            queued_tokens := List.rev tokens;
+            queued_exn := Some (save_triple lexbuf exn);
+            lparen
+          | token ->
+            let tokens = save_triple lexbuf token :: tokens in
+            if is_triggering_token token then (
+              queued_tokens := lparen :: List.rev tokens;
+              fake_triple ES6_FUN lparen
+            ) else (
+              queued_tokens := List.rev tokens;
+              lparen
+            )
+        end
+    in
+    load_triple lexbuf triple
+
+  let token lexbuf =
+    match !queued_tokens, !queued_exn with
+    | [], Some exn ->
+      queued_exn := None;
+      raise (load_triple lexbuf exn)
+    | [(LPAREN, _, _) as lparen], None ->
+      let _ = load_triple lexbuf lparen in
+      lookahead_esfun lexbuf lparen
+    | [(LBRACE, _, _) as lparen], None ->
+      let _ = load_triple lexbuf lparen in
+      lookahead_esfun lexbuf lparen
+    | [], None ->
+      begin match token lexbuf with
+      | LPAREN | LBRACE as tok ->
+          lookahead_esfun lexbuf (save_triple lexbuf tok)
+      | (LIDENT _ | UNDERSCORE) as tok ->
+          let tok = save_triple lexbuf tok in
+          begin match token lexbuf with
+          | exception exn ->
+              queued_exn := Some (save_triple lexbuf exn);
+              load_triple lexbuf tok
+          | tok' ->
+            if is_triggering_token tok' then (
+              queued_tokens := [tok; save_triple lexbuf tok'];
+              load_triple lexbuf (fake_triple ES6_FUN tok)
+            ) else (
+              queued_tokens := [save_triple lexbuf tok'];
+              load_triple lexbuf tok
+            )
+          end
+      | token -> token
+      end
+    | x :: xs, _ -> queued_tokens := xs; load_triple lexbuf x
+
+  let completion_ident_offset = ref min_int
+  let completion_ident_pos = ref Lexing.dummy_pos
+
+  let token lexbuf =
+    let space_start = lexbuf.Lexing.lex_curr_p.Lexing.pos_cnum in
+    let token = token lexbuf in
+    let token_start = lexbuf.Lexing.lex_start_p.Lexing.pos_cnum in
+    let token_stop = lexbuf.Lexing.lex_curr_p.Lexing.pos_cnum in
+    if !completion_ident_offset > min_int &&
+       space_start <= !completion_ident_offset &&
+       token_stop >= !completion_ident_offset then (
+      match token with
+      | LIDENT _ | UIDENT _ when token_start <= !completion_ident_offset ->
+          completion_ident_offset := min_int;
+          token
+      | _ ->
+        queued_tokens := save_triple lexbuf token :: !queued_tokens;
+        completion_ident_offset := min_int;
+        load_triple lexbuf
+          (LIDENT "_", !completion_ident_pos, !completion_ident_pos)
+    ) else
+      token
+
+  let init ?insert_completion_ident () =
+    is_in_string := false;
+    last_comments := [];
+    comment_start_loc := [];
+    queued_tokens := [];
+    queued_exn := None;
+    begin match insert_completion_ident with
+      | None ->
+        completion_ident_offset := min_int;
+      | Some pos ->
+        completion_ident_offset := pos.Lexing.pos_cnum;
+        completion_ident_pos := pos
+    end;
+    match !preprocessor with
+    | None -> ()
+    | Some (init, _preprocess) -> init ()
+
+  let set_preprocessor init preprocess =
+    preprocessor := Some (init, preprocess)
+
+}

--- a/tools/liquidity/reason/reason_location.ml
+++ b/tools/liquidity/reason/reason_location.ml
@@ -1,0 +1,72 @@
+module Comment = Reason_comment
+
+module Range = struct
+  (** [t] represents an interval, including endpoints,
+   * delimited by two linenumbers. *)
+  type t = {
+    lnum_start: int;
+    lnum_end: int
+  }
+
+  (**
+   * make a range delimited by [loc1] and [loc2]
+   * 1| let a = 1;
+   * 2|
+   * 3|
+   * 4|
+   * 5| let b = 2;
+   * If loc1 represents `let a = 1` and loc2 represents `let b = 2`,
+   * we get the range: {lnum_start: 2; lnum_end 4}
+   *)
+  let makeRangeBetween loc1 loc2 = Location.{
+    lnum_start = loc1.loc_end.pos_lnum + 1;
+    lnum_end = loc2.loc_start.pos_lnum - 1;
+  }
+
+  (** check whether [range] contains the [loc] *)
+  let containsLoc range loc =
+    let open Location in
+    range.lnum_start <= loc.loc_start.pos_lnum
+    && range.lnum_end >= loc.loc_end.pos_lnum
+
+  (**
+   * checks if [range] contains whitespace.
+   * When comments are passed, the computation
+   * takes the height of the comments into account.
+   *
+   * Example:
+   * 1| let a = 1;
+   * 2|
+   * 3| /* a multi-
+   * 4|   line comment */
+   * 5| let b = 1;
+   * The range (line 2 - line 4) has whitespace.
+   *
+   * 1| let a = 1;
+   * 2| /* a multi-
+   * 3|   line comment */
+   * 4| let b = 1;
+   * The range (line 2 - line 3) does not have whitespace.
+   *)
+  let containsWhitespace ?comments ~range () =
+    (* compute the amount of lines the comments occupy in the given range *)
+    let h = match comments with
+    | Some(comments) ->
+      List.fold_left (fun acc (curr : Comment.t) ->
+        let cl = Comment.location curr in
+        let open Location in
+        let startLnum = cl.loc_start.pos_lnum in
+        let endLnum = cl.loc_end.pos_lnum in
+        if containsLoc range cl then
+          acc + (endLnum - startLnum + 1)
+        else acc
+        ) 0 comments
+    | None -> 0
+    in
+    range.lnum_end - range.lnum_start - h >= 0
+end
+
+(** compute if there's space (one or more line) between [loc1] and [loc2] *)
+let hasSpaceBetween loc1 loc2 =
+  Location.(loc1.loc_start.pos_lnum - loc2.loc_end.pos_lnum) > 1
+

--- a/tools/liquidity/reason/reason_parser.mly
+++ b/tools/liquidity/reason/reason_parser.mly
@@ -1,0 +1,4976 @@
+(*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *  Forked from OCaml, which is provided under the license below:
+ *
+ *  Xavier Leroy, projet Cristal, INRIA Rocquencourt
+ *
+ *  Copyright © 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006 Inria
+ *
+ *  Permission is hereby granted, free of charge, to the Licensee obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense
+ *  under any license of the Licensee's choice, and/or sell copies of the
+ *  Software, subject to the following conditions:
+ *
+ *  1.	Redistributions of source code must retain the above copyright notice
+ *  and the following disclaimer.
+ *  2.	Redistributions in binary form must reproduce the above copyright
+ *  notice, the following disclaimer in the documentation and/or other
+ *  materials provided with the distribution.
+ *  3.	All advertising materials mentioning features or use of the Software
+ *  must display the following acknowledgement: This product includes all or
+ *  parts of the Caml system developed by Inria and its contributors.
+ *  4.	Other than specified in clause 3, neither the name of Inria nor the
+ *  names of its contributors may be used to endorse or promote products
+ *  derived from the Software without specific prior written permission.
+ *
+ *  Disclaimer
+ *
+ *  This software is provided by Inria and contributors “as is” and any express
+ *  or implied warranties, including, but not limited to, the implied
+ *  warranties of merchantability and fitness for a particular purpose are
+ *  disclaimed. in no event shall Inria or its contributors be liable for any
+ *  direct, indirect, incidental, special, exemplary, or consequential damages
+ *  (including, but not limited to, procurement of substitute goods or
+ *  services; loss of use, data, or profits; or business interruption) however
+ *  caused and on any theory of liability, whether in contract, strict
+ *  liability, or tort (including negligence or otherwise) arising in any way
+ *  out of the use of this software, even if advised of the possibility of such
+ *  damage.
+ *
+ *)
+
+(* The parser definition *)
+
+%{
+open Migrate_parsetree.OCaml_404.Ast
+open Reason_syntax_util
+open Location
+open Asttypes
+open Longident
+open Parsetree
+open Ast_helper
+open Ast_mapper
+open Reason_string
+
+(*
+   TODO:
+   - Remove all [open]s from the top of this file one by one and fix compilation
+   failures that ensue by specifying the appropriate long identifiers. That
+   will make the parser much easier to reason about.
+   - Go back to trunk, do the same (remove [open]s, and fully specify long
+   idents), to perform a clean diff.
+
+*)
+
+(**
+
+   location.ml:
+   ------------
+   let mkloc txt loc = { txt ; loc }
+   let rhs_loc n = {
+     loc_start = Parsing.rhs_start_pos n;
+     loc_end = Parsing.rhs_end_pos n;
+     loc_ghost = false;
+   }
+   let symbol_rloc () = {
+     loc_start = Parsing.symbol_start_pos ();
+     loc_end = Parsing.symbol_end_pos ();
+     loc_ghost = false;
+   }
+
+   let symbol_gloc () = {
+     loc_start = Parsing.symbol_start_pos ();
+     loc_end = Parsing.symbol_end_pos ();
+     loc_ghost = true;
+   }
+
+   ast_helper.ml:
+   ------------
+   module Typ = struct
+    val mk: ?loc:loc -> ?attrs:attrs -> core_type_desc -> core_type
+    let mk ?(loc = !default_loc) ?(attrs = []) d =
+       {ptyp_desc = d; ptyp_loc = loc; ptyp_attributes = attrs}
+     ..
+   end
+
+   parse_tree.mli
+   --------------
+   and core_type = {
+     ptyp_desc: core_type_desc;
+     ptyp_loc: Location.t;
+     ptyp_attributes: attributes; (* ... [@id1] [@id2] *)
+   }
+
+   and core_type_desc =
+     | Ptyp_any
+           (*  _ *)
+     | Ptyp_var of string
+           (* 'a *)
+     | Ptyp_arrow of label * core_type * core_type
+           (* T1 -> T2       (label = "")
+              ~l:T1 -> T2    (label = "l")
+              ?l:T1 -> T2    (label = "?l")
+            *)
+     | Ptyp_tuple of core_type list
+           (* T1 * ... * Tn   (n >= 2) *)
+
+   reason_parser.mly
+   ---------------
+   In general:
+
+                                          syntax variant          {pblah_desc: core_blah_desc
+                                                                   pblah_loc: {txt, loc}
+                                                                   pblah_attributes: ... }
+                                         /              \            /       \
+   val mkblah: ~loc -> ~attributes ->     core_blah_desc     ->      core_blah
+   let mkblah = Blah.mk
+
+*)
+
+let uncurry_payload ?(name="bs") loc = ({loc; txt = name}, PStr [])
+
+let dummy_loc () = {
+  loc_start = Lexing.dummy_pos;
+  loc_end = Lexing.dummy_pos;
+  loc_ghost = false;
+}
+
+let mklocation loc_start loc_end = {
+  loc_start = loc_start;
+  loc_end = loc_end;
+  loc_ghost = false;
+}
+
+let with_txt a txt = {
+    a with txt=txt;
+}
+
+let make_real_loc loc = {
+    loc with loc_ghost = false
+}
+
+let make_ghost_loc loc = {
+    loc with loc_ghost = true
+}
+
+let ghloc ?(loc=dummy_loc ()) d = { txt = d; loc = (make_ghost_loc loc) }
+
+(**
+  * turn an object into a real
+  *)
+let make_real_exp exp = {
+    exp with pexp_loc = make_real_loc exp.pexp_loc
+}
+let make_real_pat pat = {
+    pat with ppat_loc = make_real_loc pat.ppat_loc
+}
+(*
+ * change the location state to be a ghost location or real location
+ *)
+let set_loc_state is_ghost loc =
+    if is_ghost then make_ghost_loc loc else make_real_loc loc
+
+let mktyp ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Typ.mk ~loc d
+
+let mkpat ?(attrs=[]) ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Pat.mk ~loc ~attrs d
+
+let mkexp ?(attrs=[]) ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Exp.mk ~loc ~attrs d
+
+let mkmty ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Mty.mk ~loc d
+
+let mksig ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Sig.mk ~loc d
+
+let mkmod ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Mod.mk ~loc d
+
+let mkstr ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Str.mk ~loc d
+
+let mkclass ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Cl.mk ~loc d
+
+let mkcty ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Cty.mk ~loc d
+
+let mkctf ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Ctf.mk ~loc d
+
+let may_tuple startp endp = function
+  | []  -> assert false
+  | [x] -> {x with pexp_loc = mklocation startp endp}
+  | xs  -> mkexp ~loc:(mklocation startp endp) (Pexp_tuple xs)
+
+(**
+  Make a core_type from a as_loc(LIDENT).
+  Useful for record type punning.
+  type props = {width: int, height: int};
+  type state = {nbrOfClicks: int};
+  type component = {props, state};
+*)
+let mkct lbl =
+  let lident = Lident lbl.txt in
+  let ttype = Ptyp_constr({txt = lident; loc = lbl.loc}, []) in
+  {ptyp_desc = ttype; ptyp_loc = lbl.loc; ptyp_attributes = []}
+
+let mkcf ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Cf.mk ~loc d
+
+let simple_ghost_text_attr ?(loc=dummy_loc ()) txt =
+  let loc = set_loc_state true loc in
+  [({txt; loc}, PStr [])]
+
+let mkExplicitArityTuplePat ?(loc=dummy_loc ()) pat =
+  (* Tell OCaml type system that what this tuple construction represents is
+     not actually a tuple, and should represent several constructor
+     arguments.  This allows the syntax the ability to distinguish between:
+
+     X (10, 20)  -- One argument constructor
+     X 10 20     -- Multi argument constructor
+  *)
+  mkpat
+    ~loc
+    ~attrs:(simple_ghost_text_attr ~loc "explicit_arity")
+    pat
+
+let mkExplicitArityTupleExp ?(loc=dummy_loc ()) exp_desc =
+  mkexp
+    ~loc
+    ~attrs:(simple_ghost_text_attr ~loc "explicit_arity")
+    exp_desc
+
+let is_pattern_list_single_any = function
+  | [{ppat_desc=Ppat_any; ppat_attributes=[]} as onlyItem] -> Some onlyItem
+  | _ -> None
+
+let mkoperator {Location. txt; loc} =
+  Exp.mk ~loc (Pexp_ident(mkloc (Lident txt) loc))
+
+(*
+  Ghost expressions and patterns:
+  expressions and patterns that do not appear explicitly in the
+  source file they have the loc_ghost flag set to true.
+  Then the profiler will not try to instrument them and the
+  -annot option will not try to display their type.
+
+  Every grammar rule that generates an element with a location must
+  make at most one non-ghost element, the topmost one.
+
+  How to tell whether your location must be ghost:
+  A location corresponds to a range of characters in the source file.
+  If the location contains a piece of code that is syntactically
+  valid (according to the documentation), and corresponds to the
+  AST node, then the location must be real; in all other cases,
+  it must be ghost.
+
+  jordwalke: Noticed that ghost expressions are often used when inserting
+   additional AST nodes from a parse rule. Either an extra wrapping one, or an
+   additional inner node. This is consistent with the above description, I
+   believe.
+*)
+
+
+let ghunit ?(loc=dummy_loc ()) () =
+  mkexp ~ghost:true ~loc (Pexp_construct (mknoloc (Lident "()"), None))
+
+let mkinfixop arg1 op arg2 =
+  mkexp(Pexp_apply(op, [Nolabel, arg1; Nolabel, arg2]))
+
+let mkinfix arg1 name arg2 =
+  mkinfixop arg1 (mkoperator name) arg2
+
+let neg_string f =
+  if String.length f > 0 && f.[0] = '-'
+  then String.sub f 1 (String.length f - 1)
+  else "-" ^ f
+
+let mkuminus name arg =
+  match name.txt, arg.pexp_desc with
+  | "-", Pexp_constant(Pconst_integer (n,m)) ->
+      mkexp(Pexp_constant(Pconst_integer(neg_string n,m)))
+  | ("-" | "-."), Pexp_constant(Pconst_float (f, m)) ->
+      mkexp(Pexp_constant(Pconst_float(neg_string f, m)))
+  | txt, _ ->
+      let name = {name with txt = "~" ^ txt} in
+      mkexp(Pexp_apply(mkoperator name, [Nolabel, arg]))
+
+let prepare_functor_arg = function
+  | Some name, mty -> (name, mty)
+  | None, (Some {pmty_loc} as mty) ->
+      (mkloc "_" (make_ghost_loc pmty_loc), mty)
+  | None, None -> assert false
+
+let mk_functor_mod args body =
+  let folder arg acc =
+    let name, mty = prepare_functor_arg arg.txt in
+    mkmod ~loc:arg.loc (Pmod_functor(name, mty, acc))
+  in
+  List.fold_right folder args body
+
+let mk_functor_mty args body =
+  let folder arg acc =
+    let name, mty = prepare_functor_arg arg.txt in
+    mkmty ~loc:arg.loc (Pmty_functor(name, mty, acc))
+  in
+  List.fold_right folder args body
+
+let mkuplus name arg =
+  match name.txt, arg.pexp_desc with
+  | "+", Pexp_constant(Pconst_integer _)
+  | ("+" | "+."), Pexp_constant(Pconst_float _) ->
+      mkexp arg.pexp_desc
+  | txt, _ ->
+      let name = {name with txt = "~" ^ txt} in
+      mkexp(Pexp_apply(mkoperator name, [Nolabel, arg]))
+
+let mkexp_cons consloc args loc =
+  mkexp ~loc (Pexp_construct(mkloc (Lident "::") consloc, Some args))
+
+let mkexp_constructor_unit ?(uncurried=false) consloc loc =
+  let attrs = if uncurried then [uncurry_payload ~name:"uncurry" loc] else [] in
+  mkexp ~attrs ~loc (Pexp_construct(mkloc (Lident "()") consloc, None))
+
+let ghexp_cons args loc =
+  mkexp ~ghost:true ~loc (Pexp_construct(mkloc (Lident "::") loc, Some args))
+
+let mkpat_cons args loc =
+  mkpat ~loc (Ppat_construct(mkloc (Lident "::") loc, Some args))
+
+let ghpat_cons args loc =
+  mkpat ~ghost:true ~loc (Ppat_construct(mkloc (Lident "::") loc, Some args))
+
+let mkpat_constructor_unit consloc loc =
+  mkpat ~loc (Ppat_construct(mkloc (Lident "()") consloc, None))
+
+let simple_pattern_list_to_tuple ?(loc=dummy_loc ()) = function
+  | [] -> assert false
+  | lst -> mkpat ~loc (Ppat_tuple lst)
+
+let mktailexp_extension loc seq ext_opt =
+  let rec handle_seq = function
+    | [] ->
+        let base_case = match ext_opt with
+          | Some ext ->
+            ext
+          | None ->
+            let loc = make_ghost_loc loc in
+            let nil = { txt = Lident "[]"; loc } in
+            Exp.mk ~loc (Pexp_construct (nil, None)) in
+        base_case
+    | e1 :: el ->
+        let exp_el = handle_seq el in
+        let loc = mklocation e1.pexp_loc.loc_start exp_el.pexp_loc.loc_end in
+        let arg = mkexp ~ghost:true ~loc (Pexp_tuple [e1; exp_el]) in
+        ghexp_cons arg loc
+  in
+  handle_seq seq
+
+let mktailpat_extension loc (seq, ext_opt) =
+  let rec handle_seq = function
+    [] ->
+      let base_case = match ext_opt with
+        | Some ext ->
+          ext
+        | None ->
+          let loc = make_ghost_loc loc in
+          let nil = { txt = Lident "[]"; loc } in
+          mkpat ~loc (Ppat_construct (nil, None)) in
+      base_case
+  | p1 :: pl ->
+      let pat_pl = handle_seq pl in
+      let loc = mklocation p1.ppat_loc.loc_start pat_pl.ppat_loc.loc_end in
+      let arg = mkpat ~ghost:true ~loc (Ppat_tuple [p1; pat_pl]) in
+      ghpat_cons arg loc in
+  handle_seq seq
+
+let makeFrag loc body =
+  let attribute = ({txt = "JSX"; loc = loc}, PStr []) in
+  { body with pexp_attributes = attribute :: body.pexp_attributes }
+
+
+(* Applies attributes to the structure item, not the expression itself. Makes
+ * structure item have same location as expression. *)
+
+let mkstrexp e attrs =
+  match e with
+  | ({pexp_desc = Pexp_apply (({pexp_attributes} as e1), args) } as eRewrite)
+      when let f = (List.filter (function
+        | ({txt = "bs"}, _) -> true
+          | _ -> false ) e.pexp_attributes)  in
+      List.length f > 0
+    ->
+      let appExprAttrs = List.filter (function
+          | ({txt = "bs"}, PStr []) -> false
+          | _ -> true ) pexp_attributes in
+      let strEvalAttrs = (uncurry_payload e1.pexp_loc)::(List.filter (function
+          | ({txt = "bs"}, PStr []) -> false
+          | _ -> true ) attrs) in
+      let e = {
+        eRewrite with
+        pexp_desc = (Pexp_apply(e1, args));
+        pexp_attributes = appExprAttrs
+      } in
+      { pstr_desc = Pstr_eval (e, strEvalAttrs); pstr_loc = e.pexp_loc }
+  | _ ->
+      { pstr_desc = Pstr_eval (e, attrs); pstr_loc = e.pexp_loc }
+
+let ghexp_constraint loc e (t1, t2) =
+  match t1, t2 with
+  | Some t, None -> mkexp ~ghost:true ~loc (Pexp_constraint(e, t))
+  | _, Some t -> mkexp ~ghost:true ~loc (Pexp_coerce(e, t1, t))
+  | None, None -> assert false
+
+let array_function ?(loc=dummy_loc()) str name =
+  ghloc ~loc (Ldot(Lident str, (if !Clflags.fast then "unsafe_" ^ name else name)))
+
+let err loc s =
+  raise Reason_syntax_util.(
+    Error(loc, (Syntax_error s))
+  )
+
+let syntax_error_str loc msg =
+  if !Reason_config.recoverable then
+    Str.mk ~loc:loc (Pstr_extension (Reason_syntax_util.syntax_error_extension_node loc msg, []))
+  else
+    raise(Syntaxerr.Error(Syntaxerr.Other loc))
+
+let syntax_error () =
+  raise Syntaxerr.Escape_error
+
+let syntax_error_exp loc msg =
+  if !Reason_config.recoverable then
+    Exp.mk ~loc (Pexp_extension (Reason_syntax_util.syntax_error_extension_node loc msg))
+  else
+    err loc msg
+
+let syntax_error_pat loc msg =
+  if !Reason_config.recoverable then
+    Pat.extension ~loc (Reason_syntax_util.syntax_error_extension_node loc msg)
+  else
+    err loc msg
+
+let syntax_error_mod loc msg =
+  if !Reason_config.recoverable then
+    Mty.extension ~loc (Reason_syntax_util.syntax_error_extension_node loc msg)
+  else
+    err loc msg
+
+let unclosed opening closing =
+  raise(Syntaxerr.Error(Syntaxerr.Unclosed(opening.loc, opening.txt,
+                                           closing.loc, closing.txt)))
+
+let unclosed_extension closing =
+  Reason_syntax_util.syntax_error_extension_node closing.loc ("Expecting \"" ^ closing.txt ^ "\"")
+
+let unclosed_mod opening closing =
+  if !Reason_config.recoverable then
+    mkmod(Pmod_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let unclosed_cl opening closing =
+  if !Reason_config.recoverable then
+    mkclass(Pcl_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let unclosed_mty opening closing =
+  if !Reason_config.recoverable then
+    mkmty(Pmty_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let unclosed_cty opening closing =
+  if !Reason_config.recoverable then
+    mkcty(Pcty_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let unclosed_exp opening closing =
+  if !Reason_config.recoverable then
+    mkexp(Pexp_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let unclosed_pat opening closing =
+  if !Reason_config.recoverable then
+    mkpat(Ppat_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let expecting nonterm =
+    raise Syntaxerr.(Error(Expecting(nonterm.loc, nonterm.txt)))
+
+let expecting_pat nonterm =
+  if !Reason_config.recoverable then
+    mkpat(Ppat_extension (Reason_syntax_util.syntax_error_extension_node nonterm.loc ("Expecting " ^ nonterm.txt)))
+  else
+    expecting nonterm
+
+let not_expecting start_pos end_pos nonterm =
+    raise Syntaxerr.(Error(Not_expecting(mklocation start_pos end_pos, nonterm)))
+
+type labelled_parameter =
+  | Term of arg_label * expression option * pattern
+  | Type of string
+
+let mkexp_fun {Location.txt; loc} body =
+  let loc = mklocation loc.loc_start body.pexp_loc.loc_end in
+  match txt with
+  | Term (label, default_expr, pat) ->
+    Exp.fun_ ~loc label default_expr pat body
+  | Type str ->
+    Exp.newtype ~loc str body
+
+let mkclass_fun {Location. txt ; loc} body =
+  let loc = mklocation loc.loc_start body.pcl_loc.loc_end in
+  match txt with
+  | Term (label, default_expr, pat) ->
+    Cl.fun_ ~loc label default_expr pat body
+  | Type _ ->
+    let pat = syntax_error_pat loc "(type) not allowed in classes" in
+    Cl.fun_ ~loc Nolabel None pat body
+
+let mktyp_arrow ({Location.txt = (label, cod); loc}, uncurried) dom =
+  let loc = mklocation loc.loc_start dom.ptyp_loc.loc_end in
+  let typ = mktyp ~loc (Ptyp_arrow (label, cod, dom)) in
+  {typ with ptyp_attributes = (if uncurried then [uncurry_payload loc] else [])}
+
+let mkcty_arrow ({Location.txt = (label, cod); loc}, uncurried) dom =
+  let loc = mklocation loc.loc_start dom.pcty_loc.loc_end in
+  let ct = mkcty ~loc (Pcty_arrow (label, cod, dom)) in
+  {ct with pcty_attributes = (if uncurried then [uncurry_payload loc] else [])}
+
+(**
+  * process the occurrence of _ in the arguments of a function application
+  * replace _ with a new variable, currently __x, in the arguments
+  * return a wrapping function that wraps ((__x) => ...) around an expression
+  * e.g. foo(_, 3) becomes (__x) => foo(__x, 3)
+  *)
+let process_underscore_application args =
+  let exp_question = ref None in
+  let hidden_var = "__x" in
+  let check_arg ((lab, exp) as arg) = match exp.pexp_desc with
+    | Pexp_ident ({ txt = Lident "_"} as id) ->
+        let new_id = mkloc (Lident hidden_var) id.loc in
+        let new_exp = mkexp (Pexp_ident new_id) ~loc:exp.pexp_loc in
+        exp_question := Some new_exp;
+        (lab, new_exp)
+    | _ ->
+        arg in
+  let args = List.map check_arg args in
+  let wrap exp_apply = match !exp_question with
+    | Some {pexp_loc=loc} ->
+        let pattern = mkpat (Ppat_var (mkloc hidden_var loc)) ~loc in
+        begin match exp_apply.pexp_desc with
+        (* Transform pipe first with underscore application correct:
+         * 5->doStuff(3, _, 7);
+         * (5 |. doStuff)(3, _, 7)
+         * 5 |. (__x => doStuff(3, __x, 7))
+         *)
+        | Pexp_apply(
+          {pexp_desc= Pexp_apply(
+            {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})} as pipeExp,
+            [Nolabel, arg1; Nolabel, ({pexp_desc = Pexp_ident _} as arg2)]
+            (*         5                            doStuff                   *)
+          )},
+          args (* [3, __x, 7] *)
+          ) ->
+            (* build `doStuff(3, __x, 7)` *)
+            let innerApply = {arg2 with pexp_desc = Pexp_apply(arg2, args)} in
+            (* build `__x => doStuff(3, __x, 7)` *)
+            let innerFun =
+              mkexp (Pexp_fun (Nolabel, None, pattern, innerApply)) ~loc
+            in
+            (* build `5 |. (__x => doStuff(3, __x, 7))` *)
+            {exp_apply with pexp_desc =
+              Pexp_apply(pipeExp, [Nolabel, arg1; Nolabel, innerFun])
+            }
+        | _ ->
+          mkexp (Pexp_fun (Nolabel, None, pattern, exp_apply)) ~loc
+        end
+    | None ->
+        exp_apply in
+  (args, wrap)
+
+(**
+  * Joins a 'body' and it's 'args' to form a Pexp_apply.
+  * Example:
+  * 'add' (body) and '[1, 2]' (args) become a Pexp_apply representing 'add(1, 2)'
+  *
+  * Note that `add(. 1, 2)(. 3, 4)` & `add(. 1, 2, . 3, 4)` both
+  * give `[[@uncurry] 1, 2, [@uncurry] 3, 4]]` as args.
+  * The dot is parsed as [@uncurry] to distinguish between specific
+  * uncurrying and [@bs]. They can appear in the same arg:
+  * `add(. [@bs] 1)` is a perfectly valid, the dot indicates uncurrying
+  * for the whole application of 'add' and [@bs] sits on the `1`.
+  * Due to the dot of uncurried application possibly appearing in any
+  * position of the args, we need to post-process the args and split
+  * all args in groups that are uncurried (or not).
+  * add(. 1, . 2) should be parsed as (add(. 1))(. 2)
+  * The args can be splitted here in [1] & [2], based on those groups
+  * we can recursively build the correct nested Pexp_apply here.
+  *  -> Pexp_apply (Pexp_apply (add, 1), 2)   (* simplified ast *)
+  *)
+let mkexp_app_rev startp endp (body, args) =
+  let loc = mklocation startp endp in
+  if args = [] then {body with pexp_loc = loc}
+  else
+  (*
+   * Post process the arguments and transform [@uncurry] into [@bs].
+   * Returns a tuple with a boolean (was it uncurried?) and
+   * the posible rewritten arg.
+   *)
+  let rec process_args acc es =
+    match es with
+    | (lbl, e)::es ->
+        let attrs = e.pexp_attributes in
+        let hasUncurryAttr = ref false in
+        let newAttrs = List.filter (function
+          | ({txt = "uncurry"}, PStr []) ->
+              hasUncurryAttr := true;
+              false
+          | _ -> true) attrs
+        in
+        let uncurried = !hasUncurryAttr in
+        let newArg = (lbl, { e with pexp_attributes = newAttrs }) in
+        process_args ((uncurried, newArg)::acc) es
+    | [] -> acc
+    in
+    (*
+     * Groups all uncurried args falling under the same Pexp_apply
+     * Example:
+     *    add(. 2, 3, . 4, 5) or add(. 2, 3)(. 4, 5)  (equivalent)
+     * This results in two groups: (true, [2, 3]) & (true, [4, 5])
+     * Both groups have 'true' as their first tuple element, because
+     * they are uncurried.
+     * add(2, 3, . 4) results in the groups (false, [2, 3]) & (true, [4])
+     *)
+    let rec group grp acc = function
+    | (uncurried, arg)::xs ->
+        let (_u, grp) = grp in
+        if uncurried = true then begin
+          group (true, [arg]) ((_u, (List.rev grp))::acc) xs
+        end else begin
+          group (_u, (arg::grp)) acc xs
+        end
+    | [] ->
+        let (_u, grp) = grp in
+        List.rev ((_u, (List.rev grp))::acc)
+    in
+    (*
+     * Recursively transforms all groups into a (possibly uncurried)
+     * Pexp_apply
+     *
+     * Example:
+     *   Given the groups (true, [2, 3]) & (true, [4, 5]) and body 'add',
+     *   we get the two nested Pexp_apply associated with
+     *   (add(. 2, 3))(. 4, 5)
+     *)
+    let rec make_appl body = function
+      | args::xs ->
+          let (uncurried, args) = args in
+          let expr = if args = [] then body
+          else
+            let (args, wrap) = process_underscore_application args in
+            let args_loc = match args, List.rev args with
+              | ((_, s)::_), ((_, e)::_) -> mklocation s.pexp_loc.loc_start e.pexp_loc.loc_end
+              | _ -> assert false in
+            let expr = mkexp ~loc:args_loc (Pexp_apply (body, args)) in
+            let expr = if uncurried then {expr with pexp_attributes = [uncurry_payload loc]} else expr in
+            wrap expr
+          in
+            make_appl expr xs
+      | [] -> {body with pexp_loc = loc}
+    in
+    let processed_args = process_args [] args in
+    let groups = group (false, []) [] processed_args in
+    make_appl body groups
+
+let mkmod_app mexp marg =
+  mkmod ~loc:(mklocation mexp.pmod_loc.loc_start marg.pmod_loc.loc_end)
+    (Pmod_apply (mexp, marg))
+
+let bigarray_function ?(loc=dummy_loc()) str name =
+  ghloc ~loc (Ldot(Ldot(Lident "Bigarray", str), name))
+
+let bigarray_get ?(loc=dummy_loc()) arr arg =
+  let get = if !Clflags.fast then "unsafe_get" else "get" in
+  match arg with
+    [c1] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array1" get)),
+                       [Nolabel, arr; Nolabel, c1]))
+  | [c1;c2] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array2" get)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, c2]))
+  | [c1;c2;c3] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array3" get)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, c2; Nolabel, c3]))
+  | coords ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Genarray" "get")),
+                       [Nolabel, arr; Nolabel, mkexp ~ghost:true ~loc (Pexp_array coords)]))
+
+let bigarray_set ?(loc=dummy_loc()) arr arg newval =
+  let set = if !Clflags.fast then "unsafe_set" else "set" in
+  match arg with
+    [c1] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array1" set)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, newval]))
+  | [c1;c2] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array2" set)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, c2; Nolabel, newval]))
+  | [c1;c2;c3] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array3" set)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, c2; Nolabel, c3; Nolabel, newval]))
+  | coords ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Genarray" "set")),
+                       [Nolabel, arr;
+                        Nolabel, mkexp ~ghost:true ~loc (Pexp_array coords);
+                        Nolabel, newval]))
+
+let exp_of_label label =
+  mkexp ~loc:label.loc (Pexp_ident {label with txt=Lident(Longident.last label.txt)})
+
+let pat_of_label label =
+  mkpat ~loc:label.loc (Ppat_var {label with txt=(Longident.last label.txt)})
+
+let check_variable vl loc v =
+  if List.mem v vl then
+    raise Syntaxerr.(Error(Variable_in_scope(loc,v)))
+
+let varify_constructors var_names t =
+  let rec loop t =
+    let desc =
+      match t.ptyp_desc with
+      | Ptyp_any -> Ptyp_any
+      | Ptyp_var x ->
+          check_variable var_names t.ptyp_loc x;
+          Ptyp_var x
+      | Ptyp_arrow (label,core_type,core_type') ->
+          Ptyp_arrow(label, loop core_type, loop core_type')
+      | Ptyp_tuple lst -> Ptyp_tuple (List.map loop lst)
+      | Ptyp_constr( { txt = Lident s }, []) when List.mem s var_names ->
+          Ptyp_var s
+      | Ptyp_constr(longident, lst) ->
+          Ptyp_constr(longident, List.map loop lst)
+      | Ptyp_object (lst, o) ->
+          Ptyp_object
+            (List.map (fun (s, attrs, t) -> (s, attrs, loop t)) lst, o)
+      | Ptyp_class (longident, lst) ->
+          Ptyp_class (longident, List.map loop lst)
+      | Ptyp_alias(core_type, string) ->
+          check_variable var_names t.ptyp_loc string;
+          Ptyp_alias(loop core_type, string)
+      | Ptyp_variant(row_field_list, flag, lbl_lst_option) ->
+          Ptyp_variant(List.map loop_row_field row_field_list,
+                       flag, lbl_lst_option)
+      | Ptyp_poly(string_lst, core_type) ->
+          List.iter (check_variable var_names t.ptyp_loc) string_lst;
+          Ptyp_poly(string_lst, loop core_type)
+      | Ptyp_package(longident,lst) ->
+          Ptyp_package(longident,List.map (fun (n,typ) -> (n,loop typ) ) lst)
+      | Ptyp_extension (s, arg) ->
+          Ptyp_extension (s, arg)
+    in
+    {t with ptyp_desc = desc}
+  and loop_row_field  =
+    function
+      | Rtag(label,attrs,flag,lst) ->
+          Rtag(label,attrs,flag,List.map loop lst)
+      | Rinherit t ->
+          Rinherit (loop t)
+  in
+  loop t
+
+let pexp_newtypes ?loc newtypes exp =
+  List.fold_right (fun newtype exp -> mkexp ?loc (Pexp_newtype (newtype, exp)))
+    newtypes exp
+
+(**
+  I believe that wrap_type_annotation will automatically generate the type
+  arguments (type a) (type b) based on what was listed before the dot in a
+  polymorphic type annotation that uses locally abstract types.
+ *)
+let wrap_type_annotation newtypes core_type body =
+  let exp = mkexp(Pexp_constraint(body,core_type)) in
+  let exp = pexp_newtypes newtypes exp in
+  let typ = mktyp ~ghost:true (Ptyp_poly(newtypes,varify_constructors newtypes core_type)) in
+  (exp, typ)
+
+
+let struct_item_extension (ext_attrs, ext_id) structure_items =
+  mkstr ~ghost:true (Pstr_extension ((ext_id, PStr structure_items), ext_attrs))
+
+let expression_extension ?loc (ext_attrs, ext_id) item_expr =
+  let extension = (ext_id, PStr [mkstrexp item_expr []]) in
+  let loc = match loc with
+    | Some loc -> loc
+    | None -> make_ghost_loc (dummy_loc ())
+  in
+  Exp.extension ~loc ~attrs:ext_attrs extension
+
+(* There's no more need for these functions - this was for the following:
+ *
+ *     fun % ext [@foo] arg => arg;
+ *
+ *   Becoming
+ *
+ *     [%ext  (fun arg => arg) [@foo]]
+ *
+ *   Which we no longer support.
+ *)
+(* Applies the attributes to the body, then wraps entire thing in an extension
+ * expression, whose payload consists of a single structure item that is body
+ *)
+(* let wrap_exp_attrs body (ext, attrs) = *)
+(*   (* todo: keep exact location for the entire attribute *) *)
+(*   let body = {body with pexp_attributes = attrs @ body.pexp_attributes} in *)
+(*   match ext with *)
+(*   | None -> body *)
+(*   | Some id -> mkexp ~ghost:true (Pexp_extension (id, PStr [mkstrexp body []])) *)
+
+(* Why not just mkexp with the right attributes in the first place? *)
+(* let mkexp_attrs d attrs = *)
+(*   wrap_exp_attrs (mkexp d) attrs *)
+
+let mkcf_attrs ?(loc=dummy_loc()) d attrs =
+  Cf.mk ~loc ~attrs d
+
+let mkctf_attrs d attrs =
+  Ctf.mk ~attrs d
+
+type let_bindings =
+  { lbs_bindings: Parsetree.value_binding list;
+    lbs_rec: rec_flag;
+    lbs_extension: (attributes * string Asttypes.loc) option;
+    lbs_loc: Location.t }
+
+let mklbs ext rf lb loc =
+  { lbs_bindings = [lb];
+    lbs_rec = rf;
+    lbs_extension = ext;
+    lbs_loc = loc; }
+
+let addlbs lbs lbs' =
+  { lbs with lbs_bindings = lbs.lbs_bindings @ lbs' }
+
+let val_of_let_bindings lbs =
+  let str = Str.value lbs.lbs_rec lbs.lbs_bindings in
+  match lbs.lbs_extension with
+  | None -> str
+  | Some ext -> struct_item_extension ext [str]
+
+let expr_of_let_bindings ~loc lbs body =
+    let item_expr = Exp.let_ ~loc lbs.lbs_rec lbs.lbs_bindings body in
+    match lbs.lbs_extension with
+    | None -> item_expr
+    | Some ext -> expression_extension ~loc:(make_ghost_loc loc) ext item_expr
+
+let class_of_let_bindings lbs body =
+  if lbs.lbs_extension <> None then
+    raise Syntaxerr.(Error(Not_expecting(lbs.lbs_loc, "extension")));
+  Cl.let_ lbs.lbs_rec lbs.lbs_bindings body
+
+(*
+ * arity_conflict_resolving_mapper is triggered when both "implicit_arity" "explicit_arity"
+ * are in the attribtues. In that case we have to remove "explicit_arity"
+ *
+ * However, if we simply remove explicit_arity, we would end up with a
+ * wrapping tuple which has only one component (inner tuple).
+ * This is against the invariance where tuples must have 2+ components.
+ * Therefore, in the case we have to remove explicit_arity, we also need to
+ * unwrap the tuple to expose the inner tuple directly.
+ *
+ *)
+let arity_conflict_resolving_mapper super =
+{ super with
+  expr = begin fun mapper expr ->
+    match expr with
+      | {pexp_desc=Pexp_construct(lid, args);
+         pexp_loc;
+         pexp_attributes} when attributes_conflicted "implicit_arity" "explicit_arity" pexp_attributes ->
+         let new_args =
+           match args with
+             | Some {pexp_desc = Pexp_tuple [sp]} -> Some sp
+             | _ -> args in
+         super.expr mapper
+         {pexp_desc=Pexp_construct(lid, new_args); pexp_loc; pexp_attributes=
+          normalized_attributes "explicit_arity" pexp_attributes}
+      | x -> super.expr mapper x
+  end;
+  pat = begin fun mapper pattern ->
+    match pattern with
+      | {ppat_desc=Ppat_construct(lid, args);
+         ppat_loc;
+         ppat_attributes} when attributes_conflicted "implicit_arity" "explicit_arity" ppat_attributes ->
+         let new_args =
+           match args with
+             | Some {ppat_desc = Ppat_tuple [sp]} -> Some sp
+             | _ -> args in
+         super.pat mapper
+         {ppat_desc=Ppat_construct(lid, new_args); ppat_loc; ppat_attributes=
+          normalized_attributes "explicit_arity" ppat_attributes}
+      | x -> super.pat mapper x
+  end;
+}
+
+let reason_mapper =
+  default_mapper
+  |> reason_to_ml_swap_operator_mapper
+  |> arity_conflict_resolving_mapper
+
+let rewriteFunctorApp module_name elt loc =
+  let rec applies = function
+    | Lident _ -> false
+    | Ldot (m, _) -> applies m
+    | Lapply (_, _) -> true in
+  let rec flattenModName = function
+    | Lident id -> id
+    | Ldot (m, id) -> flattenModName m ^ "." ^ id
+    | Lapply (m1, m2) -> flattenModName m1 ^ "(" ^ flattenModName m2 ^ ")" in
+  let rec mkModExp = function
+    | Lident id -> mkmod ~loc (Pmod_ident {txt=Lident id; loc})
+    | Ldot (m, id) -> mkmod ~loc (Pmod_ident {txt=Ldot (m, id); loc})
+    | Lapply (m1, m2) -> mkmod ~loc (Pmod_apply (mkModExp m1, mkModExp m2)) in
+  if applies module_name then
+    let flat = flattenModName module_name in
+    mkexp ~loc (Pexp_letmodule({txt=flat; loc},
+                         mkModExp module_name,
+                         mkexp(Pexp_ident {txt=Ldot (Lident flat, elt); loc})))
+  else
+    mkexp ~loc (Pexp_ident {txt=Ldot (module_name, elt); loc})
+
+let jsx_component module_name attrs children loc =
+  let rec getFirstPart = function
+    | Lident fp -> fp
+    | Ldot (fp, _) -> getFirstPart fp
+    | Lapply (fp, _) -> getFirstPart fp in
+  let firstPart = getFirstPart module_name.txt in
+  let element_fn = if String.get firstPart 0 != '_' && firstPart = String.capitalize_ascii firstPart then
+    (* firstPart will be non-empty so the 0th access is fine. Modules can't start with underscore *)
+    rewriteFunctorApp module_name.txt "createElement" module_name.loc
+  else
+    mkexp ~loc:module_name.loc (Pexp_ident(mkloc (Lident firstPart) module_name.loc))
+  in
+  let body = mkexp(Pexp_apply(element_fn, attrs @ children)) ~loc in
+  let attribute = ({txt = "JSX"; loc = loc}, PStr []) in
+  { body with pexp_attributes = attribute :: body.pexp_attributes }
+
+(* We might raise some custom error messages in this file.
+  Do _not_ directly raise a Location.Error. Our public interface guarantees that we only throw Syntaxerr or Reason_syntax_util.Error *)
+let raiseSyntaxErrorFromSyntaxUtils loc fmt =
+  Printf.ksprintf
+    (fun msg -> raise Reason_syntax_util.(Error(loc, (Syntax_error msg))))
+    fmt
+
+let rec ignoreLapply = function
+  | Lident id -> Lident id
+  | Ldot (lid, id) -> Ldot (ignoreLapply lid, id)
+  | Lapply (m1, _) -> ignoreLapply m1
+
+(* Like Longident.flatten, but ignores `Lapply`s. Useful because 1) we don't want to require `Lapply` in
+   closing tags, and 2) Longident.flatten doesn't support `Lapply`. *)
+let rec flattenWithoutLapply = function
+  | Lident id -> [id]
+  | Ldot (lid, id) -> flattenWithoutLapply lid @ [id]
+  | Lapply (m1, _) -> flattenWithoutLapply m1
+
+let ensureTagsAreEqual startTag endTag loc =
+  if ignoreLapply startTag <> endTag then
+     let startTag = (String.concat "" (flattenWithoutLapply startTag)) in
+     let endTag = (String.concat "" (flattenWithoutLapply endTag)) in
+     raiseSyntaxErrorFromSyntaxUtils loc
+      "Start tag <%s> does not match end tag </%s>" startTag endTag
+
+(* `{. "foo": bar}` -> `Js.t {. foo: bar}` and {.. "foo": bar} -> `Js.t {.. foo: bar} *)
+let mkBsObjTypeSugar ~loc ~closed rows =
+  let obj = mktyp ~loc (Ptyp_object (rows, closed)) in
+  let jsDotTCtor = { txt = Longident.Ldot (Longident.Lident "Js", "t"); loc } in
+  mktyp(Ptyp_constr(jsDotTCtor, [obj]))
+
+let doc_loc loc = {txt = "ocaml.doc"; loc = loc}
+
+let doc_attr text loc =
+  let open Parsetree in
+  let exp =
+    { pexp_desc = Pexp_constant (Pconst_string(text, None));
+      pexp_loc = loc;
+      pexp_attributes = []; }
+  in
+  let item =
+    { pstr_desc = Pstr_eval (exp, []); pstr_loc = exp.pexp_loc }
+  in
+    (doc_loc loc, PStr [item])
+
+let prepend_attrs_to_labels attrs = function
+  | [] -> [] (* not possible for valid inputs *)
+  | x :: xs -> {x with pld_attributes = attrs @ x.pld_attributes} :: xs
+
+let raise_record_trailing_semi_error loc =
+  let msg = "Record entries are separated by comma; we've found a semicolon instead." in
+  raise Reason_syntax_util.(Error(loc, (Syntax_error msg)))
+
+let record_exp_spread_msg =
+  "Records can only have one `...` spread, at the beginning.
+Explanation: since records have a known, fixed shape, a spread like `{a, ...b}` wouldn't make sense, as `b` would override every field of `a` anyway."
+
+let record_pat_spread_msg =
+  "Record's `...` spread is not supported in pattern matches.
+Explanation: you can't collect a subset of a record's field into its own record, since a record needs an explicit declaration and that subset wouldn't have one.
+Solution: you need to pull out each field you want explicitly."
+
+let lowercase_module_msg =
+  Printf.sprintf "Module names must start with an uppercase letter."
+
+(* Handles "over"-parsing of spread syntax with `opt_spread`.
+ * The grammar allows a spread operator at every position, when
+ * generating the parsetree we raise a helpful error message. *)
+let filter_raise_spread_syntax msg nodes =
+  List.map (fun (dotdotdot, node) ->
+    match dotdotdot with
+    | Some dotdotdotLoc ->
+        raise Reason_syntax_util.(Error(dotdotdotLoc, (Syntax_error msg)))
+    | None -> node
+    ) nodes
+
+(*
+ * See https://github.com/ocaml/ocaml/commit/e1e03820e5fea322aa3156721bc1cc0231668101
+ * Rely on the parsing rules for generic module types, and then
+ * extract a package type, enabling more explicit error messages
+ * *)
+let package_type_of_module_type pmty =
+  let map_cstr = function
+    | Pwith_type (lid, ptyp) ->
+        let loc = ptyp.ptype_loc in
+        if ptyp.ptype_params <> [] then
+          err loc "parametrized types are not supported";
+        if ptyp.ptype_cstrs <> [] then
+          err loc "constrained types are not supported";
+        if ptyp.ptype_private <> Public then
+          err loc "private types are not supported";
+
+        (* restrictions below are checked by the 'with_constraint' rule *)
+        assert (ptyp.ptype_kind = Ptype_abstract);
+        assert (ptyp.ptype_attributes = []);
+        let ty =
+          match ptyp.ptype_manifest with
+          | Some ty -> ty
+          | None -> assert false
+        in
+        (lid, ty)
+    | _ ->
+        err pmty.pmty_loc "only 'with type t =' constraints are supported"
+  in
+  match pmty with
+  | {pmty_desc = Pmty_ident lid} -> (lid, [])
+  | {pmty_desc = Pmty_with({pmty_desc = Pmty_ident lid}, cstrs)} ->
+      (lid, List.map map_cstr cstrs)
+  | _ ->
+      err pmty.pmty_loc
+        "only module type identifier and 'with type' constraints are supported"
+
+let add_brace_attr expr =
+  let label = Location.mknoloc "reason.preserve_braces" in
+  let payload = PStr [] in
+  {expr with pexp_attributes= (label, payload) :: expr.pexp_attributes }
+
+%}
+
+
+
+(* Tokens *)
+
+%token AMPERAMPER
+%token AMPERSAND
+%token AND
+%token AS
+%token ASSERT
+%token BACKQUOTE
+%token BANG
+%token BAR
+%token BARBAR
+%token BARRBRACKET
+%token BEGIN
+%token <char> CHAR
+%token CLASS
+%token COLON
+%token COLONCOLON
+%token COLONEQUAL
+%token COLONGREATER
+%token COMMA
+%token CONSTRAINT
+%token DO
+%token DONE
+%token DOT
+%token DOTDOT
+%token DOTDOTDOT
+%token DOWNTO
+%token ELSE
+%token END
+%token EOF
+%token EQUAL
+%token EXCEPTION
+%token EXTERNAL
+%token FALSE
+%token <string * char option> FLOAT
+%token FOR
+%token FUN ES6_FUN
+%token FUNCTION
+%token FUNCTOR
+%token GREATER
+%token GREATERRBRACE
+%token GREATERDOTDOTDOT
+%token IF
+%token IN
+%token INCLUDE
+%token <string> INFIXOP0
+%token <string> INFIXOP1
+%token <string> INFIXOP2
+%token <string> INFIXOP3
+(* SLASHGREATER is an INFIXOP3 that is handled specially *)
+%token SLASHGREATER
+%token <string> INFIXOP4
+%token INHERIT
+%token INITIALIZER
+%token <string * char option> INT
+%token LAZY
+%token LBRACE
+%token LBRACELESS
+%token LBRACKET
+%token LBRACKETBAR
+%token LBRACKETLESS
+%token LBRACKETGREATER
+%token LBRACKETPERCENT
+%token LBRACKETPERCENTPERCENT
+%token LESS
+%token <string> LESSIDENT
+%token LESSGREATER
+%token LESSSLASHGREATER
+%token LESSDOTDOTGREATER
+%token EQUALGREATER
+%token LET
+%token <string> LIDENT
+%token LPAREN
+%token LBRACKETAT
+%token OF
+%token PRI
+%token SWITCH
+%token MINUS
+%token MINUSDOT
+%token MINUSGREATER
+%token MODULE
+%token MUTABLE
+%token <nativeint> NATIVEINT
+%token NEW
+%token NONREC
+%token OBJECT
+%token OPEN
+%token OR
+(* %token PARSER *)
+%token PERCENT
+%token PLUS
+%token PLUSDOT
+%token PLUSEQ
+%token <string> PREFIXOP
+%token <string> POSTFIXOP
+%token PUB
+%token QUESTION
+%token QUOTE
+%token RBRACE
+%token RBRACKET
+%token REC
+%token RPAREN
+%token <string> LESSSLASHIDENTGREATER
+%token SEMI
+%token SEMISEMI
+%token SHARP
+%token <string> SHARPOP
+%token SHARPEQUAL
+%token SIG
+%token STAR
+%token <string * string option * string option> STRING
+%token STRUCT
+%token THEN
+%token TILDE
+%token TO
+%token TRUE
+%token TRY
+%token TYPE
+%token <string> UIDENT
+%token UNDERSCORE
+%token VAL
+%token VIRTUAL
+%token WHEN
+%token WHILE
+%token WITH
+%token <string * Location.t> COMMENT
+%token <string> DOCSTRING
+
+%token EOL
+
+(* Precedences and associativities.
+
+Tokens and rules have precedences and those precedences are used to
+resolve what would otherwise be a conflict in the grammar.
+
+Precedence and associativity/Resolving conflicts:
+----------------------------
+See [http://caml.inria.fr/pub/docs/manual-ocaml-4.00/manual026.html] section
+about conflicts.
+
+We will only use associativities with operators of the kind  x * x -> x
+for example, in the rules of the form    expr: expr BINOP expr
+in all other cases, we define two precedences if needed to resolve
+conflicts.
+
+*)
+(* Question: Where is the SEMI explicit precedence? *)
+%nonassoc below_SEMI
+%right    EQUALGREATER                  (* core_type2 (t => t => t) *)
+%right    COLON
+%right    EQUAL                         (* below COLONEQUAL (lbl = x := e) *)
+%right    COLONEQUAL                    (* expr (e := e := e) *)
+%nonassoc QUESTION
+%nonassoc WITH             (* below BAR  (match ... with ...) *)
+%nonassoc AND             (* above WITH (module rec A: SIG with ... and ...) *)
+%nonassoc ELSE                          (* (if ... then ... else ...) *)
+%nonassoc AS
+%nonassoc below_BAR                     (* Allows "building up" of many bars *)
+%left     BAR                           (* pattern (p|p|p) *)
+
+%right    OR BARBAR                     (* expr (e || e || e) *)
+%right    AMPERSAND AMPERAMPER          (* expr (e && e && e) *)
+%left     INFIXOP0 LESS GREATER GREATERDOTDOTDOT (* expr (e OP e OP e) *)
+%left     LESSDOTDOTGREATER (* expr (e OP e OP e) *)
+%right    INFIXOP1                      (* expr (e OP e OP e) *)
+%right    COLONCOLON                    (* expr (e :: e :: e) *)
+%left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ (* expr (e OP e OP e) *)
+%left     PERCENT INFIXOP3 SLASHGREATER STAR          (* expr (e OP e OP e) *)
+%right    INFIXOP4                      (* expr (e OP e OP e) *)
+
+(**
+ * With the way attributes are currently parsed, if we want consistent precedence for
+ *
+ * The OCaml parser parses the following attributes:
+ *
+ *    let x = true && (false [@attrOnFalse])
+ *    let x = true && false [@attrOnFalse]
+ *    let x = 10 + 20 [@attrOn20]
+ *    let x = (10 + 20) [@attrEntireAddition]
+ *
+ * As:
+ *
+ *    let x = true && ((false)[@attrOnFalse ])
+ *    let x = true && ((false)[@attrOnFalse ])
+ *    let x = ((10 + 20)[@attrOn20 ])
+ *    let x = ((10 + 20)[@attrEntireAddition ])
+ *
+ * That is because the precedence of tokens is configured as following, which
+ * only serves to treat certain infix operators as different than others with
+ * respect to attributes *only*.
+ *
+ *    %right    OR BARBAR
+ *    %right    AMPERSAND AMPERAMPER
+ *    %nonassoc below_EQUAL
+ *    %left     INFIXOP0 EQUAL LESS GREATER
+ *    %right    INFIXOP1
+ *    %nonassoc LBRACKETAT
+ *    %right    COLONCOLON
+ *    %left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ
+ *    %left     PERCENT INFIXOP3 SLASHGREATER STAR
+ *    %right    INFIXOP4
+ *
+ * So instead, with Reason, we treat all infix operators identically w.r.t.
+ * attributes. In expressions, they have the same precedence as function
+ * arguments, as if they are additional arguments to a function application.
+ *
+ * Note that unary subtractive/plus parses with lower precedence than function
+ * application (and attributes) This means that:
+ *
+ *   let = - something blah blah [@attr];
+ *
+ * Will have the attribute applied to the entire content to the right of the
+ * unary minus, as if the attribute was merely another argument to the function
+ * application.
+ *
+ *
+ * To make the attribute apply to the unary -, wrap in parens.
+ *
+ *   let = (- something blah blah) [@attr];
+ *
+ * Where arrows occur, it will (as always) obey the rules of function/type
+ * application.
+ *
+ *   type x = int => int [@onlyAppliedToTheInt];
+ *   type x = (int => int) [@appliedToTheArrow];
+ *
+ * However, unary subtractive/plus parses with *higher* precedence than infix
+ * application, so that
+ *
+ *   3 + - funcCall arg arg + 3;
+ *
+ * Is parsed as:
+ *
+ *   3 + (- (funcCall arg arg)) + 3;
+ *
+ * TODO:
+ *
+ * We would also like to bring this behavior to `!` as well, when ! becomes
+ * "not". This is so that you may do !someFunction(arg, arg) and have the
+ * entire function application negated. In fact, we may as well just have all
+ * of PREFIXOP have the unary precedence parsing behavior for consistency.
+ *)
+
+%nonassoc attribute_precedence
+
+%nonassoc prec_unary (* unary - *)
+%nonassoc prec_constant_constructor     (* cf. simple_expr (C versus C x) *)
+(* Now that commas require wrapping parens (for tuples), prec_constr_appl no
+* longer needs to be above COMMA, but it doesn't hurt *)
+%nonassoc prec_constr_appl              (* above AS BAR COLONCOLON COMMA *)
+
+(* PREFIXOP and BANG precedence *)
+%nonassoc below_DOT_AND_SHARP           (* practically same as below_SHARP but we convey purpose *)
+%nonassoc SHARP                         (* simple_expr/toplevel_directive *)
+%nonassoc below_DOT
+
+(* We need SHARPEQUAL to have lower precedence than `[` to make e.g.
+   this work: `foo #= bar[0]`. Otherwise it would turn into `(foo#=bar)[0]` *)
+%left     SHARPEQUAL
+%nonassoc POSTFIXOP
+(* LBRACKET and DOT are %nonassoc in OCaml, because the left and right sides
+   are never the same, therefore there doesn't need to be a precedence
+   disambiguation. This could also work in Reason, but by grouping the tokens
+   below into a single precedence rule it becomes clearer that they all have the
+   same precedence. *)
+%left     SHARPOP MINUSGREATER LBRACKET DOT
+(* Finally, the first tokens of simple_expr are above everything else. *)
+%nonassoc LBRACKETLESS LBRACELESS LBRACE LPAREN
+
+
+(* Entry points *)
+
+%start implementation                   (* for implementation files *)
+%type <Ast_404.Parsetree.structure> implementation
+%start interface                        (* for interface files *)
+%type <Ast_404.Parsetree.signature> interface
+%start toplevel_phrase                  (* for interactive use *)
+%type <Ast_404.Parsetree.toplevel_phrase> toplevel_phrase
+%start use_file                         (* for the #use directive *)
+%type <Ast_404.Parsetree.toplevel_phrase list> use_file
+%start parse_core_type
+%type <Ast_404.Parsetree.core_type> parse_core_type
+%start parse_expression
+%type <Ast_404.Parsetree.expression> parse_expression
+%start parse_pattern
+%type <Ast_404.Parsetree.pattern> parse_pattern
+
+(* Instead of reporting an error directly, productions specified
+ * below will be reduced first and poped up in the stack to a higher
+ * level production.
+ *
+ * This is essential to error reporting as it is much friendier to provide
+ * a higher level error (e.g., "Expecting the parens to be closed" )
+ * as opposed to a low-level one (e.g., "Expecting to finish
+ * current type definition").
+ *
+ * See Menhir's manual for more details.
+ *)
+%on_error_reduce structure_item let_binding_body
+                 as_loc(attribute)+
+                 type_longident
+                 constr_longident
+                 pattern
+                 nonrec_flag
+                 val_ident
+                 SEMI?
+                 fun_def(EQUAL,core_type)
+                 fun_def(EQUALGREATER,non_arrowed_core_type)
+                 expr_optional_constraint
+%%
+
+(* Entry points *)
+
+implementation:
+  structure EOF
+  { apply_mapper_to_structure $1 reason_mapper }
+;
+
+interface:
+  signature EOF
+  { apply_mapper_to_signature $1 reason_mapper }
+;
+
+toplevel_phrase: embedded
+  ( EOF                              { raise End_of_file}
+  | structure_item     SEMI          { Ptop_def $1 }
+  | toplevel_directive SEMI          { $1 }
+  ) { apply_mapper_to_toplevel_phrase $1 reason_mapper }
+;
+
+use_file_no_mapper: embedded
+( EOF                              { [] }
+  | structure_item     SEMI use_file_no_mapper { Ptop_def $1  :: $3 }
+  | toplevel_directive SEMI use_file_no_mapper { $1 :: $3 }
+  | structure_item     EOF           { [Ptop_def $1 ] }
+  | toplevel_directive EOF           { [$1] }
+  ) { $1 }
+;
+
+use_file:
+  use_file_no_mapper { apply_mapper_to_use_file $1 reason_mapper }
+;
+
+parse_core_type:
+  core_type EOF
+  { apply_mapper_to_type $1 reason_mapper }
+;
+
+parse_expression:
+  expr EOF
+  { apply_mapper_to_expr $1 reason_mapper }
+;
+
+parse_pattern:
+  pattern EOF
+  { apply_mapper_to_pattern $1 reason_mapper }
+;
+
+(* Module expressions *)
+
+module_parameter:
+as_loc
+  ( LPAREN RPAREN
+    { (Some (mkloc "*" (mklocation $startpos $endpos)), None) }
+  | as_loc(UIDENT {$1} | UNDERSCORE {"_"}) COLON module_type
+    { (Some $1, Some $3) }
+  | module_type
+    { (None, Some $1) }
+) {$1};
+
+%inline two_or_more_module_parameters_comma_list:
+  lseparated_two_or_more(COMMA, module_parameter) COMMA? {$1}
+;
+
+functor_parameters:
+  | LPAREN RPAREN
+    { let loc = mklocation $startpos $endpos in
+      [mkloc (Some (mkloc "*" loc), None) loc]
+    }
+  (* This single parameter case needs to be explicitly specified so that
+   * menhir can automatically remove the conflict between sigature:
+   *
+   *   include (X)
+   *   include (X, Y) => Z
+   *
+   * Even though the later is non-sensical (maybe it won't be one day?)
+   *)
+  | LPAREN module_parameter RPAREN {[$2]}
+  | LPAREN module_parameter COMMA RPAREN {[$2]}
+  | parenthesized(two_or_more_module_parameters_comma_list) { $1 }
+;
+
+module_complex_expr:
+mark_position_mod
+  ( module_expr
+    { $1 }
+  | module_expr COLON module_type
+    { mkmod(Pmod_constraint($1, $3)) }
+  | VAL expr
+    { mkmod(Pmod_unpack $2) }
+  | VAL expr COLON MODULE? package_type
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkmod (Pmod_unpack(
+           mkexp ~ghost:true ~loc (Pexp_constraint($2, (mktyp ~ghost:true ~loc (Ptyp_package $5))))))
+    }
+  | VAL expr COLON MODULE? package_type COLONGREATER MODULE? package_type
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkmod (Pmod_unpack(
+             mkexp ~ghost:true ~loc (Pexp_coerce($2, Some(mktyp ~ghost:true ~loc (Ptyp_package $5)),
+                                    mktyp ~ghost:true ~loc (Ptyp_package $8))))) }
+  | VAL expr COLONGREATER MODULE? package_type
+    { let loc = mklocation $symbolstartpos $endpos and ghost = true in
+      let mty = mktyp ~ghost ~loc (Ptyp_package $5) in
+      mkmod (Pmod_unpack(mkexp ~ghost ~loc (Pexp_coerce($2, None, mty))))
+    }
+  ) {$1};
+
+module_arguments_comma_list:
+  lseparated_list(COMMA, module_complex_expr) COMMA? {$1}
+;
+module_arguments:
+  | module_expr_structure { [$1] }
+  | parenthesized(module_arguments_comma_list)
+    { match $1 with
+      | [] -> [mkmod ~loc:(mklocation $startpos $endpos) (Pmod_structure [])]
+      | xs -> xs
+    }
+;
+
+module_expr_body: preceded(EQUAL,module_expr) | module_expr_structure { $1 };
+
+module_expr_structure:
+  LBRACE structure RBRACE
+  { mkmod ~loc:(mklocation $startpos $endpos) (Pmod_structure($2)) }
+;
+
+module_expr:
+mark_position_mod
+  ( as_loc(mod_longident)
+    { mkmod(Pmod_ident $1) }
+  | module_expr_structure { $1 }
+  | as_loc(LPAREN) module_expr COLON module_type as_loc(error)
+    { unclosed_mod (with_txt $1 "(") (with_txt $5 ")")}
+  | LPAREN module_complex_expr RPAREN
+    { $2 }
+  | LPAREN RPAREN
+    { mkmod (Pmod_structure []) }
+  | extension
+    { mkmod (Pmod_extension $1) }
+  (**
+   * Although it would be nice (and possible) to support annotated return value
+   * here, that wouldn't be consistent with what is possible for functions.
+   * Update: In upstream, it *is* possible to annotate return values for
+   * lambdas.
+   *)
+  | either(ES6_FUN,FUN) functor_parameters preceded(COLON,simple_module_type)? EQUALGREATER module_expr
+    { let me = match $3 with
+        | None -> $5
+        | Some mt ->
+          let loc = mklocation $startpos($3) $endpos in
+          mkmod ~loc (Pmod_constraint($5, mt))
+      in
+      mk_functor_mod $2 me
+    }
+  | module_expr module_arguments
+    { List.fold_left mkmod_app $1 $2 }
+  | module_expr as_loc(LPAREN) module_expr as_loc(error)
+    { unclosed_mod (with_txt $2 "(") (with_txt $4 ")") }
+  | as_loc(LPAREN) module_expr as_loc(error)
+    { unclosed_mod (with_txt $1 "(") (with_txt $3 ")") }
+  | as_loc(LPAREN) VAL expr COLON as_loc(error)
+    { unclosed_mod (with_txt $1 "(") (with_txt $5 ")") }
+  | as_loc(LPAREN) VAL expr COLONGREATER as_loc(error)
+    { unclosed_mod (with_txt $1 "(") (with_txt $5 ")") }
+  | as_loc(LPAREN) VAL expr as_loc(error)
+    { unclosed_mod (with_txt $1 "(") (with_txt $4 ")") }
+  | attribute module_expr %prec attribute_precedence
+    { {$2 with pmod_attributes = $1 :: $2.pmod_attributes} }
+  ) {$1};
+
+(**
+ * Attributes/Extension points TODO:
+ * - Faux-ternary to support extension points (printing/parsing).
+ * - Audit to ensure every [item attributes] [item extensions] is supported.
+ * - wrap_exp_attrs / mkexp_attrs cleanup - no need for the confusing
+ * indirection.
+ * - Ensure proper parsing as ensured by commit:
+ *   4c48d802cb9e8110ab3b57ca0b6a02fdd5655283
+ * - Support the Item Extension + Item Attributes pattern/sugar/unification for
+ * all items in let sequences (let module etc / let open).
+ *)
+
+(*
+ * In OCaml there are (confusingly) two ways to execute imperitive code at the
+ * top level:
+ *
+ *   doStuff();      (* parsed as let _ = ... *)
+ *   doMoreStuff();  (* parsed as let _ = ... *)
+ *   ;;              (* SEMISEMI *)
+ *   let exportedThing = blah
+ *
+ *   let _ = doStuff()
+ *   let _ = doStuff()
+ *   let exportedThing = blah   (* SEMISEMI not needed if no leading seq_expr *)
+ *
+ *
+ * SEMISEMI (and a bunch of other inconsistencies/suprises) are the price you
+ * pay for not requiring a delimiter after each binding/imperitive action.
+ *
+ *    let myFn () =
+ *       let x = 0 in
+ *       let y = 10 in
+ *       x + y
+ *
+ * Also, in OCaml, there is a different syntax for let bindings in function
+ * bodies, where each let bindings group must end with IN.
+ *
+ * If we just *require* that every module export is terminated by a SEMI, and
+ * require that sequence expressions are grouped by some surrounding tokens {},
+ * then we can have a consistent, familiar way of executing imperitive code, or
+ * let bindings (without introducing SEMISEMI and without forcing you to write
+ * [let _ = imperitive()]).
+ *
+ *   doStuff();
+ *   doStuff();
+ *   let exportedThing = blah;   (* SEMISEMI not needed *)
+ *
+ * Also, we can then make function scoped let bindings have a consistent syntax
+ * with the top level module syntax.
+ *
+ *    let myFn () => {
+ *      let x = 0;
+ *      let y = 10;
+ *      x + y;
+ *    };
+ }
+ *
+ * There are other practical reasons to require each structure item (or record
+ * item etc) to be terminated by a SEMI. It allows IDEs to correct indentation
+ * as you type. Otherwise (as in OCaml) your editor has to wait until you type
+ * `let` again to determine the indentation of the new line - for many editors,
+ * achieving that configuration is not easy.
+ *
+ *  structure:
+ *      seq_expr attribute* structure_tail { mkstrexp $1 $2 :: $3 }
+ *    | structure_tail { $1 }
+ *  ;
+ *  structure_tail:
+ *                           { [] }
+ *    | SEMISEMI structure   { $2 }
+ *    | structure_item SEMI structure_tail { $1 :: $3 }
+ *)
+
+structure:
+  | (* Empty *) { [] }
+  | structure_item { $1 }
+  | structure_item SEMI structure { $1 @ $3 }
+  | as_loc(error) structure
+    { let menhirError = Reason_syntax_util.findMenhirErrorMessage $1.loc in
+      match menhirError with
+      | MenhirMessagesError errMessage -> (syntax_error_str errMessage.loc errMessage.msg) :: $2
+      | _ -> (syntax_error_str $1.loc "Invalid statement") :: $2
+    }
+  | as_loc(error) SEMI structure
+    { let menhirError = Reason_syntax_util.findMenhirErrorMessage $1.loc in
+      match menhirError with
+      | MenhirMessagesError errMessage -> (syntax_error_str errMessage.loc errMessage.msg) :: $3
+      | _ -> (syntax_error_str $1.loc "Invalid statement") :: $3
+    }
+  | as_loc(structure_item) error structure
+    { let menhirError = Reason_syntax_util.findMenhirErrorMessage $1.loc in
+      match menhirError with
+      | MenhirMessagesError errMessage -> (syntax_error_str errMessage.loc errMessage.msg) :: $3
+      | _ -> (syntax_error_str $1.loc "Statement has to end with a semicolon") :: $3
+    }
+;
+
+opt_LET_MODULE_ident:
+  | opt_LET_MODULE as_loc(UIDENT) { $2 }
+  | opt_LET_MODULE as_loc(LIDENT)
+    { let {loc} = $2 in
+      err loc lowercase_module_msg }
+;
+
+opt_LET_MODULE_REC_ident:
+  | opt_LET_MODULE REC as_loc(UIDENT) { $3 }
+  | opt_LET_MODULE REC as_loc(LIDENT)
+    { let {loc} = $3 in
+      err loc lowercase_module_msg }
+;
+
+structure_item:
+  | mark_position_str
+    (* We consider a floating expression to be equivalent to a single let binding
+       to the "_" (any) pattern.  *)
+    ( item_attributes unattributed_expr
+      { mkstrexp $2 $1 }
+    | item_attributes item_extension_sugar structure_item
+      { let (ext_attrs, ext_id) = $2 in
+        struct_item_extension ($1@ext_attrs, ext_id) $3 }
+    | item_attributes
+      EXTERNAL as_loc(val_ident) COLON core_type EQUAL primitive_declaration
+      { let loc = mklocation $symbolstartpos $endpos in
+        mkstr (Pstr_primitive (Val.mk $3 $5 ~prim:$7 ~attrs:$1 ~loc)) }
+    | type_declarations
+      { let (nonrec_flag, tyl) = $1 in mkstr(Pstr_type (nonrec_flag, tyl)) }
+    | str_type_extension
+      { mkstr(Pstr_typext $1) }
+    | str_exception_declaration
+      { mkstr(Pstr_exception $1) }
+    | item_attributes opt_LET_MODULE_ident module_binding_body
+      { let loc = mklocation $symbolstartpos $endpos in
+        mkstr(Pstr_module (Mb.mk $2 $3 ~attrs:$1 ~loc)) }
+    | item_attributes opt_LET_MODULE_REC_ident module_binding_body
+      and_module_bindings*
+      { let loc = mklocation $symbolstartpos $endpos($2) in
+        mkstr (Pstr_recmodule ((Mb.mk $2 $3 ~attrs:$1 ~loc) :: $4))
+      }
+    | item_attributes MODULE TYPE OF? as_loc(ident)
+      { let loc = mklocation $symbolstartpos $endpos in
+        mkstr(Pstr_modtype (Mtd.mk $5 ~attrs:$1 ~loc)) }
+    | item_attributes MODULE TYPE OF? as_loc(ident) module_type_body(EQUAL)
+      { let loc = mklocation $symbolstartpos $endpos in
+        mkstr(Pstr_modtype (Mtd.mk $5 ~typ:$6 ~attrs:$1 ~loc)) }
+    | open_statement
+      { mkstr(Pstr_open $1) }
+    | item_attributes CLASS class_declaration_details and_class_declaration*
+      { let (ident, binding, virt, params) = $3 in
+        let loc = mklocation $symbolstartpos $endpos($3) in
+        let first = Ci.mk ident binding ~virt ~params ~attrs:$1 ~loc in
+        mkstr (Pstr_class (first :: $4))
+      }
+    | class_type_declarations
+        (* Each declaration has their own preceeding attribute* *)
+      { mkstr(Pstr_class_type $1) }
+    | item_attributes INCLUDE module_expr
+      { let loc = mklocation $symbolstartpos $endpos in
+        mkstr(Pstr_include (Incl.mk $3 ~attrs:$1 ~loc))
+      }
+    | item_attributes item_extension
+      (* No sense in having item_extension_sugar for something that's already an
+       * item_extension *)
+      { mkstr(Pstr_extension ($2, $1)) }
+    | let_bindings
+      { val_of_let_bindings $1 }
+    ) { [$1] }
+ | located_attributes
+   { List.map (fun x -> mkstr ~loc:x.loc (Pstr_attribute x.txt)) $1 }
+;
+
+module_binding_body:
+  | loption(functor_parameters) module_expr_body
+    { mk_functor_mod $1 $2 }
+  | loption(functor_parameters) COLON module_type module_expr_body
+    { let loc = mklocation $startpos($3) $endpos($4) in
+      mk_functor_mod $1 (mkmod ~loc (Pmod_constraint($4, $3))) }
+;
+
+and_module_bindings:
+  item_attributes AND as_loc(UIDENT) module_binding_body
+  { Mb.mk $3 $4 ~attrs:$1 ~loc:(mklocation $symbolstartpos $endpos) }
+;
+
+(* Module types *)
+
+(*
+(*
+ * For now, WITH constraints on module types shouldn't be considered
+ * "non-arrowed" because their WITH constraints themselves might contain arrows.
+ * We could ensure that you may only supply *non* arrowed types (or wrap arrowed
+ * types in parens) in thier WITH constraints, but that's just too difficult to
+ * think about so we will simply not consider WITH constrained module types as
+ * non-arrowed.
+ *
+ * Given this, we can probably take out the below_WITH precedence in the rules
+ * down below.
+ *)
+*)
+
+(* Allowed in curried let bidings *)
+
+simple_module_type:
+mark_position_mty
+  ( parenthesized(module_parameter)
+    { match $1.txt with
+      | (None, Some x) -> x
+      | _ -> syntax_error_mod $1.loc "Expecting a simple module type"
+    }
+  | module_type_signature { $1 }
+  | as_loc(LPAREN) module_type as_loc(error)
+    { unclosed_mty (with_txt $1 "(") (with_txt $3 ")")}
+  | as_loc(mty_longident)
+    { mkmty (Pmty_ident $1) }
+  | as_loc(LBRACE) signature as_loc(error)
+    { unclosed_mty (with_txt $1 "{") (with_txt $3 "}")}
+  | extension
+    { mkmty (Pmty_extension $1) }
+  ) {$1};
+
+module_type_signature:
+  LBRACE signature RBRACE
+  { mkmty ~loc:(mklocation $startpos $endpos) (Pmty_signature $2) }
+;
+
+(*
+(*
+ * For module types, we have:
+ *
+ *  simple_module_type: (Non arrowed implied)
+ *  non_arrowed_module_type
+ *  module_type ::=
+ *    module_type WITH ...
+ *    non_arrowed_module_type
+ *    (arg : module_type) => module_type
+ *    module_type => module_type
+ *)
+*)
+
+%inline with_constraints:
+  WITH lseparated_nonempty_list(AND, with_constraint) { $2 }
+
+module_type:
+mark_position_mty
+  ( module_type with_constraints
+    (* See note above about why WITH constraints aren't considered
+     * non-arrowed.
+     * We might just consider unifying the syntax for record extension with
+     * module extension/WITH constraints.
+     *
+     *    mod MyModule = {
+     *       ModuleToInclude...
+     *    };
+     *
+     *    let module CreateFactory
+     *               (Spec: ContainerSpec)
+     *               :{DescriptorFactoryIntf.S with
+     *                  type props = Spec.props and type dependencies = Spec.props} =>
+     *
+     *)
+    { mkmty (Pmty_with($1, $2)) }
+  | simple_module_type
+    {$1}
+  | LPAREN MODULE TYPE OF module_expr RPAREN
+    { mkmty (Pmty_typeof $5) }
+  | attribute module_type %prec attribute_precedence
+    { {$2 with pmty_attributes = $1 :: $2.pmty_attributes} }
+  | functor_parameters EQUALGREATER module_type %prec below_SEMI
+      (**
+       * In OCaml, this is invalid:
+       * module MyFunctor: functor MT -> (sig end) = functor MT -> (struct end);;
+       *
+       * Not only must curried functor args have annotations, but functor
+       * annotations must include *names* for each argument in a functor type.
+       *
+       * module MyFunctor: functor (MT:MT) -> (sig end) = functor (MT:MT) -> (struct end)
+       *
+       * In Reason, we will parse the functor type:
+       *
+       *    (AB:MT) -> ReturnSig
+       *
+       * as in:
+       *                   /----------------\
+       * module MyFunctor: (A:B) => ReturnSig = functor (C:D) => {}
+       *
+       * But only for the sake of compatibility with existing OCaml code (the
+       * ability to "view" OCaml code in Reason's syntax without loss of
+       * information.) Do not write identifiers in functor argument type
+       * positions - you wouldn't do it with functions, and they are
+       * meaningless in functors.
+       *
+       *  But for sake of consistency (and for sake of a syntax that truly
+       *  unifies functor syntax with function syntax, the following "sugars"
+       *  will be parsed (and printed):
+       *
+       *   A => B => C
+       *
+       * Is parsed into:
+       *
+       * functor (_:A) -> functor (_:B) -> C
+       *
+       * And a dummy "_" is inserted into the parse tree where no name has been
+       * provided.
+       *
+       *   {SomeSig} => {} => {}
+       *
+       * Is parsed into:
+       *
+       * (_:SomeSig) => (_:{}) => {}
+       *
+       *
+       *)
+    { mk_functor_mty $1 $3 }
+  ) {$1};
+
+signature:
+  | (* Empty *) { [] }
+  | signature_items { $1 }
+  | signature_items SEMI signature { $1 @ $3 }
+;
+
+signature_item:
+  | item_attributes
+    LET as_loc(val_ident) COLON core_type
+    { let loc = mklocation $startpos($2) $endpos in
+      Psig_value (Val.mk $3 $5 ~attrs:$1 ~loc)
+    }
+  | item_attributes
+    EXTERNAL as_loc(val_ident) COLON core_type EQUAL primitive_declaration
+    { let loc = mklocation $symbolstartpos $endpos in
+      Psig_value (Val.mk $3 $5 ~prim:$7 ~attrs:$1 ~loc)
+    }
+  | type_declarations
+    { let (nonrec_flag, tyl) = $1 in Psig_type (nonrec_flag, tyl) }
+  | sig_type_extension
+    { Psig_typext $1 }
+  | sig_exception_declaration
+    { Psig_exception $1 }
+  | item_attributes opt_LET_MODULE_ident module_declaration
+    { let loc = mklocation $symbolstartpos $endpos in
+      Psig_module (Md.mk $2 $3 ~attrs:$1 ~loc)
+    }
+  | item_attributes opt_LET_MODULE_ident EQUAL as_loc(mod_longident)
+    { let loc = mklocation $symbolstartpos $endpos in
+      let loc_mod = mklocation $startpos($4) $endpos($4) in
+      Psig_module (
+        Md.mk
+            $2
+            (Mty.alias ~loc:loc_mod $4)
+            ~attrs:$1
+            ~loc
+            )
+    }
+  | item_attributes opt_LET_MODULE_REC_ident module_type_body(COLON)
+    and_module_rec_declaration*
+    { let loc = mklocation $symbolstartpos $endpos($3) in
+      Psig_recmodule (Md.mk $2 $3 ~attrs:$1 ~loc :: $4) }
+  | item_attributes MODULE TYPE as_loc(ident)
+    { let loc = mklocation $symbolstartpos $endpos in
+      Psig_modtype (Mtd.mk $4 ~attrs:$1 ~loc)
+    }
+  | item_attributes MODULE TYPE as_loc(ident) module_type_body(EQUAL)
+    { let loc = mklocation $symbolstartpos $endpos in
+      Psig_modtype (Mtd.mk $4 ~typ:$5 ~loc ~attrs:$1)
+    }
+  | open_statement
+    { Psig_open $1 }
+  | item_attributes INCLUDE module_type
+    { let loc = mklocation $symbolstartpos $endpos in
+      Psig_include (Incl.mk $3 ~attrs:$1 ~loc)
+    }
+  | class_descriptions
+    { Psig_class $1 }
+  | class_type_declarations
+    { Psig_class_type $1 }
+  | item_attributes item_extension
+    { Psig_extension ($2, $1) }
+;
+
+signature_items:
+  | as_loc(signature_item) { [mksig ~loc:$1.loc $1.txt] }
+  | located_attributes
+    { List.map (fun x -> mksig ~loc:x.loc (Psig_attribute x.txt)) $1 }
+;
+
+open_statement:
+  item_attributes OPEN override_flag as_loc(mod_longident)
+  { Opn.mk $4 ~override:$3 ~attrs:$1 ~loc:(mklocation $symbolstartpos $endpos) }
+;
+
+module_declaration:
+  loption(functor_parameters) module_type_body(COLON)
+  { mk_functor_mty $1 $2 }
+;
+
+module_type_body(DELIM):
+  | DELIM module_type { $2 }
+  | module_type_signature { $1 }
+;
+
+and_module_rec_declaration:
+  item_attributes AND as_loc(UIDENT) module_type_body(COLON)
+  { Md.mk $3 $4 ~attrs:$1 ~loc:(mklocation $symbolstartpos $endpos) }
+;
+
+(* Class expressions *)
+
+and_class_declaration:
+  item_attributes AND class_declaration_details
+  { let (ident, binding, virt, params) = $3 in
+    let loc = mklocation $symbolstartpos $endpos in
+    Ci.mk ident binding ~virt ~params ~attrs:$1 ~loc
+  }
+;
+
+class_declaration_details:
+  virtual_flag as_loc(LIDENT) ioption(class_type_parameters)
+  ioption(labeled_pattern_list) class_declaration_body
+  {
+    let tree = match $4 with
+    | None -> []
+    | Some (lpl, _uncurried) -> lpl
+    in
+    let body = List.fold_right mkclass_fun tree $5 in
+    let params = match $3 with None -> [] | Some x -> x in
+    ($2, body, $1, params)
+  }
+;
+
+class_declaration_body:
+  preceded(COLON, class_constructor_type)?
+  either(preceded(EQUAL, class_expr), class_body_expr)
+  { match $1 with
+    | None -> $2
+    | Some ct -> Cl.constraint_ ~loc:(mklocation $symbolstartpos $endpos) $2 ct
+  }
+;
+
+class_expr_lets_and_rest:
+mark_position_cl
+  ( class_expr { $1 }
+  | let_bindings SEMI class_expr_lets_and_rest
+    { class_of_let_bindings $1 $3 }
+  | object_body { mkclass (Pcl_structure $1) }
+  ) {$1};
+
+object_body_class_fields:
+  | lseparated_list(SEMI, class_field) SEMI? { List.concat $1 }
+
+object_body:
+  | loption(located_attributes)
+    mark_position_pat(class_self_expr)
+    { let attrs = List.map (fun x -> mkcf ~loc:x.loc (Pcf_attribute x.txt)) $1 in
+      Cstr.mk $2 attrs }
+  | loption(located_attributes)
+    mark_position_pat(class_self_expr) SEMI
+    object_body_class_fields
+    { let attrs = List.map (fun x -> mkcf ~loc:x.loc (Pcf_attribute x.txt)) $1 in
+      Cstr.mk $2 (attrs @ $4) }
+  | object_body_class_fields
+    { let loc = mklocation $symbolstartpos $symbolstartpos in
+      Cstr.mk (mkpat ~loc (Ppat_var (mkloc "this" loc))) $1 }
+;
+
+class_self_expr:
+  | AS pattern { $2 }
+
+class_expr:
+mark_position_cl
+  ( class_simple_expr
+    { $1 }
+  | either(ES6_FUN,FUN) labeled_pattern_list EQUALGREATER class_expr
+    { let (lp, _) = $2 in
+      List.fold_right mkclass_fun lp $4 }
+  | class_simple_expr labeled_arguments
+      (**
+       * This is an interesting way to "partially apply" class construction:
+       *
+       * let inst = new oldclass 20;
+       * class newclass = oldclass withInitArg;
+       * let inst = new newclass;
+       *)
+    { mkclass(Pcl_apply($1, $2)) }
+  | attribute class_expr
+    { {$2 with pcl_attributes = $1 :: $2.pcl_attributes} }
+  (*
+    When referring to class expressions (not regular types that happen to be
+    classes), you must refer to it as a class. This gives syntactic real estate
+    to place type parameters which are distinguished from constructor application
+    of arguments.
+
+       class myClass 'x = (class yourClass 'x int) y z;
+       inherit (class yourClass float int) initArg initArg;
+       ...
+       let myVal: myClass int = new myClass 10;
+
+   *)
+  | CLASS as_loc(class_longident) loption(type_parameters)
+    { mkclass(Pcl_constr($2, $3)) }
+  | extension
+    { mkclass(Pcl_extension $1) }
+  ) {$1};
+
+class_simple_expr:
+mark_position_cl
+  ( as_loc(class_longident)
+    { mkclass(Pcl_constr($1, [])) }
+  | class_body_expr
+    { $1 }
+  | as_loc(LBRACE) class_expr_lets_and_rest as_loc(error)
+    { unclosed_cl (with_txt $1 "{") (with_txt $3 "}") }
+  | LPAREN class_expr COLON class_constructor_type RPAREN
+    { mkclass(Pcl_constraint($2, $4)) }
+  | as_loc(LPAREN) class_expr COLON class_constructor_type as_loc(error)
+    { unclosed_cl (with_txt $1 "(") (with_txt $5 ")") }
+  | LPAREN class_expr RPAREN
+    { $2 }
+  | as_loc(LPAREN) class_expr as_loc(error)
+    { unclosed_cl (with_txt $1 "(") (with_txt $3 ")") }
+  ) {$1};
+
+%inline class_body_expr: LBRACE class_expr_lets_and_rest RBRACE { $2 };
+
+class_field:
+  | mark_position_cf
+    ( item_attributes INHERIT override_flag class_expr preceded(AS,LIDENT)?
+      { mkcf_attrs (Pcf_inherit ($3, $4, $5)) $1 }
+    | item_attributes VAL value
+      { mkcf_attrs (Pcf_val $3) $1 }
+    | item_attributes either(PUB {Public}, PRI {Private}) method_
+      { let (a, b) = $3 in mkcf_attrs (Pcf_method (a, $2, b)) $1 }
+    | item_attributes CONSTRAINT constrain_field
+      { mkcf_attrs (Pcf_constraint $3) $1 }
+    | item_attributes INITIALIZER mark_position_exp(simple_expr)
+      { mkcf_attrs (Pcf_initializer $3) $1 }
+    | item_attributes item_extension
+      { mkcf_attrs (Pcf_extension $2) $1 }
+    ) { [$1] }
+  | located_attributes
+    { List.map (fun x -> mkcf ~loc:x.loc (Pcf_attribute x.txt)) $1 }
+;
+
+value:
+(* TODO: factorize these rules (also with method): *)
+  | override_flag MUTABLE VIRTUAL as_loc(label) COLON core_type
+    { if $1 = Override
+      then not_expecting $symbolstartpos $endpos "members marked virtual may not also be marked overridden"
+      else ($4, Mutable, Cfk_virtual $6)
+    }
+  | override_flag MUTABLE VIRTUAL label COLON core_type EQUAL
+    { not_expecting $startpos($7) $endpos($7) "not expecting equal - cannot specify value for virtual val" }
+  | VIRTUAL mutable_flag as_loc(label) COLON core_type
+    { ($3, $2, Cfk_virtual $5) }
+  | VIRTUAL mutable_flag label COLON core_type EQUAL
+    { not_expecting $startpos($6) $endpos($6) "not expecting equal - cannot specify value for virtual val" }
+  | override_flag mutable_flag as_loc(label) EQUAL expr
+    { ($3, $2, Cfk_concrete ($1, $5)) }
+  | override_flag mutable_flag as_loc(label) type_constraint EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      let e = ghexp_constraint loc $6 $4 in
+      ($3, $2, Cfk_concrete ($1, e)) }
+;
+
+method_:
+(* TODO: factorize those rules... *)
+  | override_flag VIRTUAL as_loc(label) COLON poly_type
+    { if $1 = Override then syntax_error ();
+      ($3, Cfk_virtual $5)
+    }
+  | override_flag as_loc(label) fun_def(EQUAL,core_type)
+    { let loc = mklocation $symbolstartpos $endpos in
+      ($2, Cfk_concrete ($1, mkexp ~ghost:true ~loc (Pexp_poly ($3, None))))
+    }
+  | override_flag as_loc(label) preceded(COLON,poly_type)?
+    either(preceded(EQUAL,expr), braced_expr)
+      (* Without locally abstract types, you'll see a Ptyp_poly in the Pexp_poly *)
+    { let loc = mklocation $symbolstartpos $endpos in
+      ($2, Cfk_concrete ($1, mkexp ~ghost:true ~loc (Pexp_poly($4, $3))))
+    }
+  | override_flag as_loc(label) COLON TYPE LIDENT+ DOT core_type
+    either(preceded(EQUAL,expr), braced_expr)
+    (* WITH locally abstract types, you'll see a Ptyp_poly in the Pexp_poly,
+       but the expression will be a Pexp_newtype and type vars will be
+       "varified". *)
+    {
+      (* For non, methods we'd create a pattern binding:
+         ((Ppat_constraint(mkpatvar ..., Ptyp_poly (typeVars, poly_type_varified))),
+          exp_with_newtypes_constrained_by_non_varified)
+
+         For methods, we create:
+         Pexp_poly (Pexp_constraint (methodFunWithNewtypes, non_varified), Some (Ptyp_poly newTypes varified))
+       *)
+      let (exp_non_varified, poly_vars) = wrap_type_annotation $5 $7 $8 in
+      let exp = Pexp_poly(exp_non_varified, Some poly_vars) in
+      let loc = mklocation $symbolstartpos $endpos in
+      ($2, Cfk_concrete ($1, mkexp ~ghost:true ~loc exp))
+    }
+;
+
+(* A parsing of class_constructor_type is the type of the class's constructor - and if the
+   constructor takes no arguments, then simply the class_instance_type of what is
+   returned.
+
+   The class_instance_type is type of the thing returned from a class constructor
+   which can either be:
+    - The identifier of another class.
+    - Type construction of a class type. [v1, v2] classIdentifier
+    - The type definition of the object returned (which is much like the type
+      of anonymous object but with different syntax, and ability to specify
+      inheritance):
+      - The class signature body may contain the type of methods (just like object types do)
+      - Inheritance of another class_instance_type.
+      - The instance variable "val"s.
+      - Constraints (same syntax that is used at class *definition* time)
+
+
+     When In Modules:
+     ================
+     There are two primary language "class" constructs that are included in modules:
+     Class Definitions, and Class Type Definitions.
+
+     A Class Definition:
+     -------------------
+     Brings three things into the environment. For a class defined with name
+     [myClass], the environment would then contain the following:
+       1. A type called [myClass] which represents instances that have the same
+       structure as what is returned from the constructor - and do not have
+       any *more* members than what is returned from the constructor.
+       2. A type called [#myClass] which loosely speaking represents objects
+       that have the same structure as what is returned from the constructor,
+       but can also have *additional* fields as well. This ability to have
+       additional fields is accomplished via the same row-polymorphism of
+       objects without classes. Any reference to [#myClass] implicitly includes
+       a type variable, whose name we may not mention.
+       3. The class constructor for [myClass] - a function that "new" can be
+       invoked on. If the constructor is a function that takes arguments, then
+       the type of the constructor is the type of that function (including
+       the type of object returned). If it doesn't take arguments, then the
+       type of the constructor is the type of the object returned. You can
+       explicitly annotate/constrain the type of the constructor, and can
+       annotate them in module signatures as well.
+
+     The type constraint on a constructor has one syntactic nuance. The final
+     item separated by arrow must be prefixed with "new". This is merely to
+     resolve parsing conflicts. This can be fixed by making a parse rule for
+     types that parses *either* non-arowed class_instance_type or core_types,
+     but that means deferring the interpretation of patterns like "lowercase
+     identifier" and "type application", until it is known if that item was the
+     *final* arrow segment.
+
+     A Class Type Definition:
+     -----------------------
+     Brings two things into the environment. For a class type definition with
+     name [myClass], the environment would then contain the following:
+       1. A type called [myClass] which describes any object having *exactly*
+       the fields listed in the definition.
+       2. A type called [#myClass] which loosely speaking represents objects
+       that have the same structure as the definition, but can also have
+       *additional* fields as well.
+
+
+     When In Signatures:
+     ================
+
+     A Class Definition (in signature becomes a class "description"):
+     -------------------
+     A Class Definition merely includes the type of that classes constructor.
+     [class myClass: args => new classType;] This merely admits that the module
+     includes a class whose constructor has that type.
+
+     A Class Type Definition is specified exactly as it is in a module (of
+     course, it may be abstract).
+
+
+     A Class Type Definition:
+     -----------------------
+     A Class Type Definition is specified exactly as it is in a module (of
+     course, it may be abstract).
+     Here are the parsing rules for everything discussed above:
+
+
+
+    Overview of Parsing Rules:
+    ==========================
+     (Note: I have renamed class_type from the upstream compiler to
+     class_constructor_type and class_signature to class_instance_type for
+     clarity)
+
+     constructor_type:
+        | class_instance_type
+        | constructorFunction => typeWithArrows => class_instance_type
+
+     Modules
+       Class Definitions
+       class_declarations
+         | class LIDENT = class_expr
+         | class LIDENT = (class_expr : constructor_type)
+         "Pstr_class"
+
+       Class Type Definition
+       class_type_declarations
+         CLASS TYPE ident = class_instance_type
+         "Pstr_class_type"
+
+     Signatures
+       Class Descriptions (describes Class Definitions in Module)
+       class_descriptions
+         CLASS ident : constructor_type
+         "Psig_class"
+
+       Class Type Declarations (subset of Class Type Definitions in Module)
+       class_type_declarations
+         CLASS TYPE ident = class_instance_type
+        "Psig_class_type"
+
+ *)
+class_constructor_type:
+  | class_instance_type { $1 }
+  | arrow_type_parameters EQUALGREATER class_constructor_type
+    { List.fold_right mkcty_arrow $1 $3 }
+;
+
+class_type_arguments_comma_list:
+  | lseparated_nonempty_list(COMMA,core_type) COMMA? {$1}
+;
+
+class_instance_type:
+mark_position_cty
+  ( as_loc(clty_longident)
+    loption(parenthesized(class_type_arguments_comma_list))
+    { mkcty (Pcty_constr ($1, $2)) }
+  | attribute class_instance_type
+    (* Note that this will compound attributes - so they will become
+       attached to whatever *)
+    { {$2 with pcty_attributes = $1 :: $2.pcty_attributes} }
+  | class_type_body
+    { $1 }
+  | extension
+    { mkcty (Pcty_extension $1) }
+  ) {$1};
+
+class_type_body:
+  | LBRACE class_sig_body RBRACE
+    { mkcty ~loc:(mklocation $startpos $endpos) (Pcty_signature $2) }
+  | LBRACE DOT class_sig_body RBRACE
+    { let loc = mklocation $startpos $endpos in
+      let ct = mkcty ~loc (Pcty_signature $3) in
+      {ct with pcty_attributes = [uncurry_payload loc]}
+    }
+  | as_loc(LBRACE) class_sig_body as_loc(error)
+    { unclosed_cty (with_txt $1 "{") (with_txt $3 "}") }
+;
+
+class_sig_body_fields:
+  lseparated_list(SEMI, class_sig_field) SEMI? { List.concat $1 }
+
+class_sig_body:
+  | class_self_type
+  { Csig.mk $1 [] }
+  | class_self_type SEMI class_sig_body_fields
+  { Csig.mk $1 $3 }
+  | class_sig_body_fields
+  { Csig.mk (Typ.mk ~loc:(mklocation $symbolstartpos $endpos) Ptyp_any) $1 }
+;
+
+class_self_type:
+  | AS core_type { $2 }
+;
+
+class_sig_field:
+  | mark_position_ctf
+    ( item_attributes INHERIT class_instance_type
+      { mkctf_attrs (Pctf_inherit $3) $1 }
+    | item_attributes VAL value_type
+      { mkctf_attrs (Pctf_val $3) $1 }
+    | item_attributes PRI virtual_flag label COLON poly_type
+      { mkctf_attrs (Pctf_method ($4, Private, $3, $6)) $1 }
+    | item_attributes PUB virtual_flag label COLON poly_type
+      { mkctf_attrs (Pctf_method ($4, Public, $3, $6)) $1 }
+    | item_attributes CONSTRAINT constrain_field
+      { mkctf_attrs (Pctf_constraint $3) $1 }
+    | item_attributes item_extension
+      { mkctf_attrs (Pctf_extension $2) $1 }
+    ) { [$1] }
+  | located_attributes
+    { List.map (fun x -> mkctf ~loc:x.loc (Pctf_attribute x.txt)) $1 }
+;
+
+value_type:
+  mutable_or_virtual_flags label COLON core_type
+  { let (mut, virt) = $1 in ($2, mut, virt, $4) }
+;
+
+constrain:
+  core_type EQUAL core_type
+  { ($1, $3, mklocation $symbolstartpos $endpos) }
+;
+
+constrain_field:
+  core_type EQUAL core_type
+  { ($1, $3) }
+;
+
+class_descriptions:
+  item_attributes CLASS class_description_details and_class_description*
+  { let (ident, binding, virt, params) = $3 in
+    let loc = mklocation $symbolstartpos $endpos in
+    (Ci.mk ident binding ~virt ~params ~attrs:$1 ~loc :: $4)
+  }
+;
+
+and_class_description:
+  item_attributes AND class_description_details
+  { let (ident, binding, virt, params) = $3 in
+    let loc = mklocation $symbolstartpos $endpos in
+    Ci.mk ident binding ~virt ~params ~attrs:$1 ~loc
+  }
+;
+
+%inline class_type_parameter_comma_list:
+    | lseparated_nonempty_list(COMMA, type_parameter) COMMA? {$1}
+
+%inline class_type_parameters:
+  parenthesized(class_type_parameter_comma_list)
+  { $1 }
+;
+
+class_description_details:
+  virtual_flag as_loc(LIDENT) loption(class_type_parameters) COLON class_constructor_type
+  { ($2, $5, $1, $3) }
+;
+
+class_type_declarations:
+  item_attributes CLASS TYPE class_type_declaration_details
+  and_class_type_declaration*
+  { let (ident, instance_type, virt, params) = $4 in
+    let loc = mklocation $symbolstartpos $endpos in
+    (Ci.mk ident instance_type ~virt ~params ~attrs:$1 ~loc :: $5)
+  }
+;
+
+and_class_type_declaration:
+  item_attributes AND class_type_declaration_details
+  { let (ident, instance_type, virt, params) = $3 in
+    let loc = mklocation $symbolstartpos $endpos in
+    Ci.mk ident instance_type ~virt ~params ~attrs:$1 ~loc
+  }
+;
+
+class_type_declaration_details:
+  virtual_flag as_loc(LIDENT) loption(class_type_parameters)
+  either(preceded(EQUAL,class_instance_type), class_type_body)
+  { ($2, $4, $1, $3) }
+;
+
+(* Core expressions *)
+
+(* Note: If we will parse this as Pexp_apply, and it will
+ * not be printed with the braces, except in a couple of cases such as if/while
+ * loops.
+ *
+ *  let add a b = {
+ *    a + b;
+ *  };
+ *  TODO: Rename to [semi_delimited_block_sequence]
+ *
+ * Since seq_expr doesn't require a final SEMI, then without
+ * a final SEMI, a braced sequence with a single identifier is
+ * indistinguishable from a punned record.
+ *
+ *   let myThing = {x};
+ *
+ * Is it {x:x} the record or x the identifier? We simply decided to break
+ * the tie and say that it should be parsed as a single identifier because
+ * single field records are incredibly rare. Apart from this one
+ * disadvantage, there's no disadvantage to not requiring the final brace.
+ *
+ * For each valid sequence item, we must list three forms:
+ *
+ *   [item_extension_sugar] [nonempty_item_attributes] ITEM
+ *   [nonempty_item_attributes] ITEM
+ *   ITEM
+ *)
+braced_expr:
+mark_position_exp
+  ( LBRACE seq_expr RBRACE
+    { add_brace_attr $2 }
+  | LBRACE as_loc(seq_expr) error
+    { syntax_error_exp $2.loc "SyntaxError in block" }
+  | LBRACE DOTDOTDOT expr_optional_constraint COMMA? RBRACE
+    { let loc = mklocation $symbolstartpos $endpos in
+      let msg = "Record construction must have at least one field explicitly set" in
+      syntax_error_exp loc msg
+    }
+  | LBRACE DOTDOTDOT expr_optional_constraint SEMI RBRACE
+    { let loc = mklocation $startpos($4) $endpos($4) in
+      raise_record_trailing_semi_error loc }
+  | LBRACE record_expr RBRACE
+    { let (exten, fields) = $2 in mkexp (Pexp_record(fields, exten)) }
+  | as_loc(LBRACE) record_expr as_loc(error)
+    { unclosed_exp (with_txt $1 "{") (with_txt $3 "}")}
+  | LBRACE record_expr_with_string_keys RBRACE
+    { let loc = mklocation $symbolstartpos $endpos in
+      let (exten, fields) = $2 in
+      mkexp ~loc (Pexp_extension (mkloc ("bs.obj") loc,
+             PStr [mkstrexp (mkexp ~loc (Pexp_record(fields, exten))) []]))
+    }
+  | as_loc(LBRACE) record_expr_with_string_keys as_loc(error)
+    { unclosed_exp (with_txt $1 "{") (with_txt $3 "}")}
+  (* Todo: Why is this not a simple_expr? *)
+  | LBRACE object_body RBRACE
+    { mkexp (Pexp_object $2) }
+  | as_loc(LBRACE) object_body as_loc(error)
+    { unclosed_exp (with_txt $1 "{") (with_txt $3 "}") }
+) {$1};
+
+seq_expr_no_seq:
+| expr SEMI? { $1 }
+| opt_LET_MODULE_ident module_binding_body SEMI seq_expr
+  { mkexp (Pexp_letmodule($1, $2, $4)) }
+| item_attributes LET? OPEN override_flag as_loc(mod_longident) SEMI seq_expr
+  { let exp = mkexp (Pexp_open($4, $5, $7)) in
+    { exp with pexp_attributes = $1 }
+  }
+| str_exception_declaration SEMI seq_expr {
+   mkexp (Pexp_letexception ($1, $3)) }
+| let_bindings SEMI seq_expr
+  { let loc = mklocation $startpos($1) $endpos($3) in
+    expr_of_let_bindings ~loc $1 $3
+  }
+| let_bindings SEMI?
+  { let loc = mklocation $symbolstartpos $endpos in
+    expr_of_let_bindings ~loc $1 (ghunit ~loc ())
+  }
+;
+
+seq_expr:
+mark_position_exp
+  ( seq_expr_no_seq
+    { $1 }
+  | item_extension_sugar mark_position_exp(seq_expr_no_seq)
+    { expression_extension $1 $2 }
+  | expr SEMI seq_expr
+    { mkexp (Pexp_sequence($1, $3)) }
+  | item_extension_sugar expr SEMI seq_expr
+    { let loc = mklocation $startpos($1) $endpos($2) in
+      mkexp (Pexp_sequence(expression_extension ~loc $1 $2, $4)) }
+  ) { $1 }
+;
+
+(*
+
+
+A:
+let named                 a::a      b::b             => a + b;
+type named =              a::int => b::int => int;
+B:
+let namedAlias            a::aa     b::bb  => aa + bb;
+let namedAlias            a::aa     b::bb  => aa + bb;
+type namedAlias =         a::int => b::int => int;
+C:
+let namedAnnot            a::(a:int) b::(b:int)   => 20;
+D:
+let namedAliasAnnot       a::(aa:int) b::(bb:int) => 20;
+E:
+let myOptional            a::a=?    b::b=?      ()  => 10;
+type named =              a::int? => b::int? => unit => int;
+F:
+let optionalAlias         a::aa=?   b::bb=?   ()  => 10;
+G:
+let optionalAnnot         a::(a:int)=? b::(b:int)=? ()  => 10;
+H:
+let optionalAliasAnnot    a::(aa:int)=? b::(bb:int)=? ()  => 10;
+I: :
+let defOptional           a::a=10    b::b=10  ()  => 10;
+type named =              a::int?  => b::int? => unit => int;
+J:
+let defOptionalAlias      a::aa=10      b::bb=10  ()  => 10;
+K:
+let defOptionalAnnot      a::(a:int)=10 b::(b:int)=10 ()  => 10;
+L:
+let defOptionalAliasAnnot a::(aa:int)=10 b::(bb:int)=10 ()  => 10;
+
+M: Invoking them - Punned :
+let resNotAnnotated = named a::a b::b;
+N::
+let resAnnotated    = (named a::a b::b :int);
+O: Invoking them :
+let resNotAnnotated = named a::a b::b;
+P: Invoking them :
+let resAnnotated    = (named a::a b::b :int);
+
+Q: Here's why "punning" doesn't work!  :
+ Is b:: punned with a final non-named arg, or is b:: supplied b as one named arg? :
+let b = 20;
+let resAnnotated    = (named a::a b:: b);
+
+R: Proof that there are no ambiguities with return values being annotated :
+let resAnnotated    = (named a::a b :ty);
+
+
+S: Explicitly passed optionals are a nice way to say "use the default value":
+let explicitlyPassed =          myOptional a::?None b::?None;
+T: Annotating the return value of the entire function call :
+let explicitlyPassedAnnotated = (myOptional a::?None b::?None :int);
+U: Explicitly passing optional with identifier expression :
+let a = None;
+let explicitlyPassed =           myOptional a::?a b::?None;
+let explicitlyPassedAnnotated = (myOptional a::?a b::?None :int);
+
+*)
+
+labeled_pattern_constraint:
+  | AS pattern_optional_constraint { fun _punned -> $2 }
+  | preceded(COLON, core_type)?
+    { fun punned ->
+      let pat = mkpat (Ppat_var punned) ~loc:punned.loc in
+      match $1 with
+      | None -> pat
+      | Some typ ->
+        let loc = mklocation punned.loc.loc_start $endpos in
+        mkpat ~loc (Ppat_constraint(pat, typ))
+    }
+;
+
+labeled_pattern:
+as_loc
+   ( TILDE as_loc(LIDENT) labeled_pattern_constraint
+    { Term (Labelled $2.txt, None, $3 $2) }
+  | TILDE as_loc(LIDENT) labeled_pattern_constraint EQUAL expr
+    { Term (Optional $2.txt, Some $5, $3 $2) }
+  | TILDE as_loc(LIDENT) labeled_pattern_constraint EQUAL QUESTION
+    { Term (Optional $2.txt, None, $3 $2) }
+  | pattern_optional_constraint
+    { Term (Nolabel, None, $1) }
+  | TYPE LIDENT
+    { Type $2 }
+  ) { $1 }
+;
+
+
+%inline labelled_pattern_comma_list:
+  lseparated_nonempty_list(COMMA, labeled_pattern) COMMA? { $1 };
+
+%inline labeled_pattern_list:
+  | LPAREN RPAREN {
+    let loc = mklocation $startpos $endpos in
+    ([mkloc (Term (Nolabel, None, mkpat_constructor_unit loc loc)) loc], false)
+  }
+  | parenthesized(labelled_pattern_comma_list) {
+    ($1, false)
+  }
+  | LPAREN DOT RPAREN {
+      let loc = mklocation $startpos $endpos in
+      ([mkloc (Term (Nolabel, None, mkpat_constructor_unit loc loc)) loc], true)
+  }
+  | LPAREN DOT labelled_pattern_comma_list RPAREN {
+    let () = List.iter (fun p ->
+        match p.txt with
+        | Term (Labelled _, _, _)
+        | Term (Optional _, _, _)  ->
+            raise Reason_syntax_util.(
+              Error(p.loc, (Syntax_error "Uncurried function definition with labelled arguments is not supported at the moment."))
+            )
+        | _ -> ()
+      ) $3 in
+    ($3, true)
+  }
+;
+
+es6_parameters:
+  | labeled_pattern_list { $1 }
+  | as_loc(UNDERSCORE)
+    { ([{$1 with txt = Term (Nolabel, None, mkpat ~loc:$1.loc Ppat_any)}], false) }
+  | simple_pattern_ident
+    { ([Location.mkloc (Term (Nolabel, None, $1)) $1.ppat_loc], false) }
+;
+
+(* TODO: properly fix JSX labelled/optional stuff *)
+jsx_arguments:
+  (* empty *) { [] }
+  | LIDENT EQUAL QUESTION simple_expr jsx_arguments
+    { (* a=?b *)
+      [(Optional $1, $4)] @ $5
+    }
+  | QUESTION LIDENT jsx_arguments
+    { (* <Foo ?bar /> punning with explicitly passed optional *)
+      let loc_lident = mklocation $startpos($2) $endpos($2) in
+      [(Optional $2, mkexp (Pexp_ident {txt = Lident $2; loc = loc_lident}) ~loc:loc_lident)] @ $3
+    }
+  | LIDENT EQUAL simple_expr jsx_arguments
+    { (* a=b *)
+      [(Labelled $1, $3)] @ $4
+    }
+  | LIDENT jsx_arguments
+    { (* a (punning) *)
+      let loc_lident = mklocation $startpos($1) $endpos($1) in
+      [(Labelled $1, mkexp (Pexp_ident {txt = Lident $1; loc = loc_lident}) ~loc:loc_lident)] @ $2
+    }
+  | as_loc(INFIXOP3)
+    (* extra rule to provide nice error messages in the case someone
+     * wrote: <Description term=<Text text="Age" />> child </Description>
+     * or <Foo bar=<Baz />/>
+     *  />> & />/> are lexed as infix tokens *)
+  {
+    match $1.txt with
+    | "/>>" ->
+     let err = Reason_syntax_util.Syntax_error {|JSX in a JSX-argument needs to be wrapped in braces.
+    If you wrote:
+      <Description term=<Text text="Age" />> child </Description>
+    Try wrapping <Text /> in braces.
+      <Description term={<Text text="Age" />}> child </Description>|} in
+      raise (Reason_syntax_util.Error($1.loc, err))
+    | "/>/>" ->
+     let err = Reason_syntax_util.Syntax_error {|JSX in a JSX-argument needs to be wrapped in braces.
+    If you wrote:
+      <Description term=<Text text="Age" />/>
+    Try wrapping <Text /> in braces.
+      <Description term={<Text text="Age" />} />|} in
+      raise (Reason_syntax_util.Error($1.loc, err))
+    | _ -> syntax_error ()
+  }
+;
+
+jsx_start_tag_and_args:
+    as_loc(LESSIDENT) jsx_arguments
+    { let name = Longident.parse $1.txt in
+      (jsx_component {$1 with txt = name} $2, name)
+    }
+  | LESS as_loc(mod_ext_longident) jsx_arguments
+    { jsx_component $2 $3, $2.txt }
+;
+
+jsx_start_tag_and_args_without_leading_less:
+    as_loc(mod_ext_longident) jsx_arguments
+    { (jsx_component $1 $2, $1.txt) }
+  | as_loc(LIDENT) jsx_arguments
+    { let lident = Longident.Lident $1.txt in
+      (jsx_component {$1 with txt = lident } $2, lident)
+    }
+;
+
+greater_spread:
+  | GREATERDOTDOTDOT
+  | GREATER DOTDOTDOT { ">..." }
+
+jsx:
+  | LESSGREATER simple_expr_no_call* LESSSLASHGREATER
+    { let loc = mklocation $symbolstartpos $endpos in
+      let body = mktailexp_extension loc $2 None in
+      makeFrag loc body
+    }
+  | jsx_start_tag_and_args SLASHGREATER
+    { let (component, _) = $1 in
+      let loc = mklocation $symbolstartpos $endpos in
+      component [
+        (Labelled "children", mktailexp_extension loc [] None);
+        (Nolabel, mkexp_constructor_unit loc loc)
+      ] loc
+    }
+  | jsx_start_tag_and_args GREATER simple_expr_no_call* LESSSLASHIDENTGREATER
+    { let (component, start) = $1 in
+      let loc = mklocation $symbolstartpos $endpos in
+      (* TODO: Make this tag check simply a warning *)
+      let endName = Longident.parse $4 in
+      let _ = ensureTagsAreEqual start endName loc in
+      let siblings = if List.length $3 > 0 then $3 else [] in
+      component [
+        (Labelled "children", mktailexp_extension loc siblings None);
+        (Nolabel, mkexp_constructor_unit loc loc)
+      ] loc
+    }
+   | jsx_start_tag_and_args greater_spread simple_expr_no_call LESSSLASHIDENTGREATER
+     (* <Foo> ...bar </Foo> or <Foo> ...((a) => 1) </Foo> *)
+    { let (component, start) = $1 in
+      let loc = mklocation $symbolstartpos $endpos in
+      (* TODO: Make this tag check simply a warning *)
+      let endName = Longident.parse $4 in
+      let _ = ensureTagsAreEqual start endName loc in
+      let child = $3 in
+      component [
+        (Labelled "children", child);
+        (Nolabel, mkexp_constructor_unit loc loc)
+      ] loc
+    }
+;
+
+jsx_without_leading_less:
+  | GREATER simple_expr_no_call* LESSSLASHGREATER {
+    let loc = mklocation $symbolstartpos $endpos in
+    let body = mktailexp_extension loc $2 None in
+    makeFrag loc body
+  }
+  | jsx_start_tag_and_args_without_leading_less SLASHGREATER {
+    let (component, _) = $1 in
+    let loc = mklocation $symbolstartpos $endpos in
+    component [
+      (Labelled "children", mktailexp_extension loc [] None);
+      (Nolabel, mkexp_constructor_unit loc loc)
+    ] loc
+  }
+  | jsx_start_tag_and_args_without_leading_less GREATER simple_expr_no_call* LESSSLASHIDENTGREATER {
+    let (component, start) = $1 in
+    let loc = mklocation $symbolstartpos $endpos in
+    (* TODO: Make this tag check simply a warning *)
+    let endName = Longident.parse $4 in
+    let _ = ensureTagsAreEqual start endName loc in
+    let siblings = if List.length $3 > 0 then $3 else [] in
+    component [
+      (Labelled "children", mktailexp_extension loc siblings None);
+      (Nolabel, mkexp_constructor_unit loc loc)
+    ] loc
+  }
+    | jsx_start_tag_and_args_without_leading_less greater_spread simple_expr_no_call LESSSLASHIDENTGREATER {
+    let (component, start) = $1 in
+    let loc = mklocation $symbolstartpos $endpos in
+    (* TODO: Make this tag check simply a warning *)
+    let endName = Longident.parse $4 in
+    let _ = ensureTagsAreEqual start endName loc in
+    let child = $3 in
+    component [
+      (Labelled "children", child);
+      (Nolabel, mkexp_constructor_unit loc loc)
+    ] loc
+  }
+;
+
+optional_expr_extension:
+  | (* empty *) { fun exp -> exp }
+  | item_extension_sugar { fun exp -> expression_extension $1 exp  }
+;
+
+(*
+ * Parsing of expressions is quite involved as it depends on context.
+ * At the top-level of a structure, expressions can't have attributes
+ * (those are attached to the structure).
+ * In other places, attributes are allowed.
+ *
+ * The generic parts are represented by unattributed_expr_template(_).
+ * Then unattributed_expr represents the concrete unattributed expr
+ * while expr adds an attribute rule to unattributed_expr_template.
+ *)
+%inline unattributed_expr_template(E):
+mark_position_exp
+  ( simple_expr
+    { $1 }
+  | FUN optional_expr_extension fun_def(EQUALGREATER,non_arrowed_core_type)
+    { $2 $3 }
+  | ES6_FUN es6_parameters EQUALGREATER expr
+    { let (ps, uncurried) = $2 in
+      let exp = List.fold_right mkexp_fun ps $4 in
+      if uncurried then
+        let loc = mklocation $startpos $endpos in
+        {exp with pexp_attributes = (uncurry_payload loc)::exp.pexp_attributes}
+      else exp
+    }
+  | ES6_FUN es6_parameters COLON non_arrowed_core_type EQUALGREATER expr
+    { let (ps, uncurried) = $2 in
+    let exp = List.fold_right mkexp_fun ps
+        (ghexp_constraint (mklocation $startpos($4) $endpos) $6 (Some $4, None))  in
+    if uncurried then
+      let loc = mklocation $startpos $endpos in
+      {exp with pexp_attributes = (uncurry_payload loc)::exp.pexp_attributes}
+    else exp
+    }
+
+  (* List style rules like this often need a special precendence
+     such as below_BAR in order to let the entire list "build up"
+   *)
+  | FUN optional_expr_extension match_cases(expr) %prec below_BAR
+    { $2 (mkexp (Pexp_function $3)) }
+  | SWITCH optional_expr_extension simple_expr_no_constructor
+    LBRACE match_cases(seq_expr) RBRACE
+    { $2 (mkexp (Pexp_match ($3, $5))) }
+  | TRY optional_expr_extension simple_expr_no_constructor
+    LBRACE match_cases(seq_expr) RBRACE
+    { $2 (mkexp (Pexp_try ($3, $5))) }
+  | TRY optional_expr_extension simple_expr_no_constructor WITH error
+    { syntax_error_exp (mklocation $startpos($5) $endpos($5)) "Invalid try with"}
+  | IF optional_expr_extension parenthesized_expr
+       simple_expr ioption(preceded(ELSE,expr))
+    { $2 (mkexp (Pexp_ifthenelse($3, $4, $5))) }
+  | WHILE optional_expr_extension parenthesized_expr simple_expr
+    { $2 (mkexp (Pexp_while($3, $4))) }
+  | FOR optional_expr_extension LPAREN pattern IN expr direction_flag expr RPAREN
+    simple_expr
+    { $2 (mkexp (Pexp_for($4, $6, $8, $7, $10))) }
+  | LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN
+    { let loc_colon = mklocation $startpos($2) $endpos($2) in
+      let loc = mklocation $symbolstartpos $endpos in
+      mkexp_cons loc_colon (mkexp ~ghost:true ~loc (Pexp_tuple[$5;$7])) loc
+    }
+  | E as_loc(infix_operator) expr
+    { let op = match $2.txt with
+      | "->" -> {$2 with txt = "|."}
+      | _ -> $2
+      in mkinfix $1 op $3
+    }
+  | E as_loc(infix_operator) error
+    { expecting (with_txt $2 "expression after infix operator") }
+  | as_loc(subtractive) expr %prec prec_unary
+    { mkuminus $1 $2 }
+  | as_loc(additive) expr %prec prec_unary
+    { mkuplus $1 $2 }
+  | as_loc(BANG {"!"}) expr %prec prec_unary
+    { mkexp(Pexp_apply(mkoperator $1, [Nolabel,$2])) }
+  | simple_expr DOT as_loc(label_longident) EQUAL expr
+    { mkexp(Pexp_setfield($1, $3, $5)) }
+  | simple_expr LBRACKET expr RBRACKET EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Pexp_ident(array_function ~loc "Array" "set") in
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp,
+                       [Nolabel,$1; Nolabel,$3; Nolabel,$6]))
+    }
+  | simple_expr DOT LBRACKET expr RBRACKET EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Pexp_ident(array_function ~loc "String" "set") in
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp,
+                       [Nolabel,$1; Nolabel,$4; Nolabel,$7]))
+    }
+  | simple_expr bigarray_access EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      bigarray_set ~loc $1 $2 $4
+    }
+  | as_loc(label) EQUAL expr
+    { mkexp(Pexp_setinstvar($1, $3)) }
+  | ASSERT simple_expr
+    { mkexp (Pexp_assert $2) }
+  | LAZY simple_expr
+    { mkexp (Pexp_lazy $2) }
+  (*
+   * Ternary is just a shortcut for:
+   *
+   *     switch expression { | true => expr1 | false => expr2 }
+   *
+   * The COLON token priority is below QUESTION so that the following parses:
+   *
+   *    x ? y :
+   *    z ? q : r
+   *
+   *  As
+   *
+   *    x ? y :
+   *    (z ? q : r)
+   *
+   *  Instead of:
+   *
+   *    (x ? y :
+   *    z) ? q : r
+   *
+   * When a question mark is seen, *this* parsing rule has lower priority so
+   * that we, instead, shift the qusetion mark so that the *latter* ternary is
+   * recognized first on the top of the stack. (z ? q : r).
+   *)
+  | E QUESTION expr COLON expr
+    { (* Should use ghost expressions, but not sure how that would work with source maps *)
+      (* So ? will become true and : becomes false for now*)
+      let loc_question = mklocation $startpos($2) $endpos($2) in
+      let loc_colon = mklocation $startpos($4) $endpos($4) in
+      let fauxTruePat =
+        Pat.mk ~loc:loc_question (Ppat_construct({txt = Lident "true"; loc = loc_question}, None)) in
+      let fauxFalsePat =
+        Pat.mk ~loc:loc_colon (Ppat_construct({txt = Lident "false"; loc = loc_colon}, None)) in
+      let fauxMatchCaseTrue = Exp.case fauxTruePat $3 in
+      let fauxMatchCaseFalse = Exp.case fauxFalsePat $5 in
+      mkexp (Pexp_match ($1, [fauxMatchCaseTrue; fauxMatchCaseFalse]))
+    }
+  ) {$1};
+
+(*
+ * Much like how patterns are partitioned into pattern/simple_pattern,
+ * expressions are divided into expr/simple_expr.
+ * expr: contains function application, but simple_expr doesn't (unless it's
+ * wrapped in parens).
+ *)
+expr:
+  | unattributed_expr_template(expr) { $1 }
+  | mark_position_exp(
+      attribute expr { {$2 with pexp_attributes = $1 :: $2.pexp_attributes} }
+      %prec attribute_precedence
+    )
+    { $1 }
+;
+
+unattributed_expr:
+  unattributed_expr_template(unattributed_expr) { $1 };
+
+parenthesized_expr:
+  | braced_expr
+    { $1 }
+  | LPAREN DOT RPAREN
+    { let loc = mklocation $startpos $endpos in
+      mkexp_constructor_unit ~uncurried:true loc loc }
+  | LPAREN expr_list RPAREN
+    { may_tuple $startpos $endpos $2 }
+;
+
+%inline array_expr_list:
+  LBRACKETBAR
+  lseparated_list(COMMA, opt_spread(expr_optional_constraint))
+  COMMA?
+  BARRBRACKET
+  { let msg = "Arrays can't use the `...` spread currently. Please use `concat` or other Array helpers." in
+    filter_raise_spread_syntax msg $2
+  };
+
+%inline bigarray_access:
+  DOT LBRACE lseparated_nonempty_list(COMMA, expr) COMMA? RBRACE { $3 }
+
+(* The grammar of simple exprs changes slightly according to context:
+ * - in most cases, calls (like f(x)) are allowed
+ * - in some contexts, calls are forbidden
+ *   (most notably JSX lists and rhs of a SHARPOP extension).
+ *
+ * simple_expr_template contains the generic parts,
+ * simple_expr, simple_expr_no_call and simple_expr_no_constructor the specialized instances.
+ *)
+%inline simple_expr_template(E):
+  | as_loc(val_longident) { mkexp (Pexp_ident $1) }
+  | constant
+    { let attrs, cst = $1 in mkexp ~attrs (Pexp_constant cst) }
+  | jsx                   { $1 }
+  | simple_expr_direct_argument { $1 }
+  | array_expr_list
+    { mkexp (Pexp_array $1) }
+  (* Not sure why this couldn't have just been below_SHARP (Answer: Being
+   * explicit about needing to wait for "as") *)
+  | as_loc(constr_longident) %prec prec_constant_constructor
+    { mkexp (Pexp_construct ($1, None)) }
+  | name_tag %prec prec_constant_constructor
+    { mkexp (Pexp_variant ($1, None)) }
+  | LPAREN expr_list RPAREN
+    { may_tuple $startpos $endpos $2 }
+  | as_loc(LPAREN) expr_list as_loc(error)
+    { unclosed_exp (with_txt $1 "(") (with_txt $3 ")") }
+  | E as_loc(POSTFIXOP)
+    { mkexp(Pexp_apply(mkoperator $2, [Nolabel, $1])) }
+  | as_loc(mod_longident) DOT LPAREN expr_list RPAREN
+    { mkexp(Pexp_open(Fresh, $1, may_tuple $startpos($3) $endpos($5) $4)) }
+  | mod_longident DOT as_loc(LPAREN) expr_list as_loc(error)
+    { unclosed_exp (with_txt $3 "(") (with_txt $5 ")") }
+  | E DOT as_loc(label_longident)
+    { mkexp(Pexp_field($1, $3)) }
+  | as_loc(mod_longident) DOT LBRACE RBRACE
+    { let loc = mklocation $symbolstartpos $endpos in
+      let pat = mkpat (Ppat_var (mkloc "this" loc)) in
+      mkexp(Pexp_open (Fresh, $1,
+                       mkexp(Pexp_object(Cstr.mk pat []))))
+    }
+  | E LBRACKET expr RBRACKET
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Pexp_ident(array_function ~loc "Array" "get") in
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp, [Nolabel,$1; Nolabel,$3]))
+    }
+  | E as_loc(LBRACKET) expr as_loc(error)
+    { unclosed_exp (with_txt $2 "(") (with_txt $4 ")") }
+  | E DOT LBRACKET expr RBRACKET
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Pexp_ident(array_function ~loc "String" "get") in
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp, [Nolabel,$1; Nolabel,$4]))
+    }
+  | E DOT as_loc(LBRACKET) expr as_loc(error)
+    { unclosed_exp (with_txt $3 "[") (with_txt $5 "]") }
+  | E bigarray_access
+    { let loc = mklocation $symbolstartpos $endpos in
+      bigarray_get ~loc $1 $2 }
+  | as_loc(mod_longident) DOT LBRACE record_expr RBRACE
+    { let (exten, fields) = $4 in
+      let loc = mklocation $symbolstartpos $endpos in
+      let rec_exp = mkexp ~loc (Pexp_record (fields, exten)) in
+      mkexp(Pexp_open(Fresh, $1, rec_exp))
+    }
+  | mod_longident DOT as_loc(LBRACE) record_expr as_loc(error)
+    { unclosed_exp (with_txt $3 "{") (with_txt $5 "}") }
+  | as_loc(mod_longident) DOT LBRACE record_expr_with_string_keys RBRACE
+    { let (exten, fields) = $4 in
+      let loc = mklocation $symbolstartpos $endpos in
+      let rec_exp = mkexp ~loc (Pexp_extension (mkloc ("bs.obj") loc,
+             PStr [mkstrexp (mkexp ~loc (Pexp_record(fields, exten))) []]))
+      in
+      mkexp(Pexp_open(Fresh, $1, rec_exp))
+    }
+  | mod_longident DOT as_loc(LBRACE) record_expr_with_string_keys as_loc(error)
+    { unclosed_exp (with_txt $3 "{") (with_txt $5 "}") }
+  | as_loc(mod_longident) DOT LBRACKETBAR expr_list BARRBRACKET
+    { let loc = mklocation $symbolstartpos $endpos in
+      let rec_exp = Exp.mk ~loc ~attrs:[] (Pexp_array $4) in
+      mkexp(Pexp_open(Fresh, $1, rec_exp))
+    }
+  | mod_longident DOT as_loc(LBRACKETBAR) expr_list as_loc(error)
+    { unclosed_exp (with_txt $3 "[|") (with_txt $5 "|]") }
+  (* Parse Module.[<Component> <div/> </Component>] *)
+  | as_loc(mod_longident) DOT LBRACKETLESS jsx_without_leading_less RBRACKET
+    { let seq, ext_opt = [$4], None in
+      let loc = mklocation $startpos($4) $endpos($4) in
+      let list_exp = make_real_exp (mktailexp_extension loc seq ext_opt) in
+      let list_exp = { list_exp with pexp_loc = loc } in
+      mkexp (Pexp_open (Fresh, $1, list_exp))
+    }
+  | as_loc(mod_longident) DOT LBRACKET RBRACKET
+    { let loc = mklocation $startpos($3) $endpos($4) in
+      let list_exp = make_real_exp (mktailexp_extension loc [] None) in
+      let list_exp = { list_exp with pexp_loc = loc } in
+      mkexp (Pexp_open (Fresh, $1, list_exp))
+    }
+  | as_loc(mod_longident) DOT LBRACKET expr_comma_seq_extension RBRACKET
+    { let seq, ext_opt = $4 in
+      let loc = mklocation $startpos($4) $endpos($4) in
+      let list_exp = make_real_exp (mktailexp_extension loc seq ext_opt) in
+      let list_exp = { list_exp with pexp_loc = loc } in
+      mkexp (Pexp_open (Fresh, $1, list_exp))
+    }
+  | as_loc(PREFIXOP) E %prec below_DOT_AND_SHARP
+    { mkexp(Pexp_apply(mkoperator $1, [Nolabel, $2])) }
+  (**
+   * Must be below_DOT_AND_SHARP so that the parser waits for several dots for
+   * nested record access that the bang should apply to.
+   *
+   * !x.y.z should be parsed as !(((x).y).z)
+   *)
+  (*| as_loc(BANG {"!"}) E %prec below_DOT_AND_SHARP
+    { mkexp (Pexp_apply(mkoperator $1, [Nolabel,$2])) }*)
+  | NEW as_loc(class_longident)
+    { mkexp (Pexp_new $2) }
+  | as_loc(mod_longident) DOT LBRACELESS field_expr_list COMMA? GREATERRBRACE
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Exp.mk ~loc ~attrs:[] (Pexp_override $4) in
+      mkexp (Pexp_open(Fresh, $1, exp))
+    }
+  | mod_longident DOT as_loc(LBRACELESS) field_expr_list COMMA? as_loc(error)
+    { unclosed_exp (with_txt $3 "{<") (with_txt $6 ">}") }
+  | E SHARP label
+    { mkexp (Pexp_send($1, $3)) }
+  | E as_loc(SHARPOP) simple_expr_no_call
+    { mkinfixop $1 (mkoperator $2) $3 }
+  | E as_loc(SHARPEQUAL) simple_expr
+    { let op = { $2 with txt = "#=" } in
+      mkinfixop $1 (mkoperator op) $3 }
+  | E as_loc(MINUSGREATER) simple_expr_no_call
+    { mkinfixop $1 (mkoperator {$2 with txt = "|."}) $3 }
+  | as_loc(mod_longident) DOT LPAREN MODULE module_expr COLON package_type RPAREN
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkexp (Pexp_open(Fresh, $1,
+        mkexp ~loc (Pexp_constraint (mkexp ~ghost:true ~loc (Pexp_pack $5),
+                                     mktyp ~ghost:true ~loc (Ptyp_package $7)))))
+    }
+  | mod_longident DOT as_loc(LPAREN) MODULE module_expr COLON as_loc(error)
+    { unclosed_exp (with_txt $3 "(") (with_txt $7 ")")}
+  | extension
+    { mkexp (Pexp_extension $1) }
+;
+
+%inline simple_expr: simple_expr_call { mkexp_app_rev $startpos $endpos $1 };
+
+simple_expr_no_constructor:
+  mark_position_exp(simple_expr_template(simple_expr_no_constructor)) { $1 };
+
+simple_expr_template_constructor:
+  | as_loc(constr_longident)
+    mark_position_exp
+      ( non_labeled_argument_list   { mkexp (Pexp_tuple($1)) }
+      | simple_expr_direct_argument { $1 }
+      )
+    { mkExplicitArityTupleExp (Pexp_construct($1, Some $2))
+    }
+  | name_tag
+    mark_position_exp
+      ( non_labeled_argument_list
+        { (* only wrap in a tuple if there are more than one arguments *)
+          match $1 with
+          | [x] -> x
+          | l -> mkexp (Pexp_tuple(l))
+        }
+      | simple_expr_direct_argument { $1 }
+      )
+    { mkexp(Pexp_variant($1, Some $2)) }
+;
+
+simple_expr_no_call:
+  | mark_position_exp(simple_expr_template(simple_expr_no_call)) { $1 }
+  | simple_expr_template_constructor { $1 }
+;
+
+simple_expr_call:
+  | mark_position_exp(simple_expr_template(simple_expr)) { ($1, []) }
+  | simple_expr_call labeled_arguments
+    { let (body, args) = $1 in
+      (body, List.rev_append $2 args) }
+  | LBRACKET expr_comma_seq_extension RBRACKET
+    { let seq, ext_opt = $2 in
+      let loc = mklocation $startpos($2) $endpos($2) in
+      (make_real_exp (mktailexp_extension loc seq ext_opt), [])
+    }
+  | simple_expr_template_constructor { ($1, []) }
+;
+
+simple_expr_direct_argument:
+  (*
+     Because [< is a special token, the <ident and <> won't be picked up as separate
+     tokens, when a list begins witha JSX tag. So we special case it.
+     (todo: pick totally different syntax for polymorphic variance types to avoid
+     the issue alltogether.
+
+     first token
+     /\
+     [<ident    args />  , remainingitems ]
+     [<>                 , remainingitems ]
+   *)
+  | braced_expr { $1 }
+  | LBRACKETLESS jsx_without_leading_less COMMA expr_comma_seq_extension RBRACKET
+    { let entireLoc = mklocation $startpos($1) $endpos($4) in
+      let (seq, ext_opt) = $4 in
+      mktailexp_extension entireLoc ($2::seq) ext_opt
+    }
+  | LBRACKETLESS jsx_without_leading_less RBRACKET
+    { let entireLoc = mklocation $startpos($1) $endpos($3) in
+      mktailexp_extension entireLoc ($2::[]) None
+    }
+  | LBRACKETLESS jsx_without_leading_less COMMA RBRACKET
+    { let entireLoc = mklocation $startpos($1) $endpos($4) in
+      mktailexp_extension entireLoc [$2] None
+    }
+  | LBRACELESS field_expr_list COMMA? GREATERRBRACE
+    { mkexp (Pexp_override $2) }
+  | as_loc(LBRACELESS) field_expr_list COMMA? as_loc(error)
+    { unclosed_exp (with_txt $1 "{<") (with_txt $4 ">}" ) }
+  | LBRACELESS GREATERRBRACE
+    { mkexp (Pexp_override [])}
+  | LPAREN MODULE module_expr RPAREN
+    { mkexp (Pexp_pack $3) }
+  | LPAREN MODULE module_expr COLON package_type RPAREN
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkexp (Pexp_constraint (mkexp ~ghost:true ~loc (Pexp_pack $3),
+                              mktyp ~ghost:true ~loc (Ptyp_package $5)))
+    }
+  | as_loc(LPAREN) MODULE module_expr COLON as_loc(error)
+    { unclosed_exp (with_txt $1 "(") (with_txt $5 ")") }
+;
+
+%inline non_labelled_expr_comma_list:
+  lseparated_nonempty_list(COMMA, expr_optional_constraint) COMMA? { $1 };
+
+non_labeled_argument_list:
+  | parenthesized(non_labelled_expr_comma_list) { $1 }
+  | LPAREN RPAREN
+    { let loc = mklocation $startpos $endpos in
+      [mkexp_constructor_unit loc loc] }
+;
+
+%inline labelled_expr_comma_list:
+  lseparated_list(COMMA, uncurried_labeled_expr) COMMA? { $1 };
+
+labeled_arguments:
+  | mark_position_exp(simple_expr_direct_argument)
+    { [(Nolabel, $1)] }
+  | parenthesized(labelled_expr_comma_list)
+    { match $1 with
+      | [] -> let loc = mklocation $startpos $endpos in
+              [(Nolabel, mkexp_constructor_unit loc loc)]
+      | xs -> xs
+    }
+  | LPAREN DOT RPAREN
+    { let loc = mklocation $startpos $endpos in
+      [(Nolabel, mkexp_constructor_unit ~uncurried:true loc loc)]
+    }
+;
+
+labeled_expr_constraint:
+  | expr_optional_constraint { fun _punned -> $1 }
+  | type_constraint
+    { fun punned ->
+      let exp = mkexp (Pexp_ident punned) ~loc:punned.loc in
+      match $1 with
+      | typ ->
+        let loc = mklocation punned.loc.loc_start $endpos in
+        ghexp_constraint loc exp typ
+    }
+;
+
+%inline uncurried_labeled_expr:
+  | DOT? labeled_expr {
+    let uncurried = match $1 with | Some _ -> true | None -> false in
+    if uncurried then
+      let (lbl, argExpr) = $2 in
+      let loc = mklocation $startpos $endpos in
+      let up = uncurry_payload ~name:"uncurry" loc in
+      (lbl, {argExpr with pexp_attributes = up::argExpr.pexp_attributes})
+    else $2
+  }
+;
+
+longident_type_constraint:
+ | as_loc(val_longident) type_constraint?
+ { $1, $2 }
+
+labeled_expr:
+  | expr_optional_constraint { (Nolabel, $1) }
+  | TILDE as_loc(either(parenthesized(longident_type_constraint), longident_type_constraint))
+    { (* add(~a, ~b) -> parses ~a & ~b *)
+      let lident_loc, maybe_typ = $2.txt in
+      let exp = mkexp (Pexp_ident lident_loc) ~loc:lident_loc.loc in
+      let labeled_exp = match maybe_typ with
+      | None -> exp
+      | Some typ ->
+          ghexp_constraint $2.loc exp typ
+      in
+      (Labelled (Longident.last lident_loc.txt), labeled_exp)
+    }
+  | TILDE as_loc(val_longident) QUESTION
+    { (* foo(~a?)  -> parses ~a? *)
+      let exp = mkexp (Pexp_ident $2) ~loc:$2.loc in
+      (Optional (Longident.last $2.txt), exp)
+    }
+  | TILDE as_loc(LIDENT) EQUAL optional labeled_expr_constraint
+    { (* foo(~bar=?Some(1)) or add(~x=1, ~y=2) -> parses ~bar=?Some(1) & ~x=1 & ~y=1 *)
+      ($4 $2.txt, $5 { $2 with txt = Lident $2.txt })
+    }
+  | TILDE as_loc(LIDENT) EQUAL optional as_loc(UNDERSCORE)
+    { (* foo(~l =_) *)
+      let loc = $5.loc in
+      let exp = mkexp (Pexp_ident (mkloc (Lident "_") loc)) ~loc in
+      ($4 $2.txt, exp)
+    }
+  | as_loc(UNDERSCORE)
+    { (* foo(_) *)
+      let loc = $1.loc in
+      let exp = mkexp (Pexp_ident (mkloc (Lident "_") loc)) ~loc in
+      (Nolabel, exp)
+    }
+;
+
+%inline and_let_binding:
+  (* AND bindings don't accept a preceeding extension ID, but do accept
+   * preceeding attribute*. These preceeding attribute* will cause an
+   * error if this is an *expression * let binding. Otherwise, they become
+   * attribute* on the structure item for the "and" binding.
+   *)
+  item_attributes AND let_binding_body
+  { let pat, expr = $3 in
+    Vb.mk ~loc:(mklocation $symbolstartpos $endpos) ~attrs:$1 pat expr }
+;
+
+let_bindings: let_binding and_let_binding* { addlbs $1 $2 };
+
+let_binding:
+  (* Form with item extension sugar *)
+  item_attributes LET item_extension_sugar? rec_flag let_binding_body
+  { let loc = mklocation $symbolstartpos $endpos in
+    let pat, expr = $5 in
+    mklbs $3 $4 (Vb.mk ~loc ~attrs:$1 pat expr) loc }
+;
+
+let_binding_body:
+  | simple_pattern_ident type_constraint EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      ($1, ghexp_constraint loc $4 $2) }
+  | simple_pattern_ident fun_def(EQUAL,core_type)
+    { ($1, $2) }
+  | simple_pattern_ident COLON preceded(QUOTE,ident)+ DOT core_type
+      EQUAL mark_position_exp(expr)
+    { let typ = mktyp ~ghost:true (Ptyp_poly($3, $5)) in
+      let loc = mklocation $symbolstartpos $endpos in
+      (mkpat ~ghost:true ~loc (Ppat_constraint($1, typ)), $7)
+    }
+  | simple_pattern_ident COLON TYPE LIDENT+ DOT core_type
+      EQUAL mark_position_exp(expr)
+  (* Because core_type will appear to contain "type constructors" since the
+   * type variables listed in LIDENT+ don't have leading single quotes, we
+   * have to call [varify_constructors] (which is what [wrap_type_annotation]
+   * does among other things) to turn those "type constructors" that correspond
+   * to LIDENT+ into regular type variables. I don't think this should be
+   * done in the parser!
+   *)
+  (* In general, this is a very strange transformation that occurs in the
+   * standard OCaml parser, but producing the same strange transformation, and
+   * being able to recover original code from the result has the benefit that
+   * this syntax will integrate seamlessly with ASTs produced by the standard
+   * OCaml parser.
+   *
+   *  let s : type a . core_type = body
+   *
+   *  LET_BINDING:
+   *  Ppat_constraint(Ppat_var s, Ptyp_poly(newtypes, varified_core_type))
+   *  Pexp_newtype..(a, Pexp_constraint(body, NOT_varified_core_type))
+   *
+   *  When [a] is in the first arg to [PTyp_poly] the second arg [core_type]
+   *  expects to see [a] and ['a] is not allowed anywhere.
+   *  When pretty printing, we must reverse this entire process!
+   *
+   *  All of this is consistent with the Manual which states:
+   *
+   *    let rec f : type t1 t2. t1 * t2 list -> t1 = ...
+   *
+   *  is automatically expanded into
+   *
+   *    let rec f : 't1 't2. 't1 * 't2 list -> 't1 =
+   *      fun (type t1) (type t2) -> (... : t1 * t2 list -> t1)
+   *
+   * So therefore we end up generating the following two forms of parse trees
+   * for the two primary forms of explicitly polymorphic type annotations:
+   *
+   *
+   *           /-----------Ppat_constraint--------\ /-PExp_constraint--\
+   *       let x: locallyAbstractTypes . typeVars       =      exp
+   *
+   *     or
+   *           /-------------Ppat_constraint-----------\     /----PExp_constraint------\
+   *       let x: type abstractTypes . varified_core_type = (exp : core_type_non_varified)
+   *       where carified_core_type must equal (varify_constructors core_type_non_varified)
+   *
+   *     And in the later case
+   *
+   *)
+   { let exp, poly = wrap_type_annotation $4 $6 $8 in
+     let loc = mklocation $symbolstartpos $endpos in
+     (mkpat ~ghost:true ~loc (Ppat_constraint($1, poly)), exp)
+   }
+
+  (* The combination of the following two rules encompass every type of
+   * pattern *except* val_identifier. The fact that we want handle the
+   * val_ident separately as a separate rule in let_binding_body alone justifies the
+   * need for the strange structuring of
+   * [pattern]/[simple_pattern_not_ident]/[simple_pattern] - it allows us
+   * to isolate [val_ident] in the special case of [let_binding_body].
+   *
+   * TODO:
+   * Unfortunately, it means we cannot do: let (myCurriedFunc: int -> int) a -> a;
+   *)
+  | pattern EQUAL expr
+    { ($1, $3) }
+  | simple_pattern_not_ident COLON core_type EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      (mkpat ~loc (Ppat_constraint($1, $3)), $5)
+    }
+;
+
+(*
+ * TODO:
+ * In OCaml, the following function binding would be parsed by the function
+ * parsers but would return a non function. Coincidentally, everything just worked.
+ *   let x: int = 10;
+ * Since in Reason, function bindings always use arrows, it's wrong to rely
+ * on function parsers to return non function bindings:
+ *   let x: int -> 10;
+ *   let y (:returnType) -> 20;  (* wat *)
+ *)
+
+%inline match_cases(EXPR): lnonempty_list(match_case(EXPR)) { $1 };
+
+match_case(EXPR):
+  as_loc(BAR) pattern preceded(WHEN,expr)? EQUALGREATER EXPR
+  { let pat = {$2 with ppat_loc =
+      { $2.ppat_loc with
+        loc_start = $1.loc.loc_start
+      }
+    } in
+    Exp.case pat ?guard:$3 $5 }
+;
+
+fun_def(DELIM, typ):
+  labeled_pattern_list
+  preceded(COLON,typ)?
+  either(preceded(DELIM, expr), braced_expr)
+  { let loc = mklocation $startpos $endpos in
+    let (pl, uncurried) = $1 in
+    let exp = List.fold_right mkexp_fun pl
+        (match $2 with
+        | None -> $3
+        | Some ct -> Exp.constraint_ ~loc $3 ct)
+    in
+    if uncurried then
+      {exp with pexp_attributes = (uncurry_payload loc)::exp.pexp_attributes}
+    else exp
+  }
+;
+
+(* At least one comma delimited: Each item optionally annotated. *)
+expr_list:
+  lseparated_nonempty_list(COMMA, expr_optional_constraint) COMMA?
+  { $1 }
+;
+
+(* [x, y, z, ...n] --> ([x,y,z], Some n) *)
+expr_comma_seq_extension:
+  lseparated_nonempty_list(COMMA, opt_spread(expr_optional_constraint)) COMMA?
+  { match List.rev $1 with
+    (* Check if the last expr has been spread with `...` *)
+    | ((dotdotdot, e) as hd)::es ->
+      let (es, ext) = match dotdotdot with
+      | Some _ -> (es, Some e)
+      | None -> (hd::es, None)
+      in
+      let msg = "Lists can only have one `...` spread, at the end.
+Explanation: lists are singly-linked list, where a node contains a value and points to the next node. `[a, ...bc]` efficiently creates a new item and links `bc` as its next nodes. `[...bc, a]` would be expensive, as it'd need to traverse `bc` and prepend each item to `a` one by one. We therefore disallow such syntax sugar.
+Solution: directly use `concat` or other List helpers." in
+      let exprList = filter_raise_spread_syntax msg es in
+      (List.rev exprList, ext)
+    | [] -> [], None
+  }
+;
+
+(**
+ * See note about tuple patterns. There are few cases where expressions may be
+ * type constrained without requiring additional parens, and inside of tuples
+ * are one exception.
+ *)
+expr_optional_constraint:
+  | expr { $1 }
+  | expr type_constraint
+    { ghexp_constraint (mklocation $symbolstartpos $endpos) $1 $2 }
+;
+
+record_expr:
+  | DOTDOTDOT expr_optional_constraint lnonempty_list(preceded(COMMA,
+    opt_spread(lbl_expr))) COMMA?
+    { let exprList = filter_raise_spread_syntax record_exp_spread_msg $3
+      in (Some $2, exprList)
+    }
+  | DOTDOTDOT
+    expr_optional_constraint SEMI
+    lseparated_nonempty_list(COMMA, opt_spread(lbl_expr)) COMMA?
+    { let loc = mklocation $startpos($3) $endpos($3) in
+      raise_record_trailing_semi_error loc
+    }
+  | DOTDOTDOT
+    expr_optional_constraint
+    lnonempty_list(preceded(COMMA, opt_spread(lbl_expr))) SEMI
+    { let loc = mklocation $startpos($4) $endpos($4) in
+      raise_record_trailing_semi_error loc
+    }
+  | non_punned_lbl_expr COMMA?
+    { (None, [$1]) }
+  | non_punned_lbl_expr SEMI
+    { let loc = mklocation $startpos($2) $endpos($2) in
+      raise_record_trailing_semi_error loc }
+  | lbl_expr lnonempty_list(preceded(COMMA, opt_spread(lbl_expr))) COMMA?
+    { let exprList = filter_raise_spread_syntax record_exp_spread_msg $2 in
+      (None, $1 :: exprList) }
+  | lbl_expr lnonempty_list(preceded(COMMA, opt_spread(lbl_expr))) SEMI
+    { let loc = mklocation $startpos($3) $endpos($3) in
+      raise_record_trailing_semi_error loc }
+;
+
+%inline non_punned_lbl_expr:
+  | as_loc(label_longident) COLON expr { ($1, $3) }
+;
+
+%inline punned_lbl_expr:
+  | as_loc(label_longident) { ($1, exp_of_label $1) }
+;
+
+%inline lbl_expr:
+  | non_punned_lbl_expr {$1}
+  | punned_lbl_expr {$1}
+;
+
+record_expr_with_string_keys:
+  | DOTDOTDOT expr_optional_constraint COMMA string_literal_exprs_maybe_punned
+    { (Some $2, $4) }
+  | STRING COLON expr COMMA?
+    { let loc = mklocation $symbolstartpos $endpos in
+      let (s, _, _) = $1 in
+      let lident_lident_loc = mkloc (Lident s) loc in
+      (None, [(lident_lident_loc, $3)])
+    }
+  | string_literal_expr_maybe_punned_with_comma string_literal_exprs_maybe_punned {
+    (None, $1 :: $2)
+  }
+;
+
+string_literal_exprs_maybe_punned:
+  lseparated_nonempty_list(COMMA, string_literal_expr_maybe_punned) COMMA? { $1 };
+
+(* Had to manually inline these two forms for some reason *)
+string_literal_expr_maybe_punned_with_comma:
+  | STRING COMMA
+  { let loc = mklocation $startpos $endpos in
+    let (s, _, _) = $1 in
+    let lident_lident_loc = mkloc (Lident s) loc in
+    let exp = mkexp ~loc (Pexp_ident lident_lident_loc) in
+    (lident_lident_loc, exp)
+  }
+  | STRING COLON expr COMMA
+  { let loc = mklocation $startpos $endpos in
+    let (s, _, _) = $1 in
+    let lident_lident_loc = mkloc (Lident s) loc in
+    let exp = $3 in
+    (lident_lident_loc, exp)
+  }
+;
+string_literal_expr_maybe_punned:
+  STRING preceded(COLON, expr)?
+  { let loc = mklocation $startpos $endpos in
+    let (s, _, _) = $1 in
+    let lident_lident_loc = mkloc (Lident s) loc in
+    let exp = match $2 with
+      | Some x -> x
+      | None -> mkexp ~loc (Pexp_ident lident_lident_loc)
+    in
+    (lident_lident_loc, exp)
+  }
+;
+
+(**
+ * field_expr is distinct from record_expr because labels cannot/shouldn't be scoped.
+ *)
+field_expr:
+  (* Using LIDENT instead of label here, because a reduce/reduce conflict occurs on:
+   *   {blah:x}
+   *
+   * After `blah`, the parser couldn't tell whether to reduce `label` or
+   * `val_ident`. So inlining the terminal here to avoid the whole decision.
+   * Another approach would have been to place the `label` rule at at a precedence
+   * of below_COLON or something.
+   *)
+ | as_loc(LIDENT) COLON expr
+   { ($1, $3) }
+ | LIDENT
+   { let loc = mklocation $symbolstartpos $endpos in
+     let lident_loc = mkloc $1 loc in
+     let lident_lident_loc = mkloc (Lident $1) loc in
+     (lident_loc, mkexp (Pexp_ident lident_lident_loc))
+   }
+;
+
+%inline field_expr_list: lseparated_nonempty_list(COMMA, field_expr) { $1 };
+
+(* Allows for Ptyp_package core types without parens in the context
+ * of a "type_constraint":
+ * let x: module Foo.Bar.Baz = (module FirstClass)
+ *        ^^^^^^^^^^^^^^^^^^
+ *)
+%inline module_constraint_type:
+  mark_position_typ
+  (MODULE package_type
+    { mktyp(Ptyp_package($2)) }
+  ) {$1}
+;
+
+type_constraint:
+  | COLON core_type
+      preceded(COLONGREATER,core_type)?
+    { (Some $2, $3) }
+  | COLONGREATER core_type
+    { (None, Some $2) }
+  | COLON module_constraint_type
+    { (Some $2, None) }
+;
+
+(* Patterns *)
+
+pattern:
+  | pattern_without_or { $1 }
+  | mark_position_pat(pattern BAR pattern { mkpat(Ppat_or($1, $3)) }) { $1 }
+;
+
+%inline pat_comma_list:
+  lseparated_nonempty_list(COMMA, pattern_optional_constraint) COMMA? { $1 };
+
+pattern_constructor_argument:
+  | simple_pattern_direct_argument
+    { [$1] }
+  | parenthesized(pat_comma_list)
+    { $1 }
+;
+
+(**
+* Provides sugar for pattern matching on a constructor pattern with a 'direct' argument.
+* Example:
+* | Foo () => () is sugar for | Foo(()) => ()
+* | Foo [a, b, c] => () is sugar for | Foo([a, b, c]) => ()
+* | Foo [|x, y|] => () is sugar for | Foo([|x, y|]) => ()
+* }
+*)
+simple_pattern_direct_argument:
+mark_position_pat (
+   as_loc(constr_longident)
+    { mkpat(Ppat_construct(mkloc $1.txt $1.loc, None)) }
+  | simple_delimited_pattern { $1 }
+  ) {$1}
+;
+
+pattern_without_or:
+mark_position_pat
+  ( simple_pattern { $1 }
+
+  | pattern_without_or AS as_loc(val_ident)
+    { mkpat(Ppat_alias($1, $3)) }
+
+  | pattern_without_or AS as_loc(error)
+    { expecting_pat (with_txt $3 "identifier") }
+  (**
+    * Parses a (comma-less) list of patterns into a tuple, or a single pattern
+    * (if there is only one item in the list). This is kind of sloppy as there
+    * should probably be a different AST construct for the syntax construct this
+    * is used in (multiple constructor arguments). The things passed to
+    * constructors are not actually tuples either in underlying representation or
+    * semantics (they are not first class).
+    *)
+  | as_loc(constr_longident) pattern_constructor_argument
+    (* the first case is `| Foo(_)` and doesn't need explicit_arity attached. Actually, something like `| Foo(1)` doesn't either, but we
+      keep explicit_arity on the latter anyways because why not. But for `| Foo(_)` in particular, it's convenient to have explicit_arity
+      removed, so that you can have the following shortcut:
+      | Foo _ _ _ _ _
+      vs.
+      | Foo _
+    *)
+    { match is_pattern_list_single_any $2 with
+      | Some singleAnyPat ->
+        mkpat (Ppat_construct($1, Some singleAnyPat))
+      | None ->
+        let loc = mklocation $symbolstartpos $endpos in
+        let argPattern = simple_pattern_list_to_tuple ~loc $2 in
+        mkExplicitArityTuplePat (Ppat_construct($1, Some argPattern))
+    }
+
+  | name_tag simple_pattern { mkpat (Ppat_variant($1, Some $2)) }
+
+  | pattern_without_or as_loc(COLONCOLON) pattern_without_or
+    { raiseSyntaxErrorFromSyntaxUtils $2.loc
+        ":: is not supported in Reason, please use [hd, ...tl] instead" }
+
+  | pattern_without_or COLONCOLON as_loc(error)
+    { expecting_pat (with_txt $3 "pattern") }
+
+  | LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkpat_cons (mkpat ~ghost:true ~loc (Ppat_tuple[$5;$7])) loc
+    }
+
+  | as_loc(LPAREN) COLONCOLON RPAREN LPAREN
+      pattern_without_or COMMA pattern_without_or as_loc(error)
+    { unclosed_pat (with_txt $1 "(") (with_txt $8 ")") }
+
+  | EXCEPTION pattern_without_or %prec prec_constr_appl
+    { mkpat(Ppat_exception $2) }
+
+  | LAZY simple_pattern { mkpat(Ppat_lazy $2) }
+
+  (**
+   * Attribute "attribute" everything to the left of the attribute,
+   * up until the point of to the start of an expression, left paren, left
+   * bracket, comma, bar - whichever comes first.
+   *)
+  | attribute pattern_without_or %prec attribute_precedence
+    { {$2 with ppat_attributes = $1 :: $2.ppat_attributes} }
+
+  ) {$1};
+
+(* A "simple pattern" is either a value identifier, or it is a
+ * simple *non*value identifier.
+ *
+ * A "pattern" (the more general) is the set of all simple patterns,
+ * but also with:
+ * - more information such as `as X`, `lazy` etc.
+ *
+ * "labeled_simple_pattern"s contain the set of all simple_patterns, but also
+ * include patterns suitable in function bindings where labeled arguments are
+ * accepted.
+ *
+ * But, in all patterns, it seems type constraints must be grouped within some
+ * parens or something.
+ *)
+simple_pattern:
+  | simple_pattern_ident
+  | simple_pattern_not_ident { $1 }
+;
+
+simple_pattern_ident:
+  as_loc(val_ident) { mkpat ~loc:$1.loc (Ppat_var $1) }
+;
+
+simple_pattern_not_ident:
+mark_position_pat
+  ( UNDERSCORE
+    { mkpat (Ppat_any) }
+  | signed_constant
+    { let attrs, cst = $1 in mkpat ~attrs (Ppat_constant cst) }
+  | signed_constant DOTDOT signed_constant
+    { mkpat (Ppat_interval (snd $1, snd $3)) }
+  | as_loc(constr_longident)
+    { mkpat (Ppat_construct ($1, None)) }
+  | name_tag
+    { mkpat (Ppat_variant ($1, None)) }
+  | SHARP type_longident
+    { mkpat (Ppat_type ($2)) }
+  | as_loc(LBRACKETBAR) pattern_comma_list SEMI? as_loc(error)
+    { unclosed_pat (with_txt $1 "[|") (with_txt $4 "|]") }
+  | LPAREN lseparated_nonempty_list(COMMA, pattern_optional_constraint) COMMA? RPAREN
+    { match $2 with
+      | [] -> (* This shouldn't be possible *)
+        let loc = mklocation $startpos $endpos in
+        mkpat_constructor_unit loc loc
+      | [hd] -> hd
+      | _ :: _ -> mkpat (Ppat_tuple $2)
+    }
+  | as_loc(LPAREN) pattern as_loc(error)
+    { unclosed_pat (with_txt $1 "(") (with_txt $3 ")") }
+  | as_loc(LPAREN) pattern COLON core_type as_loc(error)
+    { unclosed_pat (with_txt $1 "(") (with_txt $5 ")") }
+  | LPAREN pattern COLON as_loc(error)
+    { expecting_pat (with_txt $4 "type") }
+  | LPAREN MODULE as_loc(UIDENT) RPAREN
+    { mkpat(Ppat_unpack($3)) }
+  | simple_pattern_not_ident_
+    { $1 }
+  | extension
+    { mkpat(Ppat_extension $1) }
+  ) {$1};
+
+simple_pattern_not_ident_:
+  | simple_delimited_pattern
+    { $1 }
+  | as_loc(mod_longident) DOT simple_delimited_pattern
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkpat ~loc (Ppat_open ($1, $3))
+    }
+  | as_loc(mod_longident) DOT LPAREN pattern RPAREN
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkpat ~loc (Ppat_open ($1, $4)) }
+  | as_loc(mod_longident) DOT as_loc(LBRACKET RBRACKET {Lident "[]"})
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkpat ~loc (Ppat_open($1, mkpat ~loc:$3.loc (Ppat_construct($3, None)))) }
+  | as_loc(mod_longident) DOT as_loc(LPAREN RPAREN {Lident "()"})
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkpat ~loc (Ppat_open($1, mkpat ~loc:$3.loc (Ppat_construct($3, None)))) }
+
+%inline simple_delimited_pattern:
+  | record_pattern { $1 }
+  | list_pattern   { $1 }
+  | array_pattern  { $1 }
+
+%inline record_pattern:
+    LBRACE lbl_pattern_list RBRACE
+    { let (fields, closed) = $2 in mkpat (Ppat_record (fields, closed)) }
+  | as_loc(LBRACE) lbl_pattern_list as_loc(error)
+    { unclosed_pat (with_txt $1 "{") (with_txt $3 "}") }
+;
+
+%inline list_pattern:
+    LBRACKET pattern_comma_list_extension RBRACKET
+    { make_real_pat (mktailpat_extension (mklocation $startpos($2) $endpos($2)) $2) }
+  | as_loc(LBRACKET) pattern_comma_list_extension as_loc(error)
+    { unclosed_pat (with_txt $1 "[") (with_txt $3 "]") }
+;
+
+%inline array_pattern:
+    LBRACKETBAR loption(terminated(pattern_comma_list,COMMA?)) BARRBRACKET
+    { mkpat (Ppat_array $2) }
+;
+
+pattern_optional_constraint:
+mark_position_pat
+  ( pattern                 { $1 }
+  | pattern COLON core_type
+    { mkpat(Ppat_constraint($1, $3)) }
+  (* If we kill the `let module …` syntax, this can be placed inside pattern.
+   * Allows parsing of
+   *  let foo = (type a, module X: X_t with type t = a) => X.a;
+   *                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   * The `module` keyword after the colon is optional, because `module X`
+   * clearly indicates that we're dealing with a Ppat_unpack here.
+   *)
+  | MODULE as_loc(UIDENT) COLON MODULE? package_type
+    { mkpat(
+        Ppat_constraint(
+          mkpat(Ppat_unpack($2)),
+          let loc = match $4 with
+          | Some _ -> mklocation $startpos($4) $endpos($5)
+          | None -> mklocation $startpos($5) $endpos($5)
+          in
+          mktyp ~loc (Ptyp_package($5)))) }
+  ) {$1};
+;
+
+%inline pattern_comma_list:
+  lseparated_nonempty_list(COMMA, opt_spread(pattern))
+  { let msg = "Array's `...` spread is not supported in pattern matches.
+Explanation: such spread would create a subarray; out of performance concern, our pattern matching currently guarantees to never create new intermediate data.
+Solution: if it's to validate the first few elements, use a `when` clause + Array size check + `get` checks on the current pattern. If it's to obtain a subarray, use `Array.sub` or `Belt.Array.slice`." in
+    filter_raise_spread_syntax msg $1 };
+
+(* [x, y, z, ...n] --> ([x,y,z], Some n) *)
+pattern_comma_list_extension:
+  lseparated_nonempty_list(COMMA, opt_spread(pattern)) COMMA?
+  { match List.rev $1 with
+    (* spread syntax is only allowed at the end *)
+    | ((dotdotdot, p) as hd)::ps ->
+      let (ps, spreadPat) = match dotdotdot with
+      | Some _ -> (ps, Some p)
+      | None -> (hd::ps, None)
+      in
+      let msg = "List pattern matches only supports one `...` spread, at the end.
+Explanation: a list spread at the tail is efficient, but a spread in the middle would create new list(s); out of performance concern, our pattern matching currently guarantees to never create new intermediate data." in
+      let patList = filter_raise_spread_syntax msg ps in
+      (List.rev patList, spreadPat)
+    | [] -> [], None
+  };
+;
+
+_lbl_pattern_list:
+  | opt_spread(lbl_pattern)                            { ([$1], Closed) }
+  | opt_spread(lbl_pattern) COMMA                      { ([$1], Closed) }
+  | opt_spread(lbl_pattern) COMMA UNDERSCORE COMMA?    { ([$1], Open)   }
+  | opt_spread(lbl_pattern) COMMA _lbl_pattern_list
+    { let (fields, closed) = $3 in $1 :: fields, closed }
+;
+
+%inline lbl_pattern_list:
+  _lbl_pattern_list
+  { let (fields, closed) = $1 in
+    (filter_raise_spread_syntax record_pat_spread_msg fields, closed)
+  }
+;
+
+lbl_pattern:
+  | as_loc(label_longident) COLON pattern { ($1,$3) }
+  | as_loc(label_longident)               { ($1, pat_of_label $1) }
+  | as_loc(label_longident) AS as_loc(val_ident)
+    { (* punning with alias eg. {ReasonReact.state as prevState}
+       *  -> {ReasonReact.state: state as prevState} *)
+      ($1, mkpat(Ppat_alias(pat_of_label $1, $3)))
+    }
+;
+
+(* Primitive declarations *)
+
+primitive_declaration: nonempty_list(STRING { let (s, _, _) = $1 in s }) {$1};
+
+(* Type declarations
+
+   The rule for declaring multiple types, 'type t = ... and u = ...', is
+   written in a "continuation-passing-style". In pseudo-code:
+
+   Rather than having rules like:
+     (1) "TYPE one_type (AND one_type)*"
+
+   It looks like:
+     (2) "TYPE types" where "types = one_type (AND types)?".
+
+   This give more context to prevent ambiguities when parsing attributes.
+   Because attributes can appear before AND (1), the parser should
+   decide very early whether to reduce "one_type", so that an attribute can
+   get attached to AND.
+
+   Previously, only [@..] could occur inside "one_type" and only [@@...] before
+   AND.  Now we only have [@..].
+
+   With style (2), we can inline the relevant part of "one_type"
+   (see type_declaration_kind) to parse attributes as needed and take a
+   decision only when arriving at AND.
+*)
+
+type_declarations:
+  item_attributes TYPE nonrec_flag type_declaration_details
+  { let (ident, params, constraints, kind, priv, manifest), endpos, and_types = $4 in
+    let loc = mklocation $startpos($2) endpos in
+    let ty = Type.mk ident ~params:params ~cstrs:constraints
+             ~kind ~priv ?manifest ~attrs:$1 ~loc in
+    ($3, ty :: and_types)
+  }
+;
+
+and_type_declaration:
+  | { [] }
+  | item_attributes AND type_declaration_details
+    { let (ident, params, cstrs, kind, priv, manifest), endpos, and_types = $3 in
+      let loc = mklocation $symbolstartpos endpos in
+      Type.mk ident ~params ~cstrs ~kind ~priv ?manifest ~attrs:$1 ~loc
+      :: and_types
+    }
+;
+
+type_declaration_details:
+  | as_loc(UIDENT) type_variables_with_variance type_declaration_kind
+    { raiseSyntaxErrorFromSyntaxUtils $1.loc
+        "a type name must start with a lower-case letter or an underscore" }
+  | as_loc(LIDENT) type_variables_with_variance type_declaration_kind
+    { let (kind, priv, manifest), constraints, endpos, and_types = $3 in
+      (($1, $2, constraints, kind, priv, manifest), endpos, and_types) }
+;
+
+type_declaration_kind:
+  | EQUAL private_flag constructor_declarations
+    { let (cstrs, constraints, endpos, and_types) = $3 in
+      ((Ptype_variant (cstrs), $2, None), constraints, endpos, and_types) }
+  | EQUAL core_type EQUAL private_flag constructor_declarations
+    { let (cstrs, constraints, endpos, and_types) = $5 in
+      ((Ptype_variant cstrs, $4, Some $2), constraints, endpos, and_types) }
+  | type_other_kind constraints and_type_declaration
+    { ($1, $2, $endpos($2), $3) }
+;
+
+%inline constraints:
+  | { [] }
+  | preceded(CONSTRAINT, constrain)+ { $1 }
+;
+
+type_other_kind:
+  | (*empty*)
+    { (Ptype_abstract, Public, None) }
+  | EQUAL private_flag core_type
+    { (Ptype_abstract, $2, Some $3) }
+  | EQUAL private_flag item_attributes record_declaration
+    { (Ptype_record (prepend_attrs_to_labels $3 $4), $2, None) }
+  | EQUAL DOTDOT
+    { (Ptype_open, Public, None) }
+  | EQUAL core_type EQUAL DOTDOT
+    { (Ptype_open, Public, Some $2) }
+  | EQUAL core_type EQUAL private_flag item_attributes record_declaration
+    { (Ptype_record (prepend_attrs_to_labels $5 $6), $4, Some $2) }
+;
+
+type_variables_with_variance_comma_list:
+  lseparated_nonempty_list(COMMA, type_variable_with_variance) COMMA? {$1}
+;
+
+type_variables_with_variance:
+  loption(parenthesized(type_variables_with_variance_comma_list))
+  { $1 }
+;
+
+type_variable_with_variance:
+  embedded
+  ( QUOTE ident       { (mktyp (Ptyp_var $2) , Invariant    ) }
+  | UNDERSCORE        { (mktyp (Ptyp_any)    , Invariant    ) }
+  | PLUS QUOTE ident  { (mktyp (Ptyp_var $3) , Covariant    ) }
+  | PLUS UNDERSCORE   { (mktyp (Ptyp_any)    , Covariant    ) }
+  | MINUS QUOTE ident { (mktyp (Ptyp_var $3) , Contravariant) }
+  | MINUS UNDERSCORE  { (mktyp Ptyp_any      , Contravariant) }
+  )
+  { let first, second = $1 in
+    let ptyp_loc =
+        {first.ptyp_loc with loc_start = $symbolstartpos; loc_end = $endpos}
+    in
+    ({first with ptyp_loc}, second)
+  }
+;
+
+type_parameter: type_variance type_variable { ($2, $1) };
+
+type_variance:
+  | (* empty *) { Invariant }
+  | PLUS        { Covariant }
+  | MINUS       { Contravariant }
+;
+
+type_variable:
+mark_position_typ
+  (QUOTE ident { mktyp (Ptyp_var $2) })
+  { $1 };
+
+constructor_declarations:
+  either(constructor_declaration,bar_constructor_declaration)
+  constructor_declarations_aux
+  { let (cstrs, constraints, endpos, and_types) = $2 in
+    ($1 :: cstrs, constraints, endpos, and_types)
+  }
+;
+
+constructor_declarations_aux:
+  | bar_constructor_declaration constructor_declarations_aux
+    { let (cstrs, constraints, endpos, and_types) = $2 in
+      ($1 :: cstrs, constraints, endpos, and_types)
+    }
+  | constraints and_type_declaration
+    { ([], $1, $endpos($1), $2) }
+;
+
+bar_constructor_declaration:
+  item_attributes BAR constructor_declaration
+  { {$3 with pcd_attributes = $1 @ $3.pcd_attributes} }
+;
+
+constructor_declaration:
+  item_attributes as_loc(constr_ident) generalized_constructor_arguments
+  { let args, res = $3 in
+    let loc = mklocation $symbolstartpos $endpos in
+    Type.constructor ~attrs:$1 $2 ~args ?res ~loc }
+;
+
+(* Why are there already attribute* on the extension_constructor_declaration? *)
+str_exception_declaration:
+  item_attributes EXCEPTION
+    either(extension_constructor_declaration, extension_constructor_rebind)
+  { {$3 with pext_attributes = $3.pext_attributes @ $1} }
+;
+
+sig_exception_declaration:
+  item_attributes EXCEPTION
+    extension_constructor_declaration
+  { {$3 with pext_attributes = $3.pext_attributes @ $1} }
+;
+
+generalized_constructor_arguments:
+  constructor_arguments? preceded(COLON,core_type)?
+  { ((match $1 with None -> Pcstr_tuple [] | Some x -> x), $2) }
+;
+
+constructor_arguments_comma_list:
+  lseparated_nonempty_list(COMMA, core_type) COMMA? {$1}
+;
+
+constructor_arguments:
+  | object_record_type { Pcstr_tuple [$1] }
+  | record_declaration { Pcstr_record $1 }
+  | parenthesized(constructor_arguments_comma_list)
+    { Pcstr_tuple $1 }
+;
+
+record_label_declaration:
+  | item_attributes mutable_flag as_loc(LIDENT)
+    { let loc = mklocation $symbolstartpos $endpos in
+      Type.field $3 (mkct $3) ~attrs:$1 ~mut:$2 ~loc
+    }
+  | item_attributes mutable_flag as_loc(LIDENT) COLON poly_type
+    { let loc = mklocation $symbolstartpos $endpos in
+      Type.field $3 $5 ~attrs:$1 ~mut:$2 ~loc
+    }
+;
+
+record_declaration:
+  LBRACE lseparated_nonempty_list(COMMA, record_label_declaration) COMMA? RBRACE
+  { $2 }
+;
+
+
+(* Type Extensions *)
+
+str_type_extension:
+  attrs = item_attributes
+  TYPE flag = nonrec_flag
+    ident = as_loc(itype_longident)
+    params = type_variables_with_variance
+  PLUSEQ priv = embedded(private_flag)
+  constructors =
+    attributed_ext_constructors(either(extension_constructor_declaration, extension_constructor_rebind))
+  { if flag <> Recursive then
+      not_expecting $startpos(flag) $endpos(flag) "nonrec flag";
+    Te.mk ~params ~priv ~attrs ident constructors
+  }
+;
+
+sig_type_extension:
+  attrs = item_attributes
+  TYPE flag = nonrec_flag
+    ident = as_loc(itype_longident)
+    params = type_variables_with_variance
+  PLUSEQ priv = embedded(private_flag)
+  constructors =
+    attributed_ext_constructors(extension_constructor_declaration)
+  { if flag <> Recursive then
+      not_expecting $startpos(flag) $endpos(flag) "nonrec flag";
+    Te.mk ~params ~priv ~attrs ident constructors
+  }
+;
+
+%inline attributed_ext_constructor(X):
+  item_attributes BAR item_attributes X { {$4 with pext_attributes = List.concat [$1; $3; $4.pext_attributes]} }
+  (* Why is item_attributes duplicated?
+     To be consistent with attributes on (poly)variants/gadts.
+     So we can place the attribute after the BAR.
+     Example:
+      type water +=
+        pri
+        | [@foo] MineralWater;
+  *)
+;
+
+attributed_ext_constructors(X):
+  | X attributed_ext_constructor(X)* { $1 :: $2 }
+  | attributed_ext_constructor(X)+ { $1 }
+;
+
+extension_constructor_declaration:
+  as_loc(constr_ident) generalized_constructor_arguments
+  { let args, res = $2 in
+    let loc = mklocation $symbolstartpos $endpos in
+    Te.decl $1 ~args ?res ~loc
+  }
+;
+
+extension_constructor_rebind:
+  as_loc(constr_ident) EQUAL as_loc(constr_longident)
+  { let loc = mklocation $symbolstartpos $endpos in
+    Te.rebind $1 $3 ~loc
+  }
+;
+
+(* "with" constraints (additional type equations over signature components) *)
+
+with_constraint:
+  | TYPE as_loc(label_longident) type_variables_with_variance
+      EQUAL embedded(private_flag) core_type constraints
+    { let loc = mklocation $symbolstartpos $endpos in
+      let typ = Type.mk {$2 with txt=Longident.last $2.txt}
+                  ~params:$3 ~cstrs:$7 ~manifest:$6 ~priv:$5 ~loc in
+      Pwith_type ($2, typ)
+    }
+    (* used label_longident instead of type_longident to disallow
+       functor applications in type path *)
+  | TYPE as_loc(label_longident) type_variables_with_variance
+      COLONEQUAL core_type
+    { let last = match $2.txt with
+        | Lident s -> s
+        | _ -> not_expecting $startpos($2) $endpos($2) "Long type identifier"
+      in
+      let loc = mklocation $symbolstartpos $endpos in
+      Pwith_typesubst (Type.mk {$2 with txt=last} ~params:$3 ~manifest:$5 ~loc)
+    }
+  | MODULE as_loc(mod_longident) EQUAL as_loc(mod_ext_longident)
+      { Pwith_module ($2, $4) }
+  | MODULE as_loc(UIDENT) COLONEQUAL as_loc(mod_ext_longident)
+      { Pwith_modsubst ($2, $4) }
+;
+
+(* Polymorphic types *)
+poly_type:
+mark_position_typ
+  ( core_type
+    { $1 }
+  | preceded(QUOTE,ident)+ DOT core_type
+    { mktyp(Ptyp_poly($1, $3)) }
+  ) {$1};
+
+(**
+  * OCaml types before:
+  * -------------------
+  * core_type ::=
+  *   core_type2
+  *   core_type2 as ident
+  *
+  * core_type2 ::=
+  *   simple_core_type_or_tuple
+  *   ?ident: core_type2 -> core_type2
+  *   ?ident: core_type2 -> core_type2
+  *   ident: core_type2 -> core_type2
+  *   core_type2 -> core_type2
+  *
+  * simple_core_type_or_tuple ::=
+  *   simple_core_type
+  *   simple_core_type * simple_core_type_list   (*Reason deprecates this*)
+  *
+  * simple_core_type_list ::=                    (*Reason might be able to deprecate this*)
+  *   simple_core_type
+  *   simple_core_type_list STAR simple_core_type
+  *
+  * simple_core_type ::=
+  *   simple_core_type
+  *   simple_core_type2
+  *   ( core_type)      (*core_type_comma_list of len 1*)
+  *
+  * simple_core_type2 ::=
+  *  'ident
+  *  Long.ident
+  *  simple_core_type2 Long.ident
+  *  (core_type, core_type) Long.ident
+  *  <method1: ... method_2: ...>
+  *  <>
+  *  {method1: .. method2: ..}
+  *  # class_longident #
+  *  simple_core_type2 # class_longident
+  *  (core_type, core_type) # class_longident
+  *  (module package_type)
+  *  [%]
+  *  bunch of other stuff
+  *
+  * Reason types where tuples require grouping:
+  * -------------------
+  * Simple types are implicitly non-arrowed.
+  * Non arrowed types may be shown in the trailing positino of the curried sugar
+  * function/functor bindings, but it doesn't have to be simple.
+  *
+  * let x ... :non_arrowed_core_type => ..
+  *
+  * - A better name for core_type2 would be arrowed_core_type
+  * - A better name for core_type would be aliased_arrowed_core_type
+  * core_type ::=
+  *   core_type2
+  *   core_type2 as ident
+  *
+  * core_type2 ::=
+  *   non_arrowed_core_type
+  *   ident::? non_arrowed_core_type => non_arrowed_core_type
+  *   ident:: non_arrowed_core_type => non_arrowed_core_type
+  *   core_type2 => core_type2
+  *
+  * non_arrowed_core_type ::=
+  *    non_arrowed_non_simple_core_type
+  *    simple_core_type
+  *
+  * non_arrowed_non_simple_core_type ::=
+  *   type_longident non_arrowed_simple_core_type_list
+  *   # class_longident
+  *   simple_core_type # class_longident
+  *   [core_type_comma_list] # class_longident
+  *
+  * simple_core_type ::=
+  *   <>
+  *   ()
+  *   {}
+  *
+  *
+  *  'ident
+  *  Long.ident
+  *  simple_core_type Long.ident
+  *  Long.ident non_arrowed_simple_core_type_list
+  *  <method1: ... method_2: ...>
+  *  <>
+  *  {method1: .. method2: ..}
+  *  # class_longident #
+  *  simple_core_type # class_longident
+  *  (core_type, core_type) # class_longident
+  *  (module package_type)
+  *  [%]
+  *  bunch of other stuff
+  *)
+
+(** Potentially includes:
+ * - arrows
+ * - space separated type applications
+ * - "as" aliases
+ *)
+core_type:
+mark_position_typ
+  (* For some reason, when unifying Functor type syntax (using EQUALGREATER),
+   * there was a shift reduce conflict likely caused by
+   * type module MyFunctor = {type x = blah => foo } => SomeSig
+   * That should *not* be a shift reduce conflict (on =>), and it's not clear
+   * why the shift reduce conflict showed up in core_type2. Either way, this
+   * seems to resolve the issue. If removing the below_EQUALGREATER, the shift
+   * reduce conflict is actually caused by the new Functor type annotations
+   * even though *nothing* will point towards that.
+   * If switching to Menhir, this may not be needed.
+   *)
+  (
+    core_type2
+    { $1 }
+  | core_type2 AS QUOTE ident
+    { mktyp(Ptyp_alias($1, $4)) }
+  ) {$1};
+
+(**
+ *
+ * core_type is basically just core_type2 but with a single AS x potentially
+ * appended.
+ * core_type2 Potentially includes:
+ * - arrows
+ * - space separated type applications
+ * - Polymorphic type variable application
+ *)
+core_type2:
+  item_attributes ct = unattributed_core_type
+  { match $1 with
+    | [] -> ct
+    | attrs ->
+      let loc_start = $symbolstartpos and loc_end = $endpos in
+      let ptyp_loc = {ct.ptyp_loc with loc_start; loc_end} in
+      let ptyp_attributes = attrs @ ct.ptyp_attributes in
+      {ct with ptyp_attributes; ptyp_loc}
+  }
+;
+
+unattributed_core_type:
+  | non_arrowed_simple_core_type { $1 }
+  | arrowed_simple_core_type { $1 }
+;
+
+(* arrowed: because it contains =>
+ * simple: it doesn't need to be wrapped in parens *)
+arrowed_simple_core_type:
+  | ES6_FUN arrow_type_parameters EQUALGREATER core_type2
+    { List.fold_right mktyp_arrow $2 $4 }
+  | as_loc(labelled_arrow_type_parameter_optional) EQUALGREATER core_type2
+    { mktyp_arrow ($1, false) $3 }
+  | basic_core_type EQUALGREATER core_type2
+    { mktyp (Ptyp_arrow (Nolabel, $1, $3)) }
+;
+
+labelled_arrow_type_parameter_optional:
+  | TILDE LIDENT COLON protected_type EQUAL optional
+    { ($6 $2, $4) }
+;
+
+arrow_type_parameter:
+  | protected_type  { (Nolabel, $1) }
+  | TILDE LIDENT COLON protected_type
+    { (Labelled $2, $4) }
+  | labelled_arrow_type_parameter_optional { $1 }
+;
+
+%inline uncurried_arrow_type_parameter:
+    DOT? as_loc(arrow_type_parameter)
+  { let uncurried = match $1 with | Some _ -> true | None -> false in
+    match $2.txt with
+    | (Labelled _, _) when uncurried ->
+        raise Reason_syntax_util.(Error($2.loc, (Syntax_error "An uncurried function type with labelled arguments is not supported at the moment.")))
+    | _ -> ($2, uncurried)
+  }
+
+%inline arrow_type_parameter_comma_list:
+    | lseparated_nonempty_list(COMMA, uncurried_arrow_type_parameter) COMMA? {$1}
+
+arrow_type_parameters:
+ | LPAREN arrow_type_parameter_comma_list RPAREN { $2 }
+;
+
+(* Among other distinctions, "simple" core types can be used in Variant types:
+ * type myType = Count of anySimpleCoreType. Core types (and simple core types)
+ * don't include variant declarations (`constructor_declarations`) and don't
+ * include the "faux curried" variant Constructor arguments list.
+ *
+ * In general, "simple" syntax constructs, don't need to be wrapped in
+ * parens/braces when embedded in lists of those very constructs.
+ *
+ * A [simple_core_type] *can* be wrapped in parens, but
+ * it doesn't have to be.
+ *)
+
+(* The name [core_type] was taken. [non_arrowed_core_type] is the same as
+ * [simple_core_type] but used in cases
+ * where application needn't be wrapped in additional parens *)
+(* Typically, other syntax constructs choose to allow either
+ * [simple_core_type] or
+ * [non_arrowed_non_simple_core_type] depending on whether or not
+ * they are in a context that expects space separated lists of types to carry
+ * particular meaning outside of type constructor application.
+ *
+ * type x = SomeConstructor x y;
+ *)
+non_arrowed_core_type:
+  | non_arrowed_simple_core_type
+    { $1 }
+  | attribute non_arrowed_core_type
+    { {$2 with ptyp_attributes = $1 :: $2.ptyp_attributes} }
+;
+
+%inline type_parameter_comma_list:
+  | lseparated_nonempty_list(COMMA, protected_type) COMMA? {$1}
+;
+
+type_parameters:
+  | parenthesized(type_parameter_comma_list) { $1 }
+;
+
+(* "protected" stands for an environment where non-simple grammar
+ * is actually simple. non-simple => parens, simple => no-parens necessary
+ * For examples, in lists the ( and ) combined with , form a "protected"
+ * environment for non-simple types.
+ * in tuples: (int, string, float) ||-> int, string, float are protected
+ * in functions args: (int, string) => float ||-> int, string are protected *)
+protected_type:
+  | MODULE package_type {
+      let loc = mklocation $symbolstartpos $endpos in
+      { (mktyp(Ptyp_package $2)) with ptyp_loc = loc }
+    }
+  | core_type { $1 }
+;
+
+non_arrowed_simple_core_types:
+mark_position_typ
+  ( type_parameters
+    { match $1 with
+      | [one] -> one
+      | many -> mktyp (Ptyp_tuple many)
+    }
+  ) {$1};
+
+non_arrowed_simple_core_type:
+  | non_arrowed_simple_core_types       { $1 }
+  | mark_position_typ(basic_core_type) { $1 }
+;
+
+basic_core_type:
+mark_position_typ
+  ( type_longident type_parameters
+    { mktyp(Ptyp_constr($1, $2)) }
+  | SHARP as_loc(class_longident) type_parameters
+    { mktyp(Ptyp_class($2, $3)) }
+  | QUOTE ident
+    { mktyp(Ptyp_var $2) }
+  | SHARP as_loc(class_longident)
+    { mktyp(Ptyp_class($2, [])) }
+  | UNDERSCORE
+    { mktyp(Ptyp_any) }
+  | type_longident
+    { mktyp(Ptyp_constr($1, [])) }
+  | object_record_type
+    { $1 }
+  | LBRACKET row_field_list RBRACKET
+    { mktyp(Ptyp_variant ($2, Closed, None)) }
+  | LBRACKETGREATER loption(row_field_list) RBRACKET
+    { mktyp(Ptyp_variant ($2, Open, None)) }
+  | LBRACKETLESS row_field_list loption(preceded(GREATER, name_tag+)) RBRACKET
+    { mktyp(Ptyp_variant ($2, Closed, Some $3)) }
+  | extension
+    { mktyp(Ptyp_extension $1) }
+  ) {$1};
+
+object_record_type:
+  | LBRACE RBRACE
+    { syntax_error () }
+  | LBRACE DOT string_literal_labels RBRACE
+    { (* `{. "foo": bar}` -> `Js.t({. foo: bar})` *)
+      let loc = mklocation $symbolstartpos $endpos in
+      mkBsObjTypeSugar ~loc ~closed:Closed $3
+    }
+  | LBRACE DOTDOT string_literal_labels RBRACE
+    { (* `{.. "foo": bar}` -> `Js.t({.. foo: bar})` *)
+      let loc = mklocation $symbolstartpos $endpos in
+      mkBsObjTypeSugar ~loc ~closed:Open $3
+    }
+  | LBRACE DOT loption(object_label_declarations) RBRACE
+    { mktyp (Ptyp_object ($3, Closed)) }
+  | LBRACE DOTDOT loption(object_label_declarations) RBRACE
+    { mktyp (Ptyp_object ($3, Open)) }
+;
+
+object_label_declaration:
+  | item_attributes as_loc(LIDENT)
+    { ($2.txt, $1, mkct $2) }
+  | item_attributes LIDENT COLON poly_type
+    { ($2, $1, $4) }
+;
+
+object_label_declarations:
+  lseparated_nonempty_list(COMMA, object_label_declaration) COMMA? { $1 };
+
+string_literal_label:
+  item_attributes STRING COLON poly_type
+  { let (label, _raw, _delim) = $2 in (label, $1, $4) }
+;
+
+string_literal_labels:
+  lseparated_nonempty_list(COMMA, string_literal_label) COMMA? { $1 };
+
+package_type:
+  module_type { package_type_of_module_type $1 }
+;
+
+row_field_list:
+  | row_field bar_row_field* { $1 :: $2 }
+  | bar_row_field bar_row_field* { $1 :: $2 }
+;
+
+row_field:
+  | tag_field             { $1 }
+  | non_arrowed_core_type { Rinherit $1 }
+;
+
+bar_row_field:
+  item_attributes BAR row_field
+  { match $3 with
+    | Rtag (name, attrs, amp, typs) ->
+        Rtag (name, $1 @ attrs, amp, typs)
+    | Rinherit typ ->
+        Rinherit {typ with ptyp_attributes = $1 @ typ.ptyp_attributes}
+  }
+;
+
+tag_field:
+  | item_attributes name_tag
+      boption(AMPERSAND)
+      separated_nonempty_list(AMPERSAND, non_arrowed_simple_core_types)
+    { Rtag ($2, $1, $3, $4) }
+  | item_attributes name_tag
+    { Rtag ($2, $1, true, []) }
+;
+
+(* Constants *)
+
+constant:
+  | INT          { let (n, m) = $1 in ([], Pconst_integer (n, m)) }
+  | CHAR         { ([], Pconst_char $1) }
+  | FLOAT        { let (f, m) = $1 in ([], Pconst_float (f, m)) }
+  | STRING       {
+    let (s, raw, d) = $1 in
+    let attr = match raw with
+      | None -> []
+      | Some raw ->
+        let constant = Ast_helper.Exp.constant (Pconst_string (raw, None)) in
+        [Location.mknoloc "reason.raw_literal", PStr [mkstrexp constant []]]
+    in
+    (attr, Pconst_string (s, d))
+  }
+;
+
+signed_constant:
+  | constant     { $1 }
+  | MINUS INT    { let (n, m) = $2 in ([], Pconst_integer("-" ^ n, m)) }
+  | MINUS FLOAT  { let (f, m) = $2 in ([], Pconst_float("-" ^ f, m)) }
+  | PLUS INT     { let (n, m) = $2 in ([], Pconst_integer (n, m)) }
+  | PLUS FLOAT   { let (f, m) = $2 in ([], Pconst_float(f, m)) }
+;
+
+(* Identifiers and long identifiers *)
+
+ident: UIDENT | LIDENT { $1 };
+
+val_ident:
+  | LIDENT                 { $1 }
+  | LPAREN operator RPAREN { $2 }
+;
+
+%inline infix_operator:
+  | INFIXOP0          { $1 }
+  | INFIXOP1          { $1 }
+  | INFIXOP2          { $1 }
+  | INFIXOP3          { $1 }
+  (* SLASHGREATER is INFIXOP3 but we needed to call it out specially *)
+  | SLASHGREATER      { "/>" }
+  | INFIXOP4          { $1 }
+  | PLUS              { "+" }
+  | PLUSDOT           { "+." }
+  | MINUS             { "-" }
+  | MINUSDOT          { "-." }
+  | STAR              { "*" }
+  | LESS              { "<" }
+  | GREATER           { ">" }
+  | OR                { "or" }
+  | BARBAR            { "||" }
+  | AMPERSAND         { "&" }
+  | AMPERAMPER        { "&&" }
+  | COLONEQUAL        { ":=" }
+  | PLUSEQ            { "+=" }
+  | PERCENT           { "%" }
+  (* We don't need to (and don't want to) consider </> an infix operator for now
+     because our lexer requires that "</>" be expressed as "<\/>" because
+     every star and slash after the first character must be escaped.
+  *)
+  (* Also, we don't want to consider <> an infix operator because the Reason
+     operator swapping requires that we express that as != *)
+  | LESSDOTDOTGREATER { "<..>" }
+  | GREATER GREATER   { ">>" }
+  | GREATERDOTDOTDOT { ">..." }
+;
+
+operator:
+  | PREFIXOP          { $1 }
+  | POSTFIXOP         { $1 }
+  | BANG              { "!" }
+  | infix_operator    { $1 }
+;
+%inline constr_ident:
+  | UIDENT            { $1 }
+  | LBRACKET RBRACKET { "[]" }
+  | LPAREN RPAREN     { "()" }
+  | COLONCOLON        { "::" }
+(*  | LPAREN COLONCOLON RPAREN { "::" } *)
+  | FALSE             { "false" }
+  | TRUE              { "true" }
+;
+
+val_longident:
+  | val_ident                     { Lident $1 }
+  | mod_longident DOT val_ident   { Ldot($1, $3) }
+;
+
+constr_longident:
+  | mod_longident %prec below_DOT { $1 }
+  | LBRACKET RBRACKET             { Lident "[]" }
+  | LPAREN RPAREN                 { Lident "()" }
+  | FALSE                         { Lident "false" }
+  | TRUE                          { Lident "true" }
+;
+
+label_longident:
+  | LIDENT                        { Lident $1 }
+  | mod_longident DOT LIDENT      { Ldot($1, $3) }
+;
+
+type_longident: as_loc(itype_longident) { $1 };
+
+%inline itype_longident:
+  | LIDENT                        { Lident $1 }
+  | mod_ext_longident DOT LIDENT  { Ldot($1, $3) }
+;
+
+mod_longident:
+  | UIDENT                        { Lident $1 }
+  | mod_longident DOT UIDENT      { Ldot($1, $3) }
+;
+
+mod_ext_longident: imod_ext_longident { $1 }
+
+%inline imod_ext_longident:
+  | UIDENT                        { Lident $1 }
+  | mod_ext_longident DOT UIDENT  { Ldot($1, $3) }
+  | mod_ext_apply                 { $1 }
+;
+
+mod_ext_apply:
+  imod_ext_longident
+  parenthesized(lseparated_nonempty_list(COMMA, mod_ext_longident))
+  { if not !Clflags.applicative_functors then
+      raise Syntaxerr.(Error(Applicative_path(mklocation $startpos $endpos)));
+    List.fold_left (fun p1 p2 -> Lapply (p1, p2)) $1 $2
+  }
+;
+
+mty_longident:
+  | ident                        { Lident $1 }
+  | mod_ext_longident DOT ident  { Ldot($1, $3) }
+;
+
+clty_longident:
+  | LIDENT                       { Lident $1 }
+  | mod_ext_longident DOT LIDENT { Ldot($1, $3) }
+;
+
+class_longident:
+  | LIDENT                       { Lident $1 }
+  | mod_longident DOT LIDENT     { Ldot($1, $3) }
+;
+
+(* Toplevel directives *)
+
+toplevel_directive:
+  SHARP ident embedded
+          ( (* empty *)   { Pdir_none }
+          | STRING        { let (s, _, _) = $1 in Pdir_string s }
+          | INT           { let (n, m) = $1 in Pdir_int (n, m) }
+          | val_longident { Pdir_ident $1 }
+          | mod_longident { Pdir_ident $1 }
+          | FALSE         { Pdir_bool false }
+          | TRUE          { Pdir_bool true }
+          )
+  { Ptop_dir($2, $3) }
+;
+
+(* Miscellaneous *)
+
+opt_LET_MODULE: MODULE { () } | LET MODULE { () };
+
+%inline name_tag: BACKQUOTE ident { $2 };
+
+%inline label: LIDENT { $1 };
+
+rec_flag:
+  | (* empty *)   { Nonrecursive }
+  | REC           { Recursive }
+;
+
+nonrec_flag:
+  | (* empty *)   { Recursive }
+  | NONREC        { Nonrecursive }
+;
+
+direction_flag:
+  | TO            { Upto }
+  | DOWNTO        { Downto }
+;
+
+%inline private_flag:
+  | (* empty *)   { Public }
+  | PRI           { Private }
+;
+
+mutable_flag:
+  | (* empty *)   { Immutable }
+  | MUTABLE       { Mutable }
+;
+
+virtual_flag:
+  | (* empty *)   { Concrete }
+  | VIRTUAL       { Virtual }
+;
+
+mutable_or_virtual_flags:
+  | (* empty *)   { Immutable, Concrete }
+  | VIRTUAL mutable_flag { $2, Virtual }
+  | MUTABLE virtual_flag { Mutable, $2 }
+;
+
+override_flag:
+  | (* empty *)   { Fresh }
+  | BANG          { Override }
+;
+
+subtractive:
+  | MINUS         { "-"  }
+  | MINUSDOT      { "-." }
+;
+
+additive:
+  | PLUS          { "+"  }
+  | PLUSDOT       { "+." }
+;
+
+single_attr_id:
+  | LIDENT      { $1 }
+  | UIDENT      { $1 }
+  | AND         { "and" }
+  | AS          { "as" }
+  | ASSERT      { "assert" }
+  | BEGIN       { "begin" }
+  | CLASS       { "class" }
+  | CONSTRAINT  { "constraint" }
+  | DO          { "do" }
+  | DONE        { "done" }
+  | DOWNTO      { "downto" }
+  | ELSE        { "else" }
+  | END         { "end" }
+  | EXCEPTION   { "exception" }
+  | EXTERNAL    { "external" }
+  | FALSE       { "false" }
+  | FOR         { "for" }
+  | FUN         { "fun" }
+  | FUNCTION    { "function" }
+  | FUNCTOR     { "functor" }
+  | IF          { "if" }
+  | IN          { "in" }
+  | INCLUDE     { "include" }
+  | INHERIT     { "inherit" }
+  | INITIALIZER { "initializer" }
+  | LAZY        { "lazy" }
+  | LET         { "let" }
+  | SWITCH      { "switch" }
+  | MODULE      { "module" }
+  | MUTABLE     { "mutable" }
+  | NEW         { "new" }
+  | NONREC      { "nonrec" }
+  | OBJECT      { "object" }
+  | OF          { "of" }
+  | OPEN        { "open" }
+  | OR          { "or" }
+  | PRI         { "private" }
+  | REC         { "rec" }
+  | SIG         { "sig" }
+  | STRUCT      { "struct" }
+  | THEN        { "then" }
+  | TO          { "to" }
+  | TRUE        { "true" }
+  | TRY         { "try" }
+  | TYPE        { "type" }
+  | VAL         { "val" }
+  | VIRTUAL     { "virtual" }
+  | WHEN        { "when" }
+  | WHILE       { "while" }
+  | WITH        { "with" }
+(* mod/land/lor/lxor/lsl/lsr/asr are not supported for now *)
+;
+
+attr_id:
+  | as_loc(single_attr_id) { $1 }
+  | single_attr_id DOT attr_id { mkloc ($1 ^ "." ^ $3.txt) (mklocation $symbolstartpos $endpos) }
+;
+
+attribute:
+  | LBRACKETAT attr_id payload RBRACKET { ($2, $3) }
+  | DOCSTRING { doc_attr $1 (mklocation $symbolstartpos $endpos) }
+;
+
+(* Inlined to avoid having to deal with buggy $symbolstartpos *)
+%inline located_attributes: as_loc(attribute)+ { $1 }
+
+(* Inlined to avoid having to deal with buggy $symbolstartpos *)
+%inline item_attributes:
+  | { [] }
+  | located_attributes { List.map (fun x -> x.txt) $1 }
+;
+
+item_extension_sugar:
+  PERCENT attr_id { ([], $2) }
+;
+
+extension:
+  LBRACKETPERCENT attr_id payload RBRACKET { ($2, $3) }
+;
+
+item_extension:
+  LBRACKETPERCENTPERCENT attr_id payload RBRACKET { ($2, $3) }
+;
+
+payload:
+  | structure                       { PStr $1 }
+  | COLON signature                 { PSig $2 }
+  | COLON core_type                 { PTyp $2 }
+  | QUESTION pattern                { PPat ($2, None) }
+  | QUESTION pattern WHEN expr      { PPat ($2, Some $4) }
+
+  (* Allow parsing of [@test.call x => x]
+   * By putting this rule here, a reduce/reduce conflict can be avoided
+   * If we put the "simple_pattern_ident EQUALGREATER expr" inside the
+   * unattributed_expr_template, the following ambiguity pops up:
+   *  BAR pattern option(preceded(WHEN,expr)) EQUALGREATER expr
+   *        WHEN expr
+   *             simple_pattern_ident EQUALGREATER expr // lookahead token appears
+   *             val_ident .
+   *
+   *  BAR pattern option(preceded(WHEN,expr)) EQUALGREATER expr // lookahead token appears
+   *        WHEN expr // lookahead token is inherited
+   *             simple_expr_call // lookahead token is inherited
+   *             val_longident // lookahead token is inherited
+   *             val_ident .
+   *  Since where in a payload here, there's no ambiguity when putting
+   *  the es6-style function (single arg, no parens) at this level.
+   *)
+  | simple_pattern_ident EQUALGREATER expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      let expr = Exp.fun_ ~loc Nolabel None $1 $3 in
+      PStr([mkstrexp expr []])
+    }
+;
+
+optional:
+  | { fun x -> Labelled x }
+  | QUESTION { fun x -> Optional x }
+;
+
+%inline mark_position_mod(X): x = X
+  { {x with pmod_loc = {x.pmod_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_cty(X): x = X
+  { {x with pcty_loc = {x.pcty_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_ctf(X): x = X
+  { {x with pctf_loc = {x.pctf_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_exp(X): x = X
+  { {x with pexp_loc = {x.pexp_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_typ(X): x = X
+  { {x with ptyp_loc = {x.ptyp_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_mty(X): x = X
+  { {x with pmty_loc = {x.pmty_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_str(X): x = X
+  { {x with pstr_loc = {x.pstr_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_cl(X): x = X
+  { {x with pcl_loc = {x.pcl_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_cf(X): x = X
+   { {x with pcf_loc = {x.pcf_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_pat(X): x = X
+   { {x with ppat_loc = {x.ppat_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline as_loc(X): x = X
+  { mkloc x (mklocation $symbolstartpos $endpos) }
+;
+
+either(X,Y):
+  | X { $1 }
+  | Y { $1 }
+;
+
+%inline opt_spread(X):
+  | DOTDOTDOT? X
+    { let dotdotdot = match $1 with
+      | Some _ -> Some (mklocation $startpos($1) $endpos($2))
+      | None -> None
+      in
+      (dotdotdot, $2)
+    }
+  ;
+
+%inline lnonempty_list(X): X llist_aux(X) { $1 :: List.rev $2 };
+
+%inline llist(X): llist_aux(X) { List.rev $1 };
+
+llist_aux(X):
+  | (* empty *) { [] }
+  | llist_aux(X) X { $2 :: $1 }
+;
+
+%inline lseparated_list(sep, X):
+  | (* empty *) { [] }
+  | lseparated_nonempty_list(sep, X) { $1 };
+
+%inline lseparated_nonempty_list(sep, X):
+  lseparated_nonempty_list_aux(sep, X) { List.rev $1 };
+
+lseparated_nonempty_list_aux(sep, X):
+  | X { [$1] }
+  | lseparated_nonempty_list_aux(sep, X) sep X { $3 :: $1 }
+;
+
+%inline lseparated_two_or_more(sep, X):
+  X sep lseparated_nonempty_list(sep, X) { $1 :: $3 };
+
+%inline parenthesized(X): delimited(LPAREN, X, RPAREN) { $1 };
+
+%%

--- a/tools/liquidity/reason/reason_parser.mly-orig
+++ b/tools/liquidity/reason/reason_parser.mly-orig
@@ -1,0 +1,4976 @@
+(*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *  Forked from OCaml, which is provided under the license below:
+ *
+ *  Xavier Leroy, projet Cristal, INRIA Rocquencourt
+ *
+ *  Copyright © 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006 Inria
+ *
+ *  Permission is hereby granted, free of charge, to the Licensee obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense
+ *  under any license of the Licensee's choice, and/or sell copies of the
+ *  Software, subject to the following conditions:
+ *
+ *  1.	Redistributions of source code must retain the above copyright notice
+ *  and the following disclaimer.
+ *  2.	Redistributions in binary form must reproduce the above copyright
+ *  notice, the following disclaimer in the documentation and/or other
+ *  materials provided with the distribution.
+ *  3.	All advertising materials mentioning features or use of the Software
+ *  must display the following acknowledgement: This product includes all or
+ *  parts of the Caml system developed by Inria and its contributors.
+ *  4.	Other than specified in clause 3, neither the name of Inria nor the
+ *  names of its contributors may be used to endorse or promote products
+ *  derived from the Software without specific prior written permission.
+ *
+ *  Disclaimer
+ *
+ *  This software is provided by Inria and contributors “as is” and any express
+ *  or implied warranties, including, but not limited to, the implied
+ *  warranties of merchantability and fitness for a particular purpose are
+ *  disclaimed. in no event shall Inria or its contributors be liable for any
+ *  direct, indirect, incidental, special, exemplary, or consequential damages
+ *  (including, but not limited to, procurement of substitute goods or
+ *  services; loss of use, data, or profits; or business interruption) however
+ *  caused and on any theory of liability, whether in contract, strict
+ *  liability, or tort (including negligence or otherwise) arising in any way
+ *  out of the use of this software, even if advised of the possibility of such
+ *  damage.
+ *
+ *)
+
+(* The parser definition *)
+
+%{
+open Migrate_parsetree.OCaml_404.Ast
+open Reason_syntax_util
+open Location
+open Asttypes
+open Longident
+open Parsetree
+open Ast_helper
+open Ast_mapper
+open Reason_string
+
+(*
+   TODO:
+   - Remove all [open]s from the top of this file one by one and fix compilation
+   failures that ensue by specifying the appropriate long identifiers. That
+   will make the parser much easier to reason about.
+   - Go back to trunk, do the same (remove [open]s, and fully specify long
+   idents), to perform a clean diff.
+
+*)
+
+(**
+
+   location.ml:
+   ------------
+   let mkloc txt loc = { txt ; loc }
+   let rhs_loc n = {
+     loc_start = Parsing.rhs_start_pos n;
+     loc_end = Parsing.rhs_end_pos n;
+     loc_ghost = false;
+   }
+   let symbol_rloc () = {
+     loc_start = Parsing.symbol_start_pos ();
+     loc_end = Parsing.symbol_end_pos ();
+     loc_ghost = false;
+   }
+
+   let symbol_gloc () = {
+     loc_start = Parsing.symbol_start_pos ();
+     loc_end = Parsing.symbol_end_pos ();
+     loc_ghost = true;
+   }
+
+   ast_helper.ml:
+   ------------
+   module Typ = struct
+    val mk: ?loc:loc -> ?attrs:attrs -> core_type_desc -> core_type
+    let mk ?(loc = !default_loc) ?(attrs = []) d =
+       {ptyp_desc = d; ptyp_loc = loc; ptyp_attributes = attrs}
+     ..
+   end
+
+   parse_tree.mli
+   --------------
+   and core_type = {
+     ptyp_desc: core_type_desc;
+     ptyp_loc: Location.t;
+     ptyp_attributes: attributes; (* ... [@id1] [@id2] *)
+   }
+
+   and core_type_desc =
+     | Ptyp_any
+           (*  _ *)
+     | Ptyp_var of string
+           (* 'a *)
+     | Ptyp_arrow of label * core_type * core_type
+           (* T1 -> T2       (label = "")
+              ~l:T1 -> T2    (label = "l")
+              ?l:T1 -> T2    (label = "?l")
+            *)
+     | Ptyp_tuple of core_type list
+           (* T1 * ... * Tn   (n >= 2) *)
+
+   reason_parser.mly
+   ---------------
+   In general:
+
+                                          syntax variant          {pblah_desc: core_blah_desc
+                                                                   pblah_loc: {txt, loc}
+                                                                   pblah_attributes: ... }
+                                         /              \            /       \
+   val mkblah: ~loc -> ~attributes ->     core_blah_desc     ->      core_blah
+   let mkblah = Blah.mk
+
+*)
+
+let uncurry_payload ?(name="bs") loc = ({loc; txt = name}, PStr [])
+
+let dummy_loc () = {
+  loc_start = Lexing.dummy_pos;
+  loc_end = Lexing.dummy_pos;
+  loc_ghost = false;
+}
+
+let mklocation loc_start loc_end = {
+  loc_start = loc_start;
+  loc_end = loc_end;
+  loc_ghost = false;
+}
+
+let with_txt a txt = {
+    a with txt=txt;
+}
+
+let make_real_loc loc = {
+    loc with loc_ghost = false
+}
+
+let make_ghost_loc loc = {
+    loc with loc_ghost = true
+}
+
+let ghloc ?(loc=dummy_loc ()) d = { txt = d; loc = (make_ghost_loc loc) }
+
+(**
+  * turn an object into a real
+  *)
+let make_real_exp exp = {
+    exp with pexp_loc = make_real_loc exp.pexp_loc
+}
+let make_real_pat pat = {
+    pat with ppat_loc = make_real_loc pat.ppat_loc
+}
+(*
+ * change the location state to be a ghost location or real location
+ *)
+let set_loc_state is_ghost loc =
+    if is_ghost then make_ghost_loc loc else make_real_loc loc
+
+let mktyp ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Typ.mk ~loc d
+
+let mkpat ?(attrs=[]) ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Pat.mk ~loc ~attrs d
+
+let mkexp ?(attrs=[]) ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Exp.mk ~loc ~attrs d
+
+let mkmty ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Mty.mk ~loc d
+
+let mksig ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Sig.mk ~loc d
+
+let mkmod ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Mod.mk ~loc d
+
+let mkstr ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Str.mk ~loc d
+
+let mkclass ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Cl.mk ~loc d
+
+let mkcty ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Cty.mk ~loc d
+
+let mkctf ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Ctf.mk ~loc d
+
+let may_tuple startp endp = function
+  | []  -> assert false
+  | [x] -> {x with pexp_loc = mklocation startp endp}
+  | xs  -> mkexp ~loc:(mklocation startp endp) (Pexp_tuple xs)
+
+(**
+  Make a core_type from a as_loc(LIDENT).
+  Useful for record type punning.
+  type props = {width: int, height: int};
+  type state = {nbrOfClicks: int};
+  type component = {props, state};
+*)
+let mkct lbl =
+  let lident = Lident lbl.txt in
+  let ttype = Ptyp_constr({txt = lident; loc = lbl.loc}, []) in
+  {ptyp_desc = ttype; ptyp_loc = lbl.loc; ptyp_attributes = []}
+
+let mkcf ?(loc=dummy_loc()) ?(ghost=false) d =
+    let loc = set_loc_state ghost loc in
+    Cf.mk ~loc d
+
+let simple_ghost_text_attr ?(loc=dummy_loc ()) txt =
+  let loc = set_loc_state true loc in
+  [({txt; loc}, PStr [])]
+
+let mkExplicitArityTuplePat ?(loc=dummy_loc ()) pat =
+  (* Tell OCaml type system that what this tuple construction represents is
+     not actually a tuple, and should represent several constructor
+     arguments.  This allows the syntax the ability to distinguish between:
+
+     X (10, 20)  -- One argument constructor
+     X 10 20     -- Multi argument constructor
+  *)
+  mkpat
+    ~loc
+    ~attrs:(simple_ghost_text_attr ~loc "explicit_arity")
+    pat
+
+let mkExplicitArityTupleExp ?(loc=dummy_loc ()) exp_desc =
+  mkexp
+    ~loc
+    ~attrs:(simple_ghost_text_attr ~loc "explicit_arity")
+    exp_desc
+
+let is_pattern_list_single_any = function
+  | [{ppat_desc=Ppat_any; ppat_attributes=[]} as onlyItem] -> Some onlyItem
+  | _ -> None
+
+let mkoperator {Location. txt; loc} =
+  Exp.mk ~loc (Pexp_ident(mkloc (Lident txt) loc))
+
+(*
+  Ghost expressions and patterns:
+  expressions and patterns that do not appear explicitly in the
+  source file they have the loc_ghost flag set to true.
+  Then the profiler will not try to instrument them and the
+  -annot option will not try to display their type.
+
+  Every grammar rule that generates an element with a location must
+  make at most one non-ghost element, the topmost one.
+
+  How to tell whether your location must be ghost:
+  A location corresponds to a range of characters in the source file.
+  If the location contains a piece of code that is syntactically
+  valid (according to the documentation), and corresponds to the
+  AST node, then the location must be real; in all other cases,
+  it must be ghost.
+
+  jordwalke: Noticed that ghost expressions are often used when inserting
+   additional AST nodes from a parse rule. Either an extra wrapping one, or an
+   additional inner node. This is consistent with the above description, I
+   believe.
+*)
+
+
+let ghunit ?(loc=dummy_loc ()) () =
+  mkexp ~ghost:true ~loc (Pexp_construct (mknoloc (Lident "()"), None))
+
+let mkinfixop arg1 op arg2 =
+  mkexp(Pexp_apply(op, [Nolabel, arg1; Nolabel, arg2]))
+
+let mkinfix arg1 name arg2 =
+  mkinfixop arg1 (mkoperator name) arg2
+
+let neg_string f =
+  if String.length f > 0 && f.[0] = '-'
+  then String.sub f 1 (String.length f - 1)
+  else "-" ^ f
+
+let mkuminus name arg =
+  match name.txt, arg.pexp_desc with
+  | "-", Pexp_constant(Pconst_integer (n,m)) ->
+      mkexp(Pexp_constant(Pconst_integer(neg_string n,m)))
+  | ("-" | "-."), Pexp_constant(Pconst_float (f, m)) ->
+      mkexp(Pexp_constant(Pconst_float(neg_string f, m)))
+  | txt, _ ->
+      let name = {name with txt = "~" ^ txt} in
+      mkexp(Pexp_apply(mkoperator name, [Nolabel, arg]))
+
+let prepare_functor_arg = function
+  | Some name, mty -> (name, mty)
+  | None, (Some {pmty_loc} as mty) ->
+      (mkloc "_" (make_ghost_loc pmty_loc), mty)
+  | None, None -> assert false
+
+let mk_functor_mod args body =
+  let folder arg acc =
+    let name, mty = prepare_functor_arg arg.txt in
+    mkmod ~loc:arg.loc (Pmod_functor(name, mty, acc))
+  in
+  List.fold_right folder args body
+
+let mk_functor_mty args body =
+  let folder arg acc =
+    let name, mty = prepare_functor_arg arg.txt in
+    mkmty ~loc:arg.loc (Pmty_functor(name, mty, acc))
+  in
+  List.fold_right folder args body
+
+let mkuplus name arg =
+  match name.txt, arg.pexp_desc with
+  | "+", Pexp_constant(Pconst_integer _)
+  | ("+" | "+."), Pexp_constant(Pconst_float _) ->
+      mkexp arg.pexp_desc
+  | txt, _ ->
+      let name = {name with txt = "~" ^ txt} in
+      mkexp(Pexp_apply(mkoperator name, [Nolabel, arg]))
+
+let mkexp_cons consloc args loc =
+  mkexp ~loc (Pexp_construct(mkloc (Lident "::") consloc, Some args))
+
+let mkexp_constructor_unit ?(uncurried=false) consloc loc =
+  let attrs = if uncurried then [uncurry_payload ~name:"uncurry" loc] else [] in
+  mkexp ~attrs ~loc (Pexp_construct(mkloc (Lident "()") consloc, None))
+
+let ghexp_cons args loc =
+  mkexp ~ghost:true ~loc (Pexp_construct(mkloc (Lident "::") loc, Some args))
+
+let mkpat_cons args loc =
+  mkpat ~loc (Ppat_construct(mkloc (Lident "::") loc, Some args))
+
+let ghpat_cons args loc =
+  mkpat ~ghost:true ~loc (Ppat_construct(mkloc (Lident "::") loc, Some args))
+
+let mkpat_constructor_unit consloc loc =
+  mkpat ~loc (Ppat_construct(mkloc (Lident "()") consloc, None))
+
+let simple_pattern_list_to_tuple ?(loc=dummy_loc ()) = function
+  | [] -> assert false
+  | lst -> mkpat ~loc (Ppat_tuple lst)
+
+let mktailexp_extension loc seq ext_opt =
+  let rec handle_seq = function
+    | [] ->
+        let base_case = match ext_opt with
+          | Some ext ->
+            ext
+          | None ->
+            let loc = make_ghost_loc loc in
+            let nil = { txt = Lident "[]"; loc } in
+            Exp.mk ~loc (Pexp_construct (nil, None)) in
+        base_case
+    | e1 :: el ->
+        let exp_el = handle_seq el in
+        let loc = mklocation e1.pexp_loc.loc_start exp_el.pexp_loc.loc_end in
+        let arg = mkexp ~ghost:true ~loc (Pexp_tuple [e1; exp_el]) in
+        ghexp_cons arg loc
+  in
+  handle_seq seq
+
+let mktailpat_extension loc (seq, ext_opt) =
+  let rec handle_seq = function
+    [] ->
+      let base_case = match ext_opt with
+        | Some ext ->
+          ext
+        | None ->
+          let loc = make_ghost_loc loc in
+          let nil = { txt = Lident "[]"; loc } in
+          mkpat ~loc (Ppat_construct (nil, None)) in
+      base_case
+  | p1 :: pl ->
+      let pat_pl = handle_seq pl in
+      let loc = mklocation p1.ppat_loc.loc_start pat_pl.ppat_loc.loc_end in
+      let arg = mkpat ~ghost:true ~loc (Ppat_tuple [p1; pat_pl]) in
+      ghpat_cons arg loc in
+  handle_seq seq
+
+let makeFrag loc body =
+  let attribute = ({txt = "JSX"; loc = loc}, PStr []) in
+  { body with pexp_attributes = attribute :: body.pexp_attributes }
+
+
+(* Applies attributes to the structure item, not the expression itself. Makes
+ * structure item have same location as expression. *)
+
+let mkstrexp e attrs =
+  match e with
+  | ({pexp_desc = Pexp_apply (({pexp_attributes} as e1), args) } as eRewrite)
+      when let f = (List.filter (function
+        | ({txt = "bs"}, _) -> true
+          | _ -> false ) e.pexp_attributes)  in
+      List.length f > 0
+    ->
+      let appExprAttrs = List.filter (function
+          | ({txt = "bs"}, PStr []) -> false
+          | _ -> true ) pexp_attributes in
+      let strEvalAttrs = (uncurry_payload e1.pexp_loc)::(List.filter (function
+          | ({txt = "bs"}, PStr []) -> false
+          | _ -> true ) attrs) in
+      let e = {
+        eRewrite with
+        pexp_desc = (Pexp_apply(e1, args));
+        pexp_attributes = appExprAttrs
+      } in
+      { pstr_desc = Pstr_eval (e, strEvalAttrs); pstr_loc = e.pexp_loc }
+  | _ ->
+      { pstr_desc = Pstr_eval (e, attrs); pstr_loc = e.pexp_loc }
+
+let ghexp_constraint loc e (t1, t2) =
+  match t1, t2 with
+  | Some t, None -> mkexp ~ghost:true ~loc (Pexp_constraint(e, t))
+  | _, Some t -> mkexp ~ghost:true ~loc (Pexp_coerce(e, t1, t))
+  | None, None -> assert false
+
+let array_function ?(loc=dummy_loc()) str name =
+  ghloc ~loc (Ldot(Lident str, (if !Clflags.fast then "unsafe_" ^ name else name)))
+
+let err loc s =
+  raise Reason_syntax_util.(
+    Error(loc, (Syntax_error s))
+  )
+
+let syntax_error_str loc msg =
+  if !Reason_config.recoverable then
+    Str.mk ~loc:loc (Pstr_extension (Reason_syntax_util.syntax_error_extension_node loc msg, []))
+  else
+    raise(Syntaxerr.Error(Syntaxerr.Other loc))
+
+let syntax_error () =
+  raise Syntaxerr.Escape_error
+
+let syntax_error_exp loc msg =
+  if !Reason_config.recoverable then
+    Exp.mk ~loc (Pexp_extension (Reason_syntax_util.syntax_error_extension_node loc msg))
+  else
+    err loc msg
+
+let syntax_error_pat loc msg =
+  if !Reason_config.recoverable then
+    Pat.extension ~loc (Reason_syntax_util.syntax_error_extension_node loc msg)
+  else
+    err loc msg
+
+let syntax_error_mod loc msg =
+  if !Reason_config.recoverable then
+    Mty.extension ~loc (Reason_syntax_util.syntax_error_extension_node loc msg)
+  else
+    err loc msg
+
+let unclosed opening closing =
+  raise(Syntaxerr.Error(Syntaxerr.Unclosed(opening.loc, opening.txt,
+                                           closing.loc, closing.txt)))
+
+let unclosed_extension closing =
+  Reason_syntax_util.syntax_error_extension_node closing.loc ("Expecting \"" ^ closing.txt ^ "\"")
+
+let unclosed_mod opening closing =
+  if !Reason_config.recoverable then
+    mkmod(Pmod_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let unclosed_cl opening closing =
+  if !Reason_config.recoverable then
+    mkclass(Pcl_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let unclosed_mty opening closing =
+  if !Reason_config.recoverable then
+    mkmty(Pmty_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let unclosed_cty opening closing =
+  if !Reason_config.recoverable then
+    mkcty(Pcty_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let unclosed_exp opening closing =
+  if !Reason_config.recoverable then
+    mkexp(Pexp_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let unclosed_pat opening closing =
+  if !Reason_config.recoverable then
+    mkpat(Ppat_extension (unclosed_extension closing))
+  else
+    unclosed opening closing
+
+let expecting nonterm =
+    raise Syntaxerr.(Error(Expecting(nonterm.loc, nonterm.txt)))
+
+let expecting_pat nonterm =
+  if !Reason_config.recoverable then
+    mkpat(Ppat_extension (Reason_syntax_util.syntax_error_extension_node nonterm.loc ("Expecting " ^ nonterm.txt)))
+  else
+    expecting nonterm
+
+let not_expecting start_pos end_pos nonterm =
+    raise Syntaxerr.(Error(Not_expecting(mklocation start_pos end_pos, nonterm)))
+
+type labelled_parameter =
+  | Term of arg_label * expression option * pattern
+  | Type of string
+
+let mkexp_fun {Location.txt; loc} body =
+  let loc = mklocation loc.loc_start body.pexp_loc.loc_end in
+  match txt with
+  | Term (label, default_expr, pat) ->
+    Exp.fun_ ~loc label default_expr pat body
+  | Type str ->
+    Exp.newtype ~loc str body
+
+let mkclass_fun {Location. txt ; loc} body =
+  let loc = mklocation loc.loc_start body.pcl_loc.loc_end in
+  match txt with
+  | Term (label, default_expr, pat) ->
+    Cl.fun_ ~loc label default_expr pat body
+  | Type _ ->
+    let pat = syntax_error_pat loc "(type) not allowed in classes" in
+    Cl.fun_ ~loc Nolabel None pat body
+
+let mktyp_arrow ({Location.txt = (label, cod); loc}, uncurried) dom =
+  let loc = mklocation loc.loc_start dom.ptyp_loc.loc_end in
+  let typ = mktyp ~loc (Ptyp_arrow (label, cod, dom)) in
+  {typ with ptyp_attributes = (if uncurried then [uncurry_payload loc] else [])}
+
+let mkcty_arrow ({Location.txt = (label, cod); loc}, uncurried) dom =
+  let loc = mklocation loc.loc_start dom.pcty_loc.loc_end in
+  let ct = mkcty ~loc (Pcty_arrow (label, cod, dom)) in
+  {ct with pcty_attributes = (if uncurried then [uncurry_payload loc] else [])}
+
+(**
+  * process the occurrence of _ in the arguments of a function application
+  * replace _ with a new variable, currently __x, in the arguments
+  * return a wrapping function that wraps ((__x) => ...) around an expression
+  * e.g. foo(_, 3) becomes (__x) => foo(__x, 3)
+  *)
+let process_underscore_application args =
+  let exp_question = ref None in
+  let hidden_var = "__x" in
+  let check_arg ((lab, exp) as arg) = match exp.pexp_desc with
+    | Pexp_ident ({ txt = Lident "_"} as id) ->
+        let new_id = mkloc (Lident hidden_var) id.loc in
+        let new_exp = mkexp (Pexp_ident new_id) ~loc:exp.pexp_loc in
+        exp_question := Some new_exp;
+        (lab, new_exp)
+    | _ ->
+        arg in
+  let args = List.map check_arg args in
+  let wrap exp_apply = match !exp_question with
+    | Some {pexp_loc=loc} ->
+        let pattern = mkpat (Ppat_var (mkloc hidden_var loc)) ~loc in
+        begin match exp_apply.pexp_desc with
+        (* Transform pipe first with underscore application correct:
+         * 5->doStuff(3, _, 7);
+         * (5 |. doStuff)(3, _, 7)
+         * 5 |. (__x => doStuff(3, __x, 7))
+         *)
+        | Pexp_apply(
+          {pexp_desc= Pexp_apply(
+            {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})} as pipeExp,
+            [Nolabel, arg1; Nolabel, ({pexp_desc = Pexp_ident _} as arg2)]
+            (*         5                            doStuff                   *)
+          )},
+          args (* [3, __x, 7] *)
+          ) ->
+            (* build `doStuff(3, __x, 7)` *)
+            let innerApply = {arg2 with pexp_desc = Pexp_apply(arg2, args)} in
+            (* build `__x => doStuff(3, __x, 7)` *)
+            let innerFun =
+              mkexp (Pexp_fun (Nolabel, None, pattern, innerApply)) ~loc
+            in
+            (* build `5 |. (__x => doStuff(3, __x, 7))` *)
+            {exp_apply with pexp_desc =
+              Pexp_apply(pipeExp, [Nolabel, arg1; Nolabel, innerFun])
+            }
+        | _ ->
+          mkexp (Pexp_fun (Nolabel, None, pattern, exp_apply)) ~loc
+        end
+    | None ->
+        exp_apply in
+  (args, wrap)
+
+(**
+  * Joins a 'body' and it's 'args' to form a Pexp_apply.
+  * Example:
+  * 'add' (body) and '[1, 2]' (args) become a Pexp_apply representing 'add(1, 2)'
+  *
+  * Note that `add(. 1, 2)(. 3, 4)` & `add(. 1, 2, . 3, 4)` both
+  * give `[[@uncurry] 1, 2, [@uncurry] 3, 4]]` as args.
+  * The dot is parsed as [@uncurry] to distinguish between specific
+  * uncurrying and [@bs]. They can appear in the same arg:
+  * `add(. [@bs] 1)` is a perfectly valid, the dot indicates uncurrying
+  * for the whole application of 'add' and [@bs] sits on the `1`.
+  * Due to the dot of uncurried application possibly appearing in any
+  * position of the args, we need to post-process the args and split
+  * all args in groups that are uncurried (or not).
+  * add(. 1, . 2) should be parsed as (add(. 1))(. 2)
+  * The args can be splitted here in [1] & [2], based on those groups
+  * we can recursively build the correct nested Pexp_apply here.
+  *  -> Pexp_apply (Pexp_apply (add, 1), 2)   (* simplified ast *)
+  *)
+let mkexp_app_rev startp endp (body, args) =
+  let loc = mklocation startp endp in
+  if args = [] then {body with pexp_loc = loc}
+  else
+  (*
+   * Post process the arguments and transform [@uncurry] into [@bs].
+   * Returns a tuple with a boolean (was it uncurried?) and
+   * the posible rewritten arg.
+   *)
+  let rec process_args acc es =
+    match es with
+    | (lbl, e)::es ->
+        let attrs = e.pexp_attributes in
+        let hasUncurryAttr = ref false in
+        let newAttrs = List.filter (function
+          | ({txt = "uncurry"}, PStr []) ->
+              hasUncurryAttr := true;
+              false
+          | _ -> true) attrs
+        in
+        let uncurried = !hasUncurryAttr in
+        let newArg = (lbl, { e with pexp_attributes = newAttrs }) in
+        process_args ((uncurried, newArg)::acc) es
+    | [] -> acc
+    in
+    (*
+     * Groups all uncurried args falling under the same Pexp_apply
+     * Example:
+     *    add(. 2, 3, . 4, 5) or add(. 2, 3)(. 4, 5)  (equivalent)
+     * This results in two groups: (true, [2, 3]) & (true, [4, 5])
+     * Both groups have 'true' as their first tuple element, because
+     * they are uncurried.
+     * add(2, 3, . 4) results in the groups (false, [2, 3]) & (true, [4])
+     *)
+    let rec group grp acc = function
+    | (uncurried, arg)::xs ->
+        let (_u, grp) = grp in
+        if uncurried = true then begin
+          group (true, [arg]) ((_u, (List.rev grp))::acc) xs
+        end else begin
+          group (_u, (arg::grp)) acc xs
+        end
+    | [] ->
+        let (_u, grp) = grp in
+        List.rev ((_u, (List.rev grp))::acc)
+    in
+    (*
+     * Recursively transforms all groups into a (possibly uncurried)
+     * Pexp_apply
+     *
+     * Example:
+     *   Given the groups (true, [2, 3]) & (true, [4, 5]) and body 'add',
+     *   we get the two nested Pexp_apply associated with
+     *   (add(. 2, 3))(. 4, 5)
+     *)
+    let rec make_appl body = function
+      | args::xs ->
+          let (uncurried, args) = args in
+          let expr = if args = [] then body
+          else
+            let (args, wrap) = process_underscore_application args in
+            let args_loc = match args, List.rev args with
+              | ((_, s)::_), ((_, e)::_) -> mklocation s.pexp_loc.loc_start e.pexp_loc.loc_end
+              | _ -> assert false in
+            let expr = mkexp ~loc:args_loc (Pexp_apply (body, args)) in
+            let expr = if uncurried then {expr with pexp_attributes = [uncurry_payload loc]} else expr in
+            wrap expr
+          in
+            make_appl expr xs
+      | [] -> {body with pexp_loc = loc}
+    in
+    let processed_args = process_args [] args in
+    let groups = group (false, []) [] processed_args in
+    make_appl body groups
+
+let mkmod_app mexp marg =
+  mkmod ~loc:(mklocation mexp.pmod_loc.loc_start marg.pmod_loc.loc_end)
+    (Pmod_apply (mexp, marg))
+
+let bigarray_function ?(loc=dummy_loc()) str name =
+  ghloc ~loc (Ldot(Ldot(Lident "Bigarray", str), name))
+
+let bigarray_get ?(loc=dummy_loc()) arr arg =
+  let get = if !Clflags.fast then "unsafe_get" else "get" in
+  match arg with
+    [c1] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array1" get)),
+                       [Nolabel, arr; Nolabel, c1]))
+  | [c1;c2] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array2" get)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, c2]))
+  | [c1;c2;c3] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array3" get)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, c2; Nolabel, c3]))
+  | coords ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Genarray" "get")),
+                       [Nolabel, arr; Nolabel, mkexp ~ghost:true ~loc (Pexp_array coords)]))
+
+let bigarray_set ?(loc=dummy_loc()) arr arg newval =
+  let set = if !Clflags.fast then "unsafe_set" else "set" in
+  match arg with
+    [c1] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array1" set)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, newval]))
+  | [c1;c2] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array2" set)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, c2; Nolabel, newval]))
+  | [c1;c2;c3] ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Array3" set)),
+                       [Nolabel, arr; Nolabel, c1; Nolabel, c2; Nolabel, c3; Nolabel, newval]))
+  | coords ->
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc (Pexp_ident(bigarray_function ~loc "Genarray" "set")),
+                       [Nolabel, arr;
+                        Nolabel, mkexp ~ghost:true ~loc (Pexp_array coords);
+                        Nolabel, newval]))
+
+let exp_of_label label =
+  mkexp ~loc:label.loc (Pexp_ident {label with txt=Lident(Longident.last label.txt)})
+
+let pat_of_label label =
+  mkpat ~loc:label.loc (Ppat_var {label with txt=(Longident.last label.txt)})
+
+let check_variable vl loc v =
+  if List.mem v vl then
+    raise Syntaxerr.(Error(Variable_in_scope(loc,v)))
+
+let varify_constructors var_names t =
+  let rec loop t =
+    let desc =
+      match t.ptyp_desc with
+      | Ptyp_any -> Ptyp_any
+      | Ptyp_var x ->
+          check_variable var_names t.ptyp_loc x;
+          Ptyp_var x
+      | Ptyp_arrow (label,core_type,core_type') ->
+          Ptyp_arrow(label, loop core_type, loop core_type')
+      | Ptyp_tuple lst -> Ptyp_tuple (List.map loop lst)
+      | Ptyp_constr( { txt = Lident s }, []) when List.mem s var_names ->
+          Ptyp_var s
+      | Ptyp_constr(longident, lst) ->
+          Ptyp_constr(longident, List.map loop lst)
+      | Ptyp_object (lst, o) ->
+          Ptyp_object
+            (List.map (fun (s, attrs, t) -> (s, attrs, loop t)) lst, o)
+      | Ptyp_class (longident, lst) ->
+          Ptyp_class (longident, List.map loop lst)
+      | Ptyp_alias(core_type, string) ->
+          check_variable var_names t.ptyp_loc string;
+          Ptyp_alias(loop core_type, string)
+      | Ptyp_variant(row_field_list, flag, lbl_lst_option) ->
+          Ptyp_variant(List.map loop_row_field row_field_list,
+                       flag, lbl_lst_option)
+      | Ptyp_poly(string_lst, core_type) ->
+          List.iter (check_variable var_names t.ptyp_loc) string_lst;
+          Ptyp_poly(string_lst, loop core_type)
+      | Ptyp_package(longident,lst) ->
+          Ptyp_package(longident,List.map (fun (n,typ) -> (n,loop typ) ) lst)
+      | Ptyp_extension (s, arg) ->
+          Ptyp_extension (s, arg)
+    in
+    {t with ptyp_desc = desc}
+  and loop_row_field  =
+    function
+      | Rtag(label,attrs,flag,lst) ->
+          Rtag(label,attrs,flag,List.map loop lst)
+      | Rinherit t ->
+          Rinherit (loop t)
+  in
+  loop t
+
+let pexp_newtypes ?loc newtypes exp =
+  List.fold_right (fun newtype exp -> mkexp ?loc (Pexp_newtype (newtype, exp)))
+    newtypes exp
+
+(**
+  I believe that wrap_type_annotation will automatically generate the type
+  arguments (type a) (type b) based on what was listed before the dot in a
+  polymorphic type annotation that uses locally abstract types.
+ *)
+let wrap_type_annotation newtypes core_type body =
+  let exp = mkexp(Pexp_constraint(body,core_type)) in
+  let exp = pexp_newtypes newtypes exp in
+  let typ = mktyp ~ghost:true (Ptyp_poly(newtypes,varify_constructors newtypes core_type)) in
+  (exp, typ)
+
+
+let struct_item_extension (ext_attrs, ext_id) structure_items =
+  mkstr ~ghost:true (Pstr_extension ((ext_id, PStr structure_items), ext_attrs))
+
+let expression_extension ?loc (ext_attrs, ext_id) item_expr =
+  let extension = (ext_id, PStr [mkstrexp item_expr []]) in
+  let loc = match loc with
+    | Some loc -> loc
+    | None -> make_ghost_loc (dummy_loc ())
+  in
+  Exp.extension ~loc ~attrs:ext_attrs extension
+
+(* There's no more need for these functions - this was for the following:
+ *
+ *     fun % ext [@foo] arg => arg;
+ *
+ *   Becoming
+ *
+ *     [%ext  (fun arg => arg) [@foo]]
+ *
+ *   Which we no longer support.
+ *)
+(* Applies the attributes to the body, then wraps entire thing in an extension
+ * expression, whose payload consists of a single structure item that is body
+ *)
+(* let wrap_exp_attrs body (ext, attrs) = *)
+(*   (* todo: keep exact location for the entire attribute *) *)
+(*   let body = {body with pexp_attributes = attrs @ body.pexp_attributes} in *)
+(*   match ext with *)
+(*   | None -> body *)
+(*   | Some id -> mkexp ~ghost:true (Pexp_extension (id, PStr [mkstrexp body []])) *)
+
+(* Why not just mkexp with the right attributes in the first place? *)
+(* let mkexp_attrs d attrs = *)
+(*   wrap_exp_attrs (mkexp d) attrs *)
+
+let mkcf_attrs ?(loc=dummy_loc()) d attrs =
+  Cf.mk ~loc ~attrs d
+
+let mkctf_attrs d attrs =
+  Ctf.mk ~attrs d
+
+type let_bindings =
+  { lbs_bindings: Parsetree.value_binding list;
+    lbs_rec: rec_flag;
+    lbs_extension: (attributes * string Asttypes.loc) option;
+    lbs_loc: Location.t }
+
+let mklbs ext rf lb loc =
+  { lbs_bindings = [lb];
+    lbs_rec = rf;
+    lbs_extension = ext;
+    lbs_loc = loc; }
+
+let addlbs lbs lbs' =
+  { lbs with lbs_bindings = lbs.lbs_bindings @ lbs' }
+
+let val_of_let_bindings lbs =
+  let str = Str.value lbs.lbs_rec lbs.lbs_bindings in
+  match lbs.lbs_extension with
+  | None -> str
+  | Some ext -> struct_item_extension ext [str]
+
+let expr_of_let_bindings ~loc lbs body =
+    let item_expr = Exp.let_ ~loc lbs.lbs_rec lbs.lbs_bindings body in
+    match lbs.lbs_extension with
+    | None -> item_expr
+    | Some ext -> expression_extension ~loc:(make_ghost_loc loc) ext item_expr
+
+let class_of_let_bindings lbs body =
+  if lbs.lbs_extension <> None then
+    raise Syntaxerr.(Error(Not_expecting(lbs.lbs_loc, "extension")));
+  Cl.let_ lbs.lbs_rec lbs.lbs_bindings body
+
+(*
+ * arity_conflict_resolving_mapper is triggered when both "implicit_arity" "explicit_arity"
+ * are in the attribtues. In that case we have to remove "explicit_arity"
+ *
+ * However, if we simply remove explicit_arity, we would end up with a
+ * wrapping tuple which has only one component (inner tuple).
+ * This is against the invariance where tuples must have 2+ components.
+ * Therefore, in the case we have to remove explicit_arity, we also need to
+ * unwrap the tuple to expose the inner tuple directly.
+ *
+ *)
+let arity_conflict_resolving_mapper super =
+{ super with
+  expr = begin fun mapper expr ->
+    match expr with
+      | {pexp_desc=Pexp_construct(lid, args);
+         pexp_loc;
+         pexp_attributes} when attributes_conflicted "implicit_arity" "explicit_arity" pexp_attributes ->
+         let new_args =
+           match args with
+             | Some {pexp_desc = Pexp_tuple [sp]} -> Some sp
+             | _ -> args in
+         super.expr mapper
+         {pexp_desc=Pexp_construct(lid, new_args); pexp_loc; pexp_attributes=
+          normalized_attributes "explicit_arity" pexp_attributes}
+      | x -> super.expr mapper x
+  end;
+  pat = begin fun mapper pattern ->
+    match pattern with
+      | {ppat_desc=Ppat_construct(lid, args);
+         ppat_loc;
+         ppat_attributes} when attributes_conflicted "implicit_arity" "explicit_arity" ppat_attributes ->
+         let new_args =
+           match args with
+             | Some {ppat_desc = Ppat_tuple [sp]} -> Some sp
+             | _ -> args in
+         super.pat mapper
+         {ppat_desc=Ppat_construct(lid, new_args); ppat_loc; ppat_attributes=
+          normalized_attributes "explicit_arity" ppat_attributes}
+      | x -> super.pat mapper x
+  end;
+}
+
+let reason_mapper =
+  default_mapper
+  |> reason_to_ml_swap_operator_mapper
+  |> arity_conflict_resolving_mapper
+
+let rewriteFunctorApp module_name elt loc =
+  let rec applies = function
+    | Lident _ -> false
+    | Ldot (m, _) -> applies m
+    | Lapply (_, _) -> true in
+  let rec flattenModName = function
+    | Lident id -> id
+    | Ldot (m, id) -> flattenModName m ^ "." ^ id
+    | Lapply (m1, m2) -> flattenModName m1 ^ "(" ^ flattenModName m2 ^ ")" in
+  let rec mkModExp = function
+    | Lident id -> mkmod ~loc (Pmod_ident {txt=Lident id; loc})
+    | Ldot (m, id) -> mkmod ~loc (Pmod_ident {txt=Ldot (m, id); loc})
+    | Lapply (m1, m2) -> mkmod ~loc (Pmod_apply (mkModExp m1, mkModExp m2)) in
+  if applies module_name then
+    let flat = flattenModName module_name in
+    mkexp ~loc (Pexp_letmodule({txt=flat; loc},
+                         mkModExp module_name,
+                         mkexp(Pexp_ident {txt=Ldot (Lident flat, elt); loc})))
+  else
+    mkexp ~loc (Pexp_ident {txt=Ldot (module_name, elt); loc})
+
+let jsx_component module_name attrs children loc =
+  let rec getFirstPart = function
+    | Lident fp -> fp
+    | Ldot (fp, _) -> getFirstPart fp
+    | Lapply (fp, _) -> getFirstPart fp in
+  let firstPart = getFirstPart module_name.txt in
+  let element_fn = if String.get firstPart 0 != '_' && firstPart = String.capitalize_ascii firstPart then
+    (* firstPart will be non-empty so the 0th access is fine. Modules can't start with underscore *)
+    rewriteFunctorApp module_name.txt "createElement" module_name.loc
+  else
+    mkexp ~loc:module_name.loc (Pexp_ident(mkloc (Lident firstPart) module_name.loc))
+  in
+  let body = mkexp(Pexp_apply(element_fn, attrs @ children)) ~loc in
+  let attribute = ({txt = "JSX"; loc = loc}, PStr []) in
+  { body with pexp_attributes = attribute :: body.pexp_attributes }
+
+(* We might raise some custom error messages in this file.
+  Do _not_ directly raise a Location.Error. Our public interface guarantees that we only throw Syntaxerr or Reason_syntax_util.Error *)
+let raiseSyntaxErrorFromSyntaxUtils loc fmt =
+  Printf.ksprintf
+    (fun msg -> raise Reason_syntax_util.(Error(loc, (Syntax_error msg))))
+    fmt
+
+let rec ignoreLapply = function
+  | Lident id -> Lident id
+  | Ldot (lid, id) -> Ldot (ignoreLapply lid, id)
+  | Lapply (m1, _) -> ignoreLapply m1
+
+(* Like Longident.flatten, but ignores `Lapply`s. Useful because 1) we don't want to require `Lapply` in
+   closing tags, and 2) Longident.flatten doesn't support `Lapply`. *)
+let rec flattenWithoutLapply = function
+  | Lident id -> [id]
+  | Ldot (lid, id) -> flattenWithoutLapply lid @ [id]
+  | Lapply (m1, _) -> flattenWithoutLapply m1
+
+let ensureTagsAreEqual startTag endTag loc =
+  if ignoreLapply startTag <> endTag then
+     let startTag = (String.concat "" (flattenWithoutLapply startTag)) in
+     let endTag = (String.concat "" (flattenWithoutLapply endTag)) in
+     raiseSyntaxErrorFromSyntaxUtils loc
+      "Start tag <%s> does not match end tag </%s>" startTag endTag
+
+(* `{. "foo": bar}` -> `Js.t {. foo: bar}` and {.. "foo": bar} -> `Js.t {.. foo: bar} *)
+let mkBsObjTypeSugar ~loc ~closed rows =
+  let obj = mktyp ~loc (Ptyp_object (rows, closed)) in
+  let jsDotTCtor = { txt = Longident.Ldot (Longident.Lident "Js", "t"); loc } in
+  mktyp(Ptyp_constr(jsDotTCtor, [obj]))
+
+let doc_loc loc = {txt = "ocaml.doc"; loc = loc}
+
+let doc_attr text loc =
+  let open Parsetree in
+  let exp =
+    { pexp_desc = Pexp_constant (Pconst_string(text, None));
+      pexp_loc = loc;
+      pexp_attributes = []; }
+  in
+  let item =
+    { pstr_desc = Pstr_eval (exp, []); pstr_loc = exp.pexp_loc }
+  in
+    (doc_loc loc, PStr [item])
+
+let prepend_attrs_to_labels attrs = function
+  | [] -> [] (* not possible for valid inputs *)
+  | x :: xs -> {x with pld_attributes = attrs @ x.pld_attributes} :: xs
+
+let raise_record_trailing_semi_error loc =
+  let msg = "Record entries are separated by comma; we've found a semicolon instead." in
+  raise Reason_syntax_util.(Error(loc, (Syntax_error msg)))
+
+let record_exp_spread_msg =
+  "Records can only have one `...` spread, at the beginning.
+Explanation: since records have a known, fixed shape, a spread like `{a, ...b}` wouldn't make sense, as `b` would override every field of `a` anyway."
+
+let record_pat_spread_msg =
+  "Record's `...` spread is not supported in pattern matches.
+Explanation: you can't collect a subset of a record's field into its own record, since a record needs an explicit declaration and that subset wouldn't have one.
+Solution: you need to pull out each field you want explicitly."
+
+let lowercase_module_msg =
+  Printf.sprintf "Module names must start with an uppercase letter."
+
+(* Handles "over"-parsing of spread syntax with `opt_spread`.
+ * The grammar allows a spread operator at every position, when
+ * generating the parsetree we raise a helpful error message. *)
+let filter_raise_spread_syntax msg nodes =
+  List.map (fun (dotdotdot, node) ->
+    match dotdotdot with
+    | Some dotdotdotLoc ->
+        raise Reason_syntax_util.(Error(dotdotdotLoc, (Syntax_error msg)))
+    | None -> node
+    ) nodes
+
+(*
+ * See https://github.com/ocaml/ocaml/commit/e1e03820e5fea322aa3156721bc1cc0231668101
+ * Rely on the parsing rules for generic module types, and then
+ * extract a package type, enabling more explicit error messages
+ * *)
+let package_type_of_module_type pmty =
+  let map_cstr = function
+    | Pwith_type (lid, ptyp) ->
+        let loc = ptyp.ptype_loc in
+        if ptyp.ptype_params <> [] then
+          err loc "parametrized types are not supported";
+        if ptyp.ptype_cstrs <> [] then
+          err loc "constrained types are not supported";
+        if ptyp.ptype_private <> Public then
+          err loc "private types are not supported";
+
+        (* restrictions below are checked by the 'with_constraint' rule *)
+        assert (ptyp.ptype_kind = Ptype_abstract);
+        assert (ptyp.ptype_attributes = []);
+        let ty =
+          match ptyp.ptype_manifest with
+          | Some ty -> ty
+          | None -> assert false
+        in
+        (lid, ty)
+    | _ ->
+        err pmty.pmty_loc "only 'with type t =' constraints are supported"
+  in
+  match pmty with
+  | {pmty_desc = Pmty_ident lid} -> (lid, [])
+  | {pmty_desc = Pmty_with({pmty_desc = Pmty_ident lid}, cstrs)} ->
+      (lid, List.map map_cstr cstrs)
+  | _ ->
+      err pmty.pmty_loc
+        "only module type identifier and 'with type' constraints are supported"
+
+let add_brace_attr expr =
+  let label = Location.mknoloc "reason.preserve_braces" in
+  let payload = PStr [] in
+  {expr with pexp_attributes= (label, payload) :: expr.pexp_attributes }
+
+%}
+
+
+
+(* Tokens *)
+
+%token AMPERAMPER
+%token AMPERSAND
+%token AND
+%token AS
+%token ASSERT
+%token BACKQUOTE
+%token BANG
+%token BAR
+%token BARBAR
+%token BARRBRACKET
+%token BEGIN
+%token <char> CHAR
+%token CLASS
+%token COLON
+%token COLONCOLON
+%token COLONEQUAL
+%token COLONGREATER
+%token COMMA
+%token CONSTRAINT
+%token DO
+%token DONE
+%token DOT
+%token DOTDOT
+%token DOTDOTDOT
+%token DOWNTO
+%token ELSE
+%token END
+%token EOF
+%token EQUAL
+%token EXCEPTION
+%token EXTERNAL
+%token FALSE
+%token <string * char option> FLOAT
+%token FOR
+%token FUN ES6_FUN
+%token FUNCTION
+%token FUNCTOR
+%token GREATER
+%token GREATERRBRACE
+%token GREATERDOTDOTDOT
+%token IF
+%token IN
+%token INCLUDE
+%token <string> INFIXOP0
+%token <string> INFIXOP1
+%token <string> INFIXOP2
+%token <string> INFIXOP3
+(* SLASHGREATER is an INFIXOP3 that is handled specially *)
+%token SLASHGREATER
+%token <string> INFIXOP4
+%token INHERIT
+%token INITIALIZER
+%token <string * char option> INT
+%token LAZY
+%token LBRACE
+%token LBRACELESS
+%token LBRACKET
+%token LBRACKETBAR
+%token LBRACKETLESS
+%token LBRACKETGREATER
+%token LBRACKETPERCENT
+%token LBRACKETPERCENTPERCENT
+%token LESS
+%token <string> LESSIDENT
+%token LESSGREATER
+%token LESSSLASHGREATER
+%token LESSDOTDOTGREATER
+%token EQUALGREATER
+%token LET
+%token <string> LIDENT
+%token LPAREN
+%token LBRACKETAT
+%token OF
+%token PRI
+%token SWITCH
+%token MINUS
+%token MINUSDOT
+%token MINUSGREATER
+%token MODULE
+%token MUTABLE
+%token <nativeint> NATIVEINT
+%token NEW
+%token NONREC
+%token OBJECT
+%token OPEN
+%token OR
+(* %token PARSER *)
+%token PERCENT
+%token PLUS
+%token PLUSDOT
+%token PLUSEQ
+%token <string> PREFIXOP
+%token <string> POSTFIXOP
+%token PUB
+%token QUESTION
+%token QUOTE
+%token RBRACE
+%token RBRACKET
+%token REC
+%token RPAREN
+%token <string> LESSSLASHIDENTGREATER
+%token SEMI
+%token SEMISEMI
+%token SHARP
+%token <string> SHARPOP
+%token SHARPEQUAL
+%token SIG
+%token STAR
+%token <string * string option * string option> STRING
+%token STRUCT
+%token THEN
+%token TILDE
+%token TO
+%token TRUE
+%token TRY
+%token TYPE
+%token <string> UIDENT
+%token UNDERSCORE
+%token VAL
+%token VIRTUAL
+%token WHEN
+%token WHILE
+%token WITH
+%token <string * Location.t> COMMENT
+%token <string> DOCSTRING
+
+%token EOL
+
+(* Precedences and associativities.
+
+Tokens and rules have precedences and those precedences are used to
+resolve what would otherwise be a conflict in the grammar.
+
+Precedence and associativity/Resolving conflicts:
+----------------------------
+See [http://caml.inria.fr/pub/docs/manual-ocaml-4.00/manual026.html] section
+about conflicts.
+
+We will only use associativities with operators of the kind  x * x -> x
+for example, in the rules of the form    expr: expr BINOP expr
+in all other cases, we define two precedences if needed to resolve
+conflicts.
+
+*)
+(* Question: Where is the SEMI explicit precedence? *)
+%nonassoc below_SEMI
+%right    EQUALGREATER                  (* core_type2 (t => t => t) *)
+%right    COLON
+%right    EQUAL                         (* below COLONEQUAL (lbl = x := e) *)
+%right    COLONEQUAL                    (* expr (e := e := e) *)
+%nonassoc QUESTION
+%nonassoc WITH             (* below BAR  (match ... with ...) *)
+%nonassoc AND             (* above WITH (module rec A: SIG with ... and ...) *)
+%nonassoc ELSE                          (* (if ... then ... else ...) *)
+%nonassoc AS
+%nonassoc below_BAR                     (* Allows "building up" of many bars *)
+%left     BAR                           (* pattern (p|p|p) *)
+
+%right    OR BARBAR                     (* expr (e || e || e) *)
+%right    AMPERSAND AMPERAMPER          (* expr (e && e && e) *)
+%left     INFIXOP0 LESS GREATER GREATERDOTDOTDOT (* expr (e OP e OP e) *)
+%left     LESSDOTDOTGREATER (* expr (e OP e OP e) *)
+%right    INFIXOP1                      (* expr (e OP e OP e) *)
+%right    COLONCOLON                    (* expr (e :: e :: e) *)
+%left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ (* expr (e OP e OP e) *)
+%left     PERCENT INFIXOP3 SLASHGREATER STAR          (* expr (e OP e OP e) *)
+%right    INFIXOP4                      (* expr (e OP e OP e) *)
+
+(**
+ * With the way attributes are currently parsed, if we want consistent precedence for
+ *
+ * The OCaml parser parses the following attributes:
+ *
+ *    let x = true && (false [@attrOnFalse])
+ *    let x = true && false [@attrOnFalse]
+ *    let x = 10 + 20 [@attrOn20]
+ *    let x = (10 + 20) [@attrEntireAddition]
+ *
+ * As:
+ *
+ *    let x = true && ((false)[@attrOnFalse ])
+ *    let x = true && ((false)[@attrOnFalse ])
+ *    let x = ((10 + 20)[@attrOn20 ])
+ *    let x = ((10 + 20)[@attrEntireAddition ])
+ *
+ * That is because the precedence of tokens is configured as following, which
+ * only serves to treat certain infix operators as different than others with
+ * respect to attributes *only*.
+ *
+ *    %right    OR BARBAR
+ *    %right    AMPERSAND AMPERAMPER
+ *    %nonassoc below_EQUAL
+ *    %left     INFIXOP0 EQUAL LESS GREATER
+ *    %right    INFIXOP1
+ *    %nonassoc LBRACKETAT
+ *    %right    COLONCOLON
+ *    %left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ
+ *    %left     PERCENT INFIXOP3 SLASHGREATER STAR
+ *    %right    INFIXOP4
+ *
+ * So instead, with Reason, we treat all infix operators identically w.r.t.
+ * attributes. In expressions, they have the same precedence as function
+ * arguments, as if they are additional arguments to a function application.
+ *
+ * Note that unary subtractive/plus parses with lower precedence than function
+ * application (and attributes) This means that:
+ *
+ *   let = - something blah blah [@attr];
+ *
+ * Will have the attribute applied to the entire content to the right of the
+ * unary minus, as if the attribute was merely another argument to the function
+ * application.
+ *
+ *
+ * To make the attribute apply to the unary -, wrap in parens.
+ *
+ *   let = (- something blah blah) [@attr];
+ *
+ * Where arrows occur, it will (as always) obey the rules of function/type
+ * application.
+ *
+ *   type x = int => int [@onlyAppliedToTheInt];
+ *   type x = (int => int) [@appliedToTheArrow];
+ *
+ * However, unary subtractive/plus parses with *higher* precedence than infix
+ * application, so that
+ *
+ *   3 + - funcCall arg arg + 3;
+ *
+ * Is parsed as:
+ *
+ *   3 + (- (funcCall arg arg)) + 3;
+ *
+ * TODO:
+ *
+ * We would also like to bring this behavior to `!` as well, when ! becomes
+ * "not". This is so that you may do !someFunction(arg, arg) and have the
+ * entire function application negated. In fact, we may as well just have all
+ * of PREFIXOP have the unary precedence parsing behavior for consistency.
+ *)
+
+%nonassoc attribute_precedence
+
+%nonassoc prec_unary (* unary - *)
+%nonassoc prec_constant_constructor     (* cf. simple_expr (C versus C x) *)
+(* Now that commas require wrapping parens (for tuples), prec_constr_appl no
+* longer needs to be above COMMA, but it doesn't hurt *)
+%nonassoc prec_constr_appl              (* above AS BAR COLONCOLON COMMA *)
+
+(* PREFIXOP and BANG precedence *)
+%nonassoc below_DOT_AND_SHARP           (* practically same as below_SHARP but we convey purpose *)
+%nonassoc SHARP                         (* simple_expr/toplevel_directive *)
+%nonassoc below_DOT
+
+(* We need SHARPEQUAL to have lower precedence than `[` to make e.g.
+   this work: `foo #= bar[0]`. Otherwise it would turn into `(foo#=bar)[0]` *)
+%left     SHARPEQUAL
+%nonassoc POSTFIXOP
+(* LBRACKET and DOT are %nonassoc in OCaml, because the left and right sides
+   are never the same, therefore there doesn't need to be a precedence
+   disambiguation. This could also work in Reason, but by grouping the tokens
+   below into a single precedence rule it becomes clearer that they all have the
+   same precedence. *)
+%left     SHARPOP MINUSGREATER LBRACKET DOT
+(* Finally, the first tokens of simple_expr are above everything else. *)
+%nonassoc LBRACKETLESS LBRACELESS LBRACE LPAREN
+
+
+(* Entry points *)
+
+%start implementation                   (* for implementation files *)
+%type <Ast_404.Parsetree.structure> implementation
+%start interface                        (* for interface files *)
+%type <Ast_404.Parsetree.signature> interface
+%start toplevel_phrase                  (* for interactive use *)
+%type <Ast_404.Parsetree.toplevel_phrase> toplevel_phrase
+%start use_file                         (* for the #use directive *)
+%type <Ast_404.Parsetree.toplevel_phrase list> use_file
+%start parse_core_type
+%type <Ast_404.Parsetree.core_type> parse_core_type
+%start parse_expression
+%type <Ast_404.Parsetree.expression> parse_expression
+%start parse_pattern
+%type <Ast_404.Parsetree.pattern> parse_pattern
+
+(* Instead of reporting an error directly, productions specified
+ * below will be reduced first and poped up in the stack to a higher
+ * level production.
+ *
+ * This is essential to error reporting as it is much friendier to provide
+ * a higher level error (e.g., "Expecting the parens to be closed" )
+ * as opposed to a low-level one (e.g., "Expecting to finish
+ * current type definition").
+ *
+ * See Menhir's manual for more details.
+ *)
+%on_error_reduce structure_item let_binding_body
+                 as_loc(attribute)+
+                 type_longident
+                 constr_longident
+                 pattern
+                 nonrec_flag
+                 val_ident
+                 SEMI?
+                 fun_def(EQUAL,core_type)
+                 fun_def(EQUALGREATER,non_arrowed_core_type)
+                 expr_optional_constraint
+%%
+
+(* Entry points *)
+
+implementation:
+  structure EOF
+  { apply_mapper_to_structure $1 reason_mapper }
+;
+
+interface:
+  signature EOF
+  { apply_mapper_to_signature $1 reason_mapper }
+;
+
+toplevel_phrase: embedded
+  ( EOF                              { raise End_of_file}
+  | structure_item     SEMI          { Ptop_def $1 }
+  | toplevel_directive SEMI          { $1 }
+  ) { apply_mapper_to_toplevel_phrase $1 reason_mapper }
+;
+
+use_file_no_mapper: embedded
+( EOF                              { [] }
+  | structure_item     SEMI use_file_no_mapper { Ptop_def $1  :: $3 }
+  | toplevel_directive SEMI use_file_no_mapper { $1 :: $3 }
+  | structure_item     EOF           { [Ptop_def $1 ] }
+  | toplevel_directive EOF           { [$1] }
+  ) { $1 }
+;
+
+use_file:
+  use_file_no_mapper { apply_mapper_to_use_file $1 reason_mapper }
+;
+
+parse_core_type:
+  core_type EOF
+  { apply_mapper_to_type $1 reason_mapper }
+;
+
+parse_expression:
+  expr EOF
+  { apply_mapper_to_expr $1 reason_mapper }
+;
+
+parse_pattern:
+  pattern EOF
+  { apply_mapper_to_pattern $1 reason_mapper }
+;
+
+(* Module expressions *)
+
+module_parameter:
+as_loc
+  ( LPAREN RPAREN
+    { (Some (mkloc "*" (mklocation $startpos $endpos)), None) }
+  | as_loc(UIDENT {$1} | UNDERSCORE {"_"}) COLON module_type
+    { (Some $1, Some $3) }
+  | module_type
+    { (None, Some $1) }
+) {$1};
+
+%inline two_or_more_module_parameters_comma_list:
+  lseparated_two_or_more(COMMA, module_parameter) COMMA? {$1}
+;
+
+functor_parameters:
+  | LPAREN RPAREN
+    { let loc = mklocation $startpos $endpos in
+      [mkloc (Some (mkloc "*" loc), None) loc]
+    }
+  (* This single parameter case needs to be explicitly specified so that
+   * menhir can automatically remove the conflict between sigature:
+   *
+   *   include (X)
+   *   include (X, Y) => Z
+   *
+   * Even though the later is non-sensical (maybe it won't be one day?)
+   *)
+  | LPAREN module_parameter RPAREN {[$2]}
+  | LPAREN module_parameter COMMA RPAREN {[$2]}
+  | parenthesized(two_or_more_module_parameters_comma_list) { $1 }
+;
+
+module_complex_expr:
+mark_position_mod
+  ( module_expr
+    { $1 }
+  | module_expr COLON module_type
+    { mkmod(Pmod_constraint($1, $3)) }
+  | VAL expr
+    { mkmod(Pmod_unpack $2) }
+  | VAL expr COLON MODULE? package_type
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkmod (Pmod_unpack(
+           mkexp ~ghost:true ~loc (Pexp_constraint($2, (mktyp ~ghost:true ~loc (Ptyp_package $5))))))
+    }
+  | VAL expr COLON MODULE? package_type COLONGREATER MODULE? package_type
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkmod (Pmod_unpack(
+             mkexp ~ghost:true ~loc (Pexp_coerce($2, Some(mktyp ~ghost:true ~loc (Ptyp_package $5)),
+                                    mktyp ~ghost:true ~loc (Ptyp_package $8))))) }
+  | VAL expr COLONGREATER MODULE? package_type
+    { let loc = mklocation $symbolstartpos $endpos and ghost = true in
+      let mty = mktyp ~ghost ~loc (Ptyp_package $5) in
+      mkmod (Pmod_unpack(mkexp ~ghost ~loc (Pexp_coerce($2, None, mty))))
+    }
+  ) {$1};
+
+module_arguments_comma_list:
+  lseparated_list(COMMA, module_complex_expr) COMMA? {$1}
+;
+module_arguments:
+  | module_expr_structure { [$1] }
+  | parenthesized(module_arguments_comma_list)
+    { match $1 with
+      | [] -> [mkmod ~loc:(mklocation $startpos $endpos) (Pmod_structure [])]
+      | xs -> xs
+    }
+;
+
+module_expr_body: preceded(EQUAL,module_expr) | module_expr_structure { $1 };
+
+module_expr_structure:
+  LBRACE structure RBRACE
+  { mkmod ~loc:(mklocation $startpos $endpos) (Pmod_structure($2)) }
+;
+
+module_expr:
+mark_position_mod
+  ( as_loc(mod_longident)
+    { mkmod(Pmod_ident $1) }
+  | module_expr_structure { $1 }
+  | as_loc(LPAREN) module_expr COLON module_type as_loc(error)
+    { unclosed_mod (with_txt $1 "(") (with_txt $5 ")")}
+  | LPAREN module_complex_expr RPAREN
+    { $2 }
+  | LPAREN RPAREN
+    { mkmod (Pmod_structure []) }
+  | extension
+    { mkmod (Pmod_extension $1) }
+  (**
+   * Although it would be nice (and possible) to support annotated return value
+   * here, that wouldn't be consistent with what is possible for functions.
+   * Update: In upstream, it *is* possible to annotate return values for
+   * lambdas.
+   *)
+  | either(ES6_FUN,FUN) functor_parameters preceded(COLON,simple_module_type)? EQUALGREATER module_expr
+    { let me = match $3 with
+        | None -> $5
+        | Some mt ->
+          let loc = mklocation $startpos($3) $endpos in
+          mkmod ~loc (Pmod_constraint($5, mt))
+      in
+      mk_functor_mod $2 me
+    }
+  | module_expr module_arguments
+    { List.fold_left mkmod_app $1 $2 }
+  | module_expr as_loc(LPAREN) module_expr as_loc(error)
+    { unclosed_mod (with_txt $2 "(") (with_txt $4 ")") }
+  | as_loc(LPAREN) module_expr as_loc(error)
+    { unclosed_mod (with_txt $1 "(") (with_txt $3 ")") }
+  | as_loc(LPAREN) VAL expr COLON as_loc(error)
+    { unclosed_mod (with_txt $1 "(") (with_txt $5 ")") }
+  | as_loc(LPAREN) VAL expr COLONGREATER as_loc(error)
+    { unclosed_mod (with_txt $1 "(") (with_txt $5 ")") }
+  | as_loc(LPAREN) VAL expr as_loc(error)
+    { unclosed_mod (with_txt $1 "(") (with_txt $4 ")") }
+  | attribute module_expr %prec attribute_precedence
+    { {$2 with pmod_attributes = $1 :: $2.pmod_attributes} }
+  ) {$1};
+
+(**
+ * Attributes/Extension points TODO:
+ * - Faux-ternary to support extension points (printing/parsing).
+ * - Audit to ensure every [item attributes] [item extensions] is supported.
+ * - wrap_exp_attrs / mkexp_attrs cleanup - no need for the confusing
+ * indirection.
+ * - Ensure proper parsing as ensured by commit:
+ *   4c48d802cb9e8110ab3b57ca0b6a02fdd5655283
+ * - Support the Item Extension + Item Attributes pattern/sugar/unification for
+ * all items in let sequences (let module etc / let open).
+ *)
+
+(*
+ * In OCaml there are (confusingly) two ways to execute imperitive code at the
+ * top level:
+ *
+ *   doStuff();      (* parsed as let _ = ... *)
+ *   doMoreStuff();  (* parsed as let _ = ... *)
+ *   ;;              (* SEMISEMI *)
+ *   let exportedThing = blah
+ *
+ *   let _ = doStuff()
+ *   let _ = doStuff()
+ *   let exportedThing = blah   (* SEMISEMI not needed if no leading seq_expr *)
+ *
+ *
+ * SEMISEMI (and a bunch of other inconsistencies/suprises) are the price you
+ * pay for not requiring a delimiter after each binding/imperitive action.
+ *
+ *    let myFn () =
+ *       let x = 0 in
+ *       let y = 10 in
+ *       x + y
+ *
+ * Also, in OCaml, there is a different syntax for let bindings in function
+ * bodies, where each let bindings group must end with IN.
+ *
+ * If we just *require* that every module export is terminated by a SEMI, and
+ * require that sequence expressions are grouped by some surrounding tokens {},
+ * then we can have a consistent, familiar way of executing imperitive code, or
+ * let bindings (without introducing SEMISEMI and without forcing you to write
+ * [let _ = imperitive()]).
+ *
+ *   doStuff();
+ *   doStuff();
+ *   let exportedThing = blah;   (* SEMISEMI not needed *)
+ *
+ * Also, we can then make function scoped let bindings have a consistent syntax
+ * with the top level module syntax.
+ *
+ *    let myFn () => {
+ *      let x = 0;
+ *      let y = 10;
+ *      x + y;
+ *    };
+ }
+ *
+ * There are other practical reasons to require each structure item (or record
+ * item etc) to be terminated by a SEMI. It allows IDEs to correct indentation
+ * as you type. Otherwise (as in OCaml) your editor has to wait until you type
+ * `let` again to determine the indentation of the new line - for many editors,
+ * achieving that configuration is not easy.
+ *
+ *  structure:
+ *      seq_expr attribute* structure_tail { mkstrexp $1 $2 :: $3 }
+ *    | structure_tail { $1 }
+ *  ;
+ *  structure_tail:
+ *                           { [] }
+ *    | SEMISEMI structure   { $2 }
+ *    | structure_item SEMI structure_tail { $1 :: $3 }
+ *)
+
+structure:
+  | (* Empty *) { [] }
+  | structure_item { $1 }
+  | structure_item SEMI structure { $1 @ $3 }
+  | as_loc(error) structure
+    { let menhirError = Reason_syntax_util.findMenhirErrorMessage $1.loc in
+      match menhirError with
+      | MenhirMessagesError errMessage -> (syntax_error_str errMessage.loc errMessage.msg) :: $2
+      | _ -> (syntax_error_str $1.loc "Invalid statement") :: $2
+    }
+  | as_loc(error) SEMI structure
+    { let menhirError = Reason_syntax_util.findMenhirErrorMessage $1.loc in
+      match menhirError with
+      | MenhirMessagesError errMessage -> (syntax_error_str errMessage.loc errMessage.msg) :: $3
+      | _ -> (syntax_error_str $1.loc "Invalid statement") :: $3
+    }
+  | as_loc(structure_item) error structure
+    { let menhirError = Reason_syntax_util.findMenhirErrorMessage $1.loc in
+      match menhirError with
+      | MenhirMessagesError errMessage -> (syntax_error_str errMessage.loc errMessage.msg) :: $3
+      | _ -> (syntax_error_str $1.loc "Statement has to end with a semicolon") :: $3
+    }
+;
+
+opt_LET_MODULE_ident:
+  | opt_LET_MODULE as_loc(UIDENT) { $2 }
+  | opt_LET_MODULE as_loc(LIDENT)
+    { let {loc} = $2 in
+      err loc lowercase_module_msg }
+;
+
+opt_LET_MODULE_REC_ident:
+  | opt_LET_MODULE REC as_loc(UIDENT) { $3 }
+  | opt_LET_MODULE REC as_loc(LIDENT)
+    { let {loc} = $3 in
+      err loc lowercase_module_msg }
+;
+
+structure_item:
+  | mark_position_str
+    (* We consider a floating expression to be equivalent to a single let binding
+       to the "_" (any) pattern.  *)
+    ( item_attributes unattributed_expr
+      { mkstrexp $2 $1 }
+    | item_attributes item_extension_sugar structure_item
+      { let (ext_attrs, ext_id) = $2 in
+        struct_item_extension ($1@ext_attrs, ext_id) $3 }
+    | item_attributes
+      EXTERNAL as_loc(val_ident) COLON core_type EQUAL primitive_declaration
+      { let loc = mklocation $symbolstartpos $endpos in
+        mkstr (Pstr_primitive (Val.mk $3 $5 ~prim:$7 ~attrs:$1 ~loc)) }
+    | type_declarations
+      { let (nonrec_flag, tyl) = $1 in mkstr(Pstr_type (nonrec_flag, tyl)) }
+    | str_type_extension
+      { mkstr(Pstr_typext $1) }
+    | str_exception_declaration
+      { mkstr(Pstr_exception $1) }
+    | item_attributes opt_LET_MODULE_ident module_binding_body
+      { let loc = mklocation $symbolstartpos $endpos in
+        mkstr(Pstr_module (Mb.mk $2 $3 ~attrs:$1 ~loc)) }
+    | item_attributes opt_LET_MODULE_REC_ident module_binding_body
+      and_module_bindings*
+      { let loc = mklocation $symbolstartpos $endpos($2) in
+        mkstr (Pstr_recmodule ((Mb.mk $2 $3 ~attrs:$1 ~loc) :: $4))
+      }
+    | item_attributes MODULE TYPE OF? as_loc(ident)
+      { let loc = mklocation $symbolstartpos $endpos in
+        mkstr(Pstr_modtype (Mtd.mk $5 ~attrs:$1 ~loc)) }
+    | item_attributes MODULE TYPE OF? as_loc(ident) module_type_body(EQUAL)
+      { let loc = mklocation $symbolstartpos $endpos in
+        mkstr(Pstr_modtype (Mtd.mk $5 ~typ:$6 ~attrs:$1 ~loc)) }
+    | open_statement
+      { mkstr(Pstr_open $1) }
+    | item_attributes CLASS class_declaration_details and_class_declaration*
+      { let (ident, binding, virt, params) = $3 in
+        let loc = mklocation $symbolstartpos $endpos($3) in
+        let first = Ci.mk ident binding ~virt ~params ~attrs:$1 ~loc in
+        mkstr (Pstr_class (first :: $4))
+      }
+    | class_type_declarations
+        (* Each declaration has their own preceeding attribute* *)
+      { mkstr(Pstr_class_type $1) }
+    | item_attributes INCLUDE module_expr
+      { let loc = mklocation $symbolstartpos $endpos in
+        mkstr(Pstr_include (Incl.mk $3 ~attrs:$1 ~loc))
+      }
+    | item_attributes item_extension
+      (* No sense in having item_extension_sugar for something that's already an
+       * item_extension *)
+      { mkstr(Pstr_extension ($2, $1)) }
+    | let_bindings
+      { val_of_let_bindings $1 }
+    ) { [$1] }
+ | located_attributes
+   { List.map (fun x -> mkstr ~loc:x.loc (Pstr_attribute x.txt)) $1 }
+;
+
+module_binding_body:
+  | loption(functor_parameters) module_expr_body
+    { mk_functor_mod $1 $2 }
+  | loption(functor_parameters) COLON module_type module_expr_body
+    { let loc = mklocation $startpos($3) $endpos($4) in
+      mk_functor_mod $1 (mkmod ~loc (Pmod_constraint($4, $3))) }
+;
+
+and_module_bindings:
+  item_attributes AND as_loc(UIDENT) module_binding_body
+  { Mb.mk $3 $4 ~attrs:$1 ~loc:(mklocation $symbolstartpos $endpos) }
+;
+
+(* Module types *)
+
+(*
+(*
+ * For now, WITH constraints on module types shouldn't be considered
+ * "non-arrowed" because their WITH constraints themselves might contain arrows.
+ * We could ensure that you may only supply *non* arrowed types (or wrap arrowed
+ * types in parens) in thier WITH constraints, but that's just too difficult to
+ * think about so we will simply not consider WITH constrained module types as
+ * non-arrowed.
+ *
+ * Given this, we can probably take out the below_WITH precedence in the rules
+ * down below.
+ *)
+*)
+
+(* Allowed in curried let bidings *)
+
+simple_module_type:
+mark_position_mty
+  ( parenthesized(module_parameter)
+    { match $1.txt with
+      | (None, Some x) -> x
+      | _ -> syntax_error_mod $1.loc "Expecting a simple module type"
+    }
+  | module_type_signature { $1 }
+  | as_loc(LPAREN) module_type as_loc(error)
+    { unclosed_mty (with_txt $1 "(") (with_txt $3 ")")}
+  | as_loc(mty_longident)
+    { mkmty (Pmty_ident $1) }
+  | as_loc(LBRACE) signature as_loc(error)
+    { unclosed_mty (with_txt $1 "{") (with_txt $3 "}")}
+  | extension
+    { mkmty (Pmty_extension $1) }
+  ) {$1};
+
+module_type_signature:
+  LBRACE signature RBRACE
+  { mkmty ~loc:(mklocation $startpos $endpos) (Pmty_signature $2) }
+;
+
+(*
+(*
+ * For module types, we have:
+ *
+ *  simple_module_type: (Non arrowed implied)
+ *  non_arrowed_module_type
+ *  module_type ::=
+ *    module_type WITH ...
+ *    non_arrowed_module_type
+ *    (arg : module_type) => module_type
+ *    module_type => module_type
+ *)
+*)
+
+%inline with_constraints:
+  WITH lseparated_nonempty_list(AND, with_constraint) { $2 }
+
+module_type:
+mark_position_mty
+  ( module_type with_constraints
+    (* See note above about why WITH constraints aren't considered
+     * non-arrowed.
+     * We might just consider unifying the syntax for record extension with
+     * module extension/WITH constraints.
+     *
+     *    mod MyModule = {
+     *       ModuleToInclude...
+     *    };
+     *
+     *    let module CreateFactory
+     *               (Spec: ContainerSpec)
+     *               :{DescriptorFactoryIntf.S with
+     *                  type props = Spec.props and type dependencies = Spec.props} =>
+     *
+     *)
+    { mkmty (Pmty_with($1, $2)) }
+  | simple_module_type
+    {$1}
+  | LPAREN MODULE TYPE OF module_expr RPAREN
+    { mkmty (Pmty_typeof $5) }
+  | attribute module_type %prec attribute_precedence
+    { {$2 with pmty_attributes = $1 :: $2.pmty_attributes} }
+  | functor_parameters EQUALGREATER module_type %prec below_SEMI
+      (**
+       * In OCaml, this is invalid:
+       * module MyFunctor: functor MT -> (sig end) = functor MT -> (struct end);;
+       *
+       * Not only must curried functor args have annotations, but functor
+       * annotations must include *names* for each argument in a functor type.
+       *
+       * module MyFunctor: functor (MT:MT) -> (sig end) = functor (MT:MT) -> (struct end)
+       *
+       * In Reason, we will parse the functor type:
+       *
+       *    (AB:MT) -> ReturnSig
+       *
+       * as in:
+       *                   /----------------\
+       * module MyFunctor: (A:B) => ReturnSig = functor (C:D) => {}
+       *
+       * But only for the sake of compatibility with existing OCaml code (the
+       * ability to "view" OCaml code in Reason's syntax without loss of
+       * information.) Do not write identifiers in functor argument type
+       * positions - you wouldn't do it with functions, and they are
+       * meaningless in functors.
+       *
+       *  But for sake of consistency (and for sake of a syntax that truly
+       *  unifies functor syntax with function syntax, the following "sugars"
+       *  will be parsed (and printed):
+       *
+       *   A => B => C
+       *
+       * Is parsed into:
+       *
+       * functor (_:A) -> functor (_:B) -> C
+       *
+       * And a dummy "_" is inserted into the parse tree where no name has been
+       * provided.
+       *
+       *   {SomeSig} => {} => {}
+       *
+       * Is parsed into:
+       *
+       * (_:SomeSig) => (_:{}) => {}
+       *
+       *
+       *)
+    { mk_functor_mty $1 $3 }
+  ) {$1};
+
+signature:
+  | (* Empty *) { [] }
+  | signature_items { $1 }
+  | signature_items SEMI signature { $1 @ $3 }
+;
+
+signature_item:
+  | item_attributes
+    LET as_loc(val_ident) COLON core_type
+    { let loc = mklocation $startpos($2) $endpos in
+      Psig_value (Val.mk $3 $5 ~attrs:$1 ~loc)
+    }
+  | item_attributes
+    EXTERNAL as_loc(val_ident) COLON core_type EQUAL primitive_declaration
+    { let loc = mklocation $symbolstartpos $endpos in
+      Psig_value (Val.mk $3 $5 ~prim:$7 ~attrs:$1 ~loc)
+    }
+  | type_declarations
+    { let (nonrec_flag, tyl) = $1 in Psig_type (nonrec_flag, tyl) }
+  | sig_type_extension
+    { Psig_typext $1 }
+  | sig_exception_declaration
+    { Psig_exception $1 }
+  | item_attributes opt_LET_MODULE_ident module_declaration
+    { let loc = mklocation $symbolstartpos $endpos in
+      Psig_module (Md.mk $2 $3 ~attrs:$1 ~loc)
+    }
+  | item_attributes opt_LET_MODULE_ident EQUAL as_loc(mod_longident)
+    { let loc = mklocation $symbolstartpos $endpos in
+      let loc_mod = mklocation $startpos($4) $endpos($4) in
+      Psig_module (
+        Md.mk
+            $2
+            (Mty.alias ~loc:loc_mod $4)
+            ~attrs:$1
+            ~loc
+            )
+    }
+  | item_attributes opt_LET_MODULE_REC_ident module_type_body(COLON)
+    and_module_rec_declaration*
+    { let loc = mklocation $symbolstartpos $endpos($3) in
+      Psig_recmodule (Md.mk $2 $3 ~attrs:$1 ~loc :: $4) }
+  | item_attributes MODULE TYPE as_loc(ident)
+    { let loc = mklocation $symbolstartpos $endpos in
+      Psig_modtype (Mtd.mk $4 ~attrs:$1 ~loc)
+    }
+  | item_attributes MODULE TYPE as_loc(ident) module_type_body(EQUAL)
+    { let loc = mklocation $symbolstartpos $endpos in
+      Psig_modtype (Mtd.mk $4 ~typ:$5 ~loc ~attrs:$1)
+    }
+  | open_statement
+    { Psig_open $1 }
+  | item_attributes INCLUDE module_type
+    { let loc = mklocation $symbolstartpos $endpos in
+      Psig_include (Incl.mk $3 ~attrs:$1 ~loc)
+    }
+  | class_descriptions
+    { Psig_class $1 }
+  | class_type_declarations
+    { Psig_class_type $1 }
+  | item_attributes item_extension
+    { Psig_extension ($2, $1) }
+;
+
+signature_items:
+  | as_loc(signature_item) { [mksig ~loc:$1.loc $1.txt] }
+  | located_attributes
+    { List.map (fun x -> mksig ~loc:x.loc (Psig_attribute x.txt)) $1 }
+;
+
+open_statement:
+  item_attributes OPEN override_flag as_loc(mod_longident)
+  { Opn.mk $4 ~override:$3 ~attrs:$1 ~loc:(mklocation $symbolstartpos $endpos) }
+;
+
+module_declaration:
+  loption(functor_parameters) module_type_body(COLON)
+  { mk_functor_mty $1 $2 }
+;
+
+module_type_body(DELIM):
+  | DELIM module_type { $2 }
+  | module_type_signature { $1 }
+;
+
+and_module_rec_declaration:
+  item_attributes AND as_loc(UIDENT) module_type_body(COLON)
+  { Md.mk $3 $4 ~attrs:$1 ~loc:(mklocation $symbolstartpos $endpos) }
+;
+
+(* Class expressions *)
+
+and_class_declaration:
+  item_attributes AND class_declaration_details
+  { let (ident, binding, virt, params) = $3 in
+    let loc = mklocation $symbolstartpos $endpos in
+    Ci.mk ident binding ~virt ~params ~attrs:$1 ~loc
+  }
+;
+
+class_declaration_details:
+  virtual_flag as_loc(LIDENT) ioption(class_type_parameters)
+  ioption(labeled_pattern_list) class_declaration_body
+  {
+    let tree = match $4 with
+    | None -> []
+    | Some (lpl, _uncurried) -> lpl
+    in
+    let body = List.fold_right mkclass_fun tree $5 in
+    let params = match $3 with None -> [] | Some x -> x in
+    ($2, body, $1, params)
+  }
+;
+
+class_declaration_body:
+  preceded(COLON, class_constructor_type)?
+  either(preceded(EQUAL, class_expr), class_body_expr)
+  { match $1 with
+    | None -> $2
+    | Some ct -> Cl.constraint_ ~loc:(mklocation $symbolstartpos $endpos) $2 ct
+  }
+;
+
+class_expr_lets_and_rest:
+mark_position_cl
+  ( class_expr { $1 }
+  | let_bindings SEMI class_expr_lets_and_rest
+    { class_of_let_bindings $1 $3 }
+  | object_body { mkclass (Pcl_structure $1) }
+  ) {$1};
+
+object_body_class_fields:
+  | lseparated_list(SEMI, class_field) SEMI? { List.concat $1 }
+
+object_body:
+  | loption(located_attributes)
+    mark_position_pat(class_self_expr)
+    { let attrs = List.map (fun x -> mkcf ~loc:x.loc (Pcf_attribute x.txt)) $1 in
+      Cstr.mk $2 attrs }
+  | loption(located_attributes)
+    mark_position_pat(class_self_expr) SEMI
+    object_body_class_fields
+    { let attrs = List.map (fun x -> mkcf ~loc:x.loc (Pcf_attribute x.txt)) $1 in
+      Cstr.mk $2 (attrs @ $4) }
+  | object_body_class_fields
+    { let loc = mklocation $symbolstartpos $symbolstartpos in
+      Cstr.mk (mkpat ~loc (Ppat_var (mkloc "this" loc))) $1 }
+;
+
+class_self_expr:
+  | AS pattern { $2 }
+
+class_expr:
+mark_position_cl
+  ( class_simple_expr
+    { $1 }
+  | either(ES6_FUN,FUN) labeled_pattern_list EQUALGREATER class_expr
+    { let (lp, _) = $2 in
+      List.fold_right mkclass_fun lp $4 }
+  | class_simple_expr labeled_arguments
+      (**
+       * This is an interesting way to "partially apply" class construction:
+       *
+       * let inst = new oldclass 20;
+       * class newclass = oldclass withInitArg;
+       * let inst = new newclass;
+       *)
+    { mkclass(Pcl_apply($1, $2)) }
+  | attribute class_expr
+    { {$2 with pcl_attributes = $1 :: $2.pcl_attributes} }
+  (*
+    When referring to class expressions (not regular types that happen to be
+    classes), you must refer to it as a class. This gives syntactic real estate
+    to place type parameters which are distinguished from constructor application
+    of arguments.
+
+       class myClass 'x = (class yourClass 'x int) y z;
+       inherit (class yourClass float int) initArg initArg;
+       ...
+       let myVal: myClass int = new myClass 10;
+
+   *)
+  | CLASS as_loc(class_longident) loption(type_parameters)
+    { mkclass(Pcl_constr($2, $3)) }
+  | extension
+    { mkclass(Pcl_extension $1) }
+  ) {$1};
+
+class_simple_expr:
+mark_position_cl
+  ( as_loc(class_longident)
+    { mkclass(Pcl_constr($1, [])) }
+  | class_body_expr
+    { $1 }
+  | as_loc(LBRACE) class_expr_lets_and_rest as_loc(error)
+    { unclosed_cl (with_txt $1 "{") (with_txt $3 "}") }
+  | LPAREN class_expr COLON class_constructor_type RPAREN
+    { mkclass(Pcl_constraint($2, $4)) }
+  | as_loc(LPAREN) class_expr COLON class_constructor_type as_loc(error)
+    { unclosed_cl (with_txt $1 "(") (with_txt $5 ")") }
+  | LPAREN class_expr RPAREN
+    { $2 }
+  | as_loc(LPAREN) class_expr as_loc(error)
+    { unclosed_cl (with_txt $1 "(") (with_txt $3 ")") }
+  ) {$1};
+
+%inline class_body_expr: LBRACE class_expr_lets_and_rest RBRACE { $2 };
+
+class_field:
+  | mark_position_cf
+    ( item_attributes INHERIT override_flag class_expr preceded(AS,LIDENT)?
+      { mkcf_attrs (Pcf_inherit ($3, $4, $5)) $1 }
+    | item_attributes VAL value
+      { mkcf_attrs (Pcf_val $3) $1 }
+    | item_attributes either(PUB {Public}, PRI {Private}) method_
+      { let (a, b) = $3 in mkcf_attrs (Pcf_method (a, $2, b)) $1 }
+    | item_attributes CONSTRAINT constrain_field
+      { mkcf_attrs (Pcf_constraint $3) $1 }
+    | item_attributes INITIALIZER mark_position_exp(simple_expr)
+      { mkcf_attrs (Pcf_initializer $3) $1 }
+    | item_attributes item_extension
+      { mkcf_attrs (Pcf_extension $2) $1 }
+    ) { [$1] }
+  | located_attributes
+    { List.map (fun x -> mkcf ~loc:x.loc (Pcf_attribute x.txt)) $1 }
+;
+
+value:
+(* TODO: factorize these rules (also with method): *)
+  | override_flag MUTABLE VIRTUAL as_loc(label) COLON core_type
+    { if $1 = Override
+      then not_expecting $symbolstartpos $endpos "members marked virtual may not also be marked overridden"
+      else ($4, Mutable, Cfk_virtual $6)
+    }
+  | override_flag MUTABLE VIRTUAL label COLON core_type EQUAL
+    { not_expecting $startpos($7) $endpos($7) "not expecting equal - cannot specify value for virtual val" }
+  | VIRTUAL mutable_flag as_loc(label) COLON core_type
+    { ($3, $2, Cfk_virtual $5) }
+  | VIRTUAL mutable_flag label COLON core_type EQUAL
+    { not_expecting $startpos($6) $endpos($6) "not expecting equal - cannot specify value for virtual val" }
+  | override_flag mutable_flag as_loc(label) EQUAL expr
+    { ($3, $2, Cfk_concrete ($1, $5)) }
+  | override_flag mutable_flag as_loc(label) type_constraint EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      let e = ghexp_constraint loc $6 $4 in
+      ($3, $2, Cfk_concrete ($1, e)) }
+;
+
+method_:
+(* TODO: factorize those rules... *)
+  | override_flag VIRTUAL as_loc(label) COLON poly_type
+    { if $1 = Override then syntax_error ();
+      ($3, Cfk_virtual $5)
+    }
+  | override_flag as_loc(label) fun_def(EQUAL,core_type)
+    { let loc = mklocation $symbolstartpos $endpos in
+      ($2, Cfk_concrete ($1, mkexp ~ghost:true ~loc (Pexp_poly ($3, None))))
+    }
+  | override_flag as_loc(label) preceded(COLON,poly_type)?
+    either(preceded(EQUAL,expr), braced_expr)
+      (* Without locally abstract types, you'll see a Ptyp_poly in the Pexp_poly *)
+    { let loc = mklocation $symbolstartpos $endpos in
+      ($2, Cfk_concrete ($1, mkexp ~ghost:true ~loc (Pexp_poly($4, $3))))
+    }
+  | override_flag as_loc(label) COLON TYPE LIDENT+ DOT core_type
+    either(preceded(EQUAL,expr), braced_expr)
+    (* WITH locally abstract types, you'll see a Ptyp_poly in the Pexp_poly,
+       but the expression will be a Pexp_newtype and type vars will be
+       "varified". *)
+    {
+      (* For non, methods we'd create a pattern binding:
+         ((Ppat_constraint(mkpatvar ..., Ptyp_poly (typeVars, poly_type_varified))),
+          exp_with_newtypes_constrained_by_non_varified)
+
+         For methods, we create:
+         Pexp_poly (Pexp_constraint (methodFunWithNewtypes, non_varified), Some (Ptyp_poly newTypes varified))
+       *)
+      let (exp_non_varified, poly_vars) = wrap_type_annotation $5 $7 $8 in
+      let exp = Pexp_poly(exp_non_varified, Some poly_vars) in
+      let loc = mklocation $symbolstartpos $endpos in
+      ($2, Cfk_concrete ($1, mkexp ~ghost:true ~loc exp))
+    }
+;
+
+(* A parsing of class_constructor_type is the type of the class's constructor - and if the
+   constructor takes no arguments, then simply the class_instance_type of what is
+   returned.
+
+   The class_instance_type is type of the thing returned from a class constructor
+   which can either be:
+    - The identifier of another class.
+    - Type construction of a class type. [v1, v2] classIdentifier
+    - The type definition of the object returned (which is much like the type
+      of anonymous object but with different syntax, and ability to specify
+      inheritance):
+      - The class signature body may contain the type of methods (just like object types do)
+      - Inheritance of another class_instance_type.
+      - The instance variable "val"s.
+      - Constraints (same syntax that is used at class *definition* time)
+
+
+     When In Modules:
+     ================
+     There are two primary language "class" constructs that are included in modules:
+     Class Definitions, and Class Type Definitions.
+
+     A Class Definition:
+     -------------------
+     Brings three things into the environment. For a class defined with name
+     [myClass], the environment would then contain the following:
+       1. A type called [myClass] which represents instances that have the same
+       structure as what is returned from the constructor - and do not have
+       any *more* members than what is returned from the constructor.
+       2. A type called [#myClass] which loosely speaking represents objects
+       that have the same structure as what is returned from the constructor,
+       but can also have *additional* fields as well. This ability to have
+       additional fields is accomplished via the same row-polymorphism of
+       objects without classes. Any reference to [#myClass] implicitly includes
+       a type variable, whose name we may not mention.
+       3. The class constructor for [myClass] - a function that "new" can be
+       invoked on. If the constructor is a function that takes arguments, then
+       the type of the constructor is the type of that function (including
+       the type of object returned). If it doesn't take arguments, then the
+       type of the constructor is the type of the object returned. You can
+       explicitly annotate/constrain the type of the constructor, and can
+       annotate them in module signatures as well.
+
+     The type constraint on a constructor has one syntactic nuance. The final
+     item separated by arrow must be prefixed with "new". This is merely to
+     resolve parsing conflicts. This can be fixed by making a parse rule for
+     types that parses *either* non-arowed class_instance_type or core_types,
+     but that means deferring the interpretation of patterns like "lowercase
+     identifier" and "type application", until it is known if that item was the
+     *final* arrow segment.
+
+     A Class Type Definition:
+     -----------------------
+     Brings two things into the environment. For a class type definition with
+     name [myClass], the environment would then contain the following:
+       1. A type called [myClass] which describes any object having *exactly*
+       the fields listed in the definition.
+       2. A type called [#myClass] which loosely speaking represents objects
+       that have the same structure as the definition, but can also have
+       *additional* fields as well.
+
+
+     When In Signatures:
+     ================
+
+     A Class Definition (in signature becomes a class "description"):
+     -------------------
+     A Class Definition merely includes the type of that classes constructor.
+     [class myClass: args => new classType;] This merely admits that the module
+     includes a class whose constructor has that type.
+
+     A Class Type Definition is specified exactly as it is in a module (of
+     course, it may be abstract).
+
+
+     A Class Type Definition:
+     -----------------------
+     A Class Type Definition is specified exactly as it is in a module (of
+     course, it may be abstract).
+     Here are the parsing rules for everything discussed above:
+
+
+
+    Overview of Parsing Rules:
+    ==========================
+     (Note: I have renamed class_type from the upstream compiler to
+     class_constructor_type and class_signature to class_instance_type for
+     clarity)
+
+     constructor_type:
+        | class_instance_type
+        | constructorFunction => typeWithArrows => class_instance_type
+
+     Modules
+       Class Definitions
+       class_declarations
+         | class LIDENT = class_expr
+         | class LIDENT = (class_expr : constructor_type)
+         "Pstr_class"
+
+       Class Type Definition
+       class_type_declarations
+         CLASS TYPE ident = class_instance_type
+         "Pstr_class_type"
+
+     Signatures
+       Class Descriptions (describes Class Definitions in Module)
+       class_descriptions
+         CLASS ident : constructor_type
+         "Psig_class"
+
+       Class Type Declarations (subset of Class Type Definitions in Module)
+       class_type_declarations
+         CLASS TYPE ident = class_instance_type
+        "Psig_class_type"
+
+ *)
+class_constructor_type:
+  | class_instance_type { $1 }
+  | arrow_type_parameters EQUALGREATER class_constructor_type
+    { List.fold_right mkcty_arrow $1 $3 }
+;
+
+class_type_arguments_comma_list:
+  | lseparated_nonempty_list(COMMA,core_type) COMMA? {$1}
+;
+
+class_instance_type:
+mark_position_cty
+  ( as_loc(clty_longident)
+    loption(parenthesized(class_type_arguments_comma_list))
+    { mkcty (Pcty_constr ($1, $2)) }
+  | attribute class_instance_type
+    (* Note that this will compound attributes - so they will become
+       attached to whatever *)
+    { {$2 with pcty_attributes = $1 :: $2.pcty_attributes} }
+  | class_type_body
+    { $1 }
+  | extension
+    { mkcty (Pcty_extension $1) }
+  ) {$1};
+
+class_type_body:
+  | LBRACE class_sig_body RBRACE
+    { mkcty ~loc:(mklocation $startpos $endpos) (Pcty_signature $2) }
+  | LBRACE DOT class_sig_body RBRACE
+    { let loc = mklocation $startpos $endpos in
+      let ct = mkcty ~loc (Pcty_signature $3) in
+      {ct with pcty_attributes = [uncurry_payload loc]}
+    }
+  | as_loc(LBRACE) class_sig_body as_loc(error)
+    { unclosed_cty (with_txt $1 "{") (with_txt $3 "}") }
+;
+
+class_sig_body_fields:
+  lseparated_list(SEMI, class_sig_field) SEMI? { List.concat $1 }
+
+class_sig_body:
+  | class_self_type
+  { Csig.mk $1 [] }
+  | class_self_type SEMI class_sig_body_fields
+  { Csig.mk $1 $3 }
+  | class_sig_body_fields
+  { Csig.mk (Typ.mk ~loc:(mklocation $symbolstartpos $endpos) Ptyp_any) $1 }
+;
+
+class_self_type:
+  | AS core_type { $2 }
+;
+
+class_sig_field:
+  | mark_position_ctf
+    ( item_attributes INHERIT class_instance_type
+      { mkctf_attrs (Pctf_inherit $3) $1 }
+    | item_attributes VAL value_type
+      { mkctf_attrs (Pctf_val $3) $1 }
+    | item_attributes PRI virtual_flag label COLON poly_type
+      { mkctf_attrs (Pctf_method ($4, Private, $3, $6)) $1 }
+    | item_attributes PUB virtual_flag label COLON poly_type
+      { mkctf_attrs (Pctf_method ($4, Public, $3, $6)) $1 }
+    | item_attributes CONSTRAINT constrain_field
+      { mkctf_attrs (Pctf_constraint $3) $1 }
+    | item_attributes item_extension
+      { mkctf_attrs (Pctf_extension $2) $1 }
+    ) { [$1] }
+  | located_attributes
+    { List.map (fun x -> mkctf ~loc:x.loc (Pctf_attribute x.txt)) $1 }
+;
+
+value_type:
+  mutable_or_virtual_flags label COLON core_type
+  { let (mut, virt) = $1 in ($2, mut, virt, $4) }
+;
+
+constrain:
+  core_type EQUAL core_type
+  { ($1, $3, mklocation $symbolstartpos $endpos) }
+;
+
+constrain_field:
+  core_type EQUAL core_type
+  { ($1, $3) }
+;
+
+class_descriptions:
+  item_attributes CLASS class_description_details and_class_description*
+  { let (ident, binding, virt, params) = $3 in
+    let loc = mklocation $symbolstartpos $endpos in
+    (Ci.mk ident binding ~virt ~params ~attrs:$1 ~loc :: $4)
+  }
+;
+
+and_class_description:
+  item_attributes AND class_description_details
+  { let (ident, binding, virt, params) = $3 in
+    let loc = mklocation $symbolstartpos $endpos in
+    Ci.mk ident binding ~virt ~params ~attrs:$1 ~loc
+  }
+;
+
+%inline class_type_parameter_comma_list:
+    | lseparated_nonempty_list(COMMA, type_parameter) COMMA? {$1}
+
+%inline class_type_parameters:
+  parenthesized(class_type_parameter_comma_list)
+  { $1 }
+;
+
+class_description_details:
+  virtual_flag as_loc(LIDENT) loption(class_type_parameters) COLON class_constructor_type
+  { ($2, $5, $1, $3) }
+;
+
+class_type_declarations:
+  item_attributes CLASS TYPE class_type_declaration_details
+  and_class_type_declaration*
+  { let (ident, instance_type, virt, params) = $4 in
+    let loc = mklocation $symbolstartpos $endpos in
+    (Ci.mk ident instance_type ~virt ~params ~attrs:$1 ~loc :: $5)
+  }
+;
+
+and_class_type_declaration:
+  item_attributes AND class_type_declaration_details
+  { let (ident, instance_type, virt, params) = $3 in
+    let loc = mklocation $symbolstartpos $endpos in
+    Ci.mk ident instance_type ~virt ~params ~attrs:$1 ~loc
+  }
+;
+
+class_type_declaration_details:
+  virtual_flag as_loc(LIDENT) loption(class_type_parameters)
+  either(preceded(EQUAL,class_instance_type), class_type_body)
+  { ($2, $4, $1, $3) }
+;
+
+(* Core expressions *)
+
+(* Note: If we will parse this as Pexp_apply, and it will
+ * not be printed with the braces, except in a couple of cases such as if/while
+ * loops.
+ *
+ *  let add a b = {
+ *    a + b;
+ *  };
+ *  TODO: Rename to [semi_delimited_block_sequence]
+ *
+ * Since seq_expr doesn't require a final SEMI, then without
+ * a final SEMI, a braced sequence with a single identifier is
+ * indistinguishable from a punned record.
+ *
+ *   let myThing = {x};
+ *
+ * Is it {x:x} the record or x the identifier? We simply decided to break
+ * the tie and say that it should be parsed as a single identifier because
+ * single field records are incredibly rare. Apart from this one
+ * disadvantage, there's no disadvantage to not requiring the final brace.
+ *
+ * For each valid sequence item, we must list three forms:
+ *
+ *   [item_extension_sugar] [nonempty_item_attributes] ITEM
+ *   [nonempty_item_attributes] ITEM
+ *   ITEM
+ *)
+braced_expr:
+mark_position_exp
+  ( LBRACE seq_expr RBRACE
+    { add_brace_attr $2 }
+  | LBRACE as_loc(seq_expr) error
+    { syntax_error_exp $2.loc "SyntaxError in block" }
+  | LBRACE DOTDOTDOT expr_optional_constraint COMMA? RBRACE
+    { let loc = mklocation $symbolstartpos $endpos in
+      let msg = "Record construction must have at least one field explicitly set" in
+      syntax_error_exp loc msg
+    }
+  | LBRACE DOTDOTDOT expr_optional_constraint SEMI RBRACE
+    { let loc = mklocation $startpos($4) $endpos($4) in
+      raise_record_trailing_semi_error loc }
+  | LBRACE record_expr RBRACE
+    { let (exten, fields) = $2 in mkexp (Pexp_record(fields, exten)) }
+  | as_loc(LBRACE) record_expr as_loc(error)
+    { unclosed_exp (with_txt $1 "{") (with_txt $3 "}")}
+  | LBRACE record_expr_with_string_keys RBRACE
+    { let loc = mklocation $symbolstartpos $endpos in
+      let (exten, fields) = $2 in
+      mkexp ~loc (Pexp_extension (mkloc ("bs.obj") loc,
+             PStr [mkstrexp (mkexp ~loc (Pexp_record(fields, exten))) []]))
+    }
+  | as_loc(LBRACE) record_expr_with_string_keys as_loc(error)
+    { unclosed_exp (with_txt $1 "{") (with_txt $3 "}")}
+  (* Todo: Why is this not a simple_expr? *)
+  | LBRACE object_body RBRACE
+    { mkexp (Pexp_object $2) }
+  | as_loc(LBRACE) object_body as_loc(error)
+    { unclosed_exp (with_txt $1 "{") (with_txt $3 "}") }
+) {$1};
+
+seq_expr_no_seq:
+| expr SEMI? { $1 }
+| opt_LET_MODULE_ident module_binding_body SEMI seq_expr
+  { mkexp (Pexp_letmodule($1, $2, $4)) }
+| item_attributes LET? OPEN override_flag as_loc(mod_longident) SEMI seq_expr
+  { let exp = mkexp (Pexp_open($4, $5, $7)) in
+    { exp with pexp_attributes = $1 }
+  }
+| str_exception_declaration SEMI seq_expr {
+   mkexp (Pexp_letexception ($1, $3)) }
+| let_bindings SEMI seq_expr
+  { let loc = mklocation $startpos($1) $endpos($3) in
+    expr_of_let_bindings ~loc $1 $3
+  }
+| let_bindings SEMI?
+  { let loc = mklocation $symbolstartpos $endpos in
+    expr_of_let_bindings ~loc $1 (ghunit ~loc ())
+  }
+;
+
+seq_expr:
+mark_position_exp
+  ( seq_expr_no_seq
+    { $1 }
+  | item_extension_sugar mark_position_exp(seq_expr_no_seq)
+    { expression_extension $1 $2 }
+  | expr SEMI seq_expr
+    { mkexp (Pexp_sequence($1, $3)) }
+  | item_extension_sugar expr SEMI seq_expr
+    { let loc = mklocation $startpos($1) $endpos($2) in
+      mkexp (Pexp_sequence(expression_extension ~loc $1 $2, $4)) }
+  ) { $1 }
+;
+
+(*
+
+
+A:
+let named                 a::a      b::b             => a + b;
+type named =              a::int => b::int => int;
+B:
+let namedAlias            a::aa     b::bb  => aa + bb;
+let namedAlias            a::aa     b::bb  => aa + bb;
+type namedAlias =         a::int => b::int => int;
+C:
+let namedAnnot            a::(a:int) b::(b:int)   => 20;
+D:
+let namedAliasAnnot       a::(aa:int) b::(bb:int) => 20;
+E:
+let myOptional            a::a=?    b::b=?      ()  => 10;
+type named =              a::int? => b::int? => unit => int;
+F:
+let optionalAlias         a::aa=?   b::bb=?   ()  => 10;
+G:
+let optionalAnnot         a::(a:int)=? b::(b:int)=? ()  => 10;
+H:
+let optionalAliasAnnot    a::(aa:int)=? b::(bb:int)=? ()  => 10;
+I: :
+let defOptional           a::a=10    b::b=10  ()  => 10;
+type named =              a::int?  => b::int? => unit => int;
+J:
+let defOptionalAlias      a::aa=10      b::bb=10  ()  => 10;
+K:
+let defOptionalAnnot      a::(a:int)=10 b::(b:int)=10 ()  => 10;
+L:
+let defOptionalAliasAnnot a::(aa:int)=10 b::(bb:int)=10 ()  => 10;
+
+M: Invoking them - Punned :
+let resNotAnnotated = named a::a b::b;
+N::
+let resAnnotated    = (named a::a b::b :int);
+O: Invoking them :
+let resNotAnnotated = named a::a b::b;
+P: Invoking them :
+let resAnnotated    = (named a::a b::b :int);
+
+Q: Here's why "punning" doesn't work!  :
+ Is b:: punned with a final non-named arg, or is b:: supplied b as one named arg? :
+let b = 20;
+let resAnnotated    = (named a::a b:: b);
+
+R: Proof that there are no ambiguities with return values being annotated :
+let resAnnotated    = (named a::a b :ty);
+
+
+S: Explicitly passed optionals are a nice way to say "use the default value":
+let explicitlyPassed =          myOptional a::?None b::?None;
+T: Annotating the return value of the entire function call :
+let explicitlyPassedAnnotated = (myOptional a::?None b::?None :int);
+U: Explicitly passing optional with identifier expression :
+let a = None;
+let explicitlyPassed =           myOptional a::?a b::?None;
+let explicitlyPassedAnnotated = (myOptional a::?a b::?None :int);
+
+*)
+
+labeled_pattern_constraint:
+  | AS pattern_optional_constraint { fun _punned -> $2 }
+  | preceded(COLON, core_type)?
+    { fun punned ->
+      let pat = mkpat (Ppat_var punned) ~loc:punned.loc in
+      match $1 with
+      | None -> pat
+      | Some typ ->
+        let loc = mklocation punned.loc.loc_start $endpos in
+        mkpat ~loc (Ppat_constraint(pat, typ))
+    }
+;
+
+labeled_pattern:
+as_loc
+   ( TILDE as_loc(LIDENT) labeled_pattern_constraint
+    { Term (Labelled $2.txt, None, $3 $2) }
+  | TILDE as_loc(LIDENT) labeled_pattern_constraint EQUAL expr
+    { Term (Optional $2.txt, Some $5, $3 $2) }
+  | TILDE as_loc(LIDENT) labeled_pattern_constraint EQUAL QUESTION
+    { Term (Optional $2.txt, None, $3 $2) }
+  | pattern_optional_constraint
+    { Term (Nolabel, None, $1) }
+  | TYPE LIDENT
+    { Type $2 }
+  ) { $1 }
+;
+
+
+%inline labelled_pattern_comma_list:
+  lseparated_nonempty_list(COMMA, labeled_pattern) COMMA? { $1 };
+
+%inline labeled_pattern_list:
+  | LPAREN RPAREN {
+    let loc = mklocation $startpos $endpos in
+    ([mkloc (Term (Nolabel, None, mkpat_constructor_unit loc loc)) loc], false)
+  }
+  | parenthesized(labelled_pattern_comma_list) {
+    ($1, false)
+  }
+  | LPAREN DOT RPAREN {
+      let loc = mklocation $startpos $endpos in
+      ([mkloc (Term (Nolabel, None, mkpat_constructor_unit loc loc)) loc], true)
+  }
+  | LPAREN DOT labelled_pattern_comma_list RPAREN {
+    let () = List.iter (fun p ->
+        match p.txt with
+        | Term (Labelled _, _, _)
+        | Term (Optional _, _, _)  ->
+            raise Reason_syntax_util.(
+              Error(p.loc, (Syntax_error "Uncurried function definition with labelled arguments is not supported at the moment."))
+            )
+        | _ -> ()
+      ) $3 in
+    ($3, true)
+  }
+;
+
+es6_parameters:
+  | labeled_pattern_list { $1 }
+  | as_loc(UNDERSCORE)
+    { ([{$1 with txt = Term (Nolabel, None, mkpat ~loc:$1.loc Ppat_any)}], false) }
+  | simple_pattern_ident
+    { ([Location.mkloc (Term (Nolabel, None, $1)) $1.ppat_loc], false) }
+;
+
+(* TODO: properly fix JSX labelled/optional stuff *)
+jsx_arguments:
+  (* empty *) { [] }
+  | LIDENT EQUAL QUESTION simple_expr jsx_arguments
+    { (* a=?b *)
+      [(Optional $1, $4)] @ $5
+    }
+  | QUESTION LIDENT jsx_arguments
+    { (* <Foo ?bar /> punning with explicitly passed optional *)
+      let loc_lident = mklocation $startpos($2) $endpos($2) in
+      [(Optional $2, mkexp (Pexp_ident {txt = Lident $2; loc = loc_lident}) ~loc:loc_lident)] @ $3
+    }
+  | LIDENT EQUAL simple_expr jsx_arguments
+    { (* a=b *)
+      [(Labelled $1, $3)] @ $4
+    }
+  | LIDENT jsx_arguments
+    { (* a (punning) *)
+      let loc_lident = mklocation $startpos($1) $endpos($1) in
+      [(Labelled $1, mkexp (Pexp_ident {txt = Lident $1; loc = loc_lident}) ~loc:loc_lident)] @ $2
+    }
+  | as_loc(INFIXOP3)
+    (* extra rule to provide nice error messages in the case someone
+     * wrote: <Description term=<Text text="Age" />> child </Description>
+     * or <Foo bar=<Baz />/>
+     *  />> & />/> are lexed as infix tokens *)
+  {
+    match $1.txt with
+    | "/>>" ->
+     let err = Reason_syntax_util.Syntax_error {|JSX in a JSX-argument needs to be wrapped in braces.
+    If you wrote:
+      <Description term=<Text text="Age" />> child </Description>
+    Try wrapping <Text /> in braces.
+      <Description term={<Text text="Age" />}> child </Description>|} in
+      raise (Reason_syntax_util.Error($1.loc, err))
+    | "/>/>" ->
+     let err = Reason_syntax_util.Syntax_error {|JSX in a JSX-argument needs to be wrapped in braces.
+    If you wrote:
+      <Description term=<Text text="Age" />/>
+    Try wrapping <Text /> in braces.
+      <Description term={<Text text="Age" />} />|} in
+      raise (Reason_syntax_util.Error($1.loc, err))
+    | _ -> syntax_error ()
+  }
+;
+
+jsx_start_tag_and_args:
+    as_loc(LESSIDENT) jsx_arguments
+    { let name = Longident.parse $1.txt in
+      (jsx_component {$1 with txt = name} $2, name)
+    }
+  | LESS as_loc(mod_ext_longident) jsx_arguments
+    { jsx_component $2 $3, $2.txt }
+;
+
+jsx_start_tag_and_args_without_leading_less:
+    as_loc(mod_ext_longident) jsx_arguments
+    { (jsx_component $1 $2, $1.txt) }
+  | as_loc(LIDENT) jsx_arguments
+    { let lident = Longident.Lident $1.txt in
+      (jsx_component {$1 with txt = lident } $2, lident)
+    }
+;
+
+greater_spread:
+  | GREATERDOTDOTDOT
+  | GREATER DOTDOTDOT { ">..." }
+
+jsx:
+  | LESSGREATER simple_expr_no_call* LESSSLASHGREATER
+    { let loc = mklocation $symbolstartpos $endpos in
+      let body = mktailexp_extension loc $2 None in
+      makeFrag loc body
+    }
+  | jsx_start_tag_and_args SLASHGREATER
+    { let (component, _) = $1 in
+      let loc = mklocation $symbolstartpos $endpos in
+      component [
+        (Labelled "children", mktailexp_extension loc [] None);
+        (Nolabel, mkexp_constructor_unit loc loc)
+      ] loc
+    }
+  | jsx_start_tag_and_args GREATER simple_expr_no_call* LESSSLASHIDENTGREATER
+    { let (component, start) = $1 in
+      let loc = mklocation $symbolstartpos $endpos in
+      (* TODO: Make this tag check simply a warning *)
+      let endName = Longident.parse $4 in
+      let _ = ensureTagsAreEqual start endName loc in
+      let siblings = if List.length $3 > 0 then $3 else [] in
+      component [
+        (Labelled "children", mktailexp_extension loc siblings None);
+        (Nolabel, mkexp_constructor_unit loc loc)
+      ] loc
+    }
+   | jsx_start_tag_and_args greater_spread simple_expr_no_call LESSSLASHIDENTGREATER
+     (* <Foo> ...bar </Foo> or <Foo> ...((a) => 1) </Foo> *)
+    { let (component, start) = $1 in
+      let loc = mklocation $symbolstartpos $endpos in
+      (* TODO: Make this tag check simply a warning *)
+      let endName = Longident.parse $4 in
+      let _ = ensureTagsAreEqual start endName loc in
+      let child = $3 in
+      component [
+        (Labelled "children", child);
+        (Nolabel, mkexp_constructor_unit loc loc)
+      ] loc
+    }
+;
+
+jsx_without_leading_less:
+  | GREATER simple_expr_no_call* LESSSLASHGREATER {
+    let loc = mklocation $symbolstartpos $endpos in
+    let body = mktailexp_extension loc $2 None in
+    makeFrag loc body
+  }
+  | jsx_start_tag_and_args_without_leading_less SLASHGREATER {
+    let (component, _) = $1 in
+    let loc = mklocation $symbolstartpos $endpos in
+    component [
+      (Labelled "children", mktailexp_extension loc [] None);
+      (Nolabel, mkexp_constructor_unit loc loc)
+    ] loc
+  }
+  | jsx_start_tag_and_args_without_leading_less GREATER simple_expr_no_call* LESSSLASHIDENTGREATER {
+    let (component, start) = $1 in
+    let loc = mklocation $symbolstartpos $endpos in
+    (* TODO: Make this tag check simply a warning *)
+    let endName = Longident.parse $4 in
+    let _ = ensureTagsAreEqual start endName loc in
+    let siblings = if List.length $3 > 0 then $3 else [] in
+    component [
+      (Labelled "children", mktailexp_extension loc siblings None);
+      (Nolabel, mkexp_constructor_unit loc loc)
+    ] loc
+  }
+    | jsx_start_tag_and_args_without_leading_less greater_spread simple_expr_no_call LESSSLASHIDENTGREATER {
+    let (component, start) = $1 in
+    let loc = mklocation $symbolstartpos $endpos in
+    (* TODO: Make this tag check simply a warning *)
+    let endName = Longident.parse $4 in
+    let _ = ensureTagsAreEqual start endName loc in
+    let child = $3 in
+    component [
+      (Labelled "children", child);
+      (Nolabel, mkexp_constructor_unit loc loc)
+    ] loc
+  }
+;
+
+optional_expr_extension:
+  | (* empty *) { fun exp -> exp }
+  | item_extension_sugar { fun exp -> expression_extension $1 exp  }
+;
+
+(*
+ * Parsing of expressions is quite involved as it depends on context.
+ * At the top-level of a structure, expressions can't have attributes
+ * (those are attached to the structure).
+ * In other places, attributes are allowed.
+ *
+ * The generic parts are represented by unattributed_expr_template(_).
+ * Then unattributed_expr represents the concrete unattributed expr
+ * while expr adds an attribute rule to unattributed_expr_template.
+ *)
+%inline unattributed_expr_template(E):
+mark_position_exp
+  ( simple_expr
+    { $1 }
+  | FUN optional_expr_extension fun_def(EQUALGREATER,non_arrowed_core_type)
+    { $2 $3 }
+  | ES6_FUN es6_parameters EQUALGREATER expr
+    { let (ps, uncurried) = $2 in
+      let exp = List.fold_right mkexp_fun ps $4 in
+      if uncurried then
+        let loc = mklocation $startpos $endpos in
+        {exp with pexp_attributes = (uncurry_payload loc)::exp.pexp_attributes}
+      else exp
+    }
+  | ES6_FUN es6_parameters COLON non_arrowed_core_type EQUALGREATER expr
+    { let (ps, uncurried) = $2 in
+    let exp = List.fold_right mkexp_fun ps
+        (ghexp_constraint (mklocation $startpos($4) $endpos) $6 (Some $4, None))  in
+    if uncurried then
+      let loc = mklocation $startpos $endpos in
+      {exp with pexp_attributes = (uncurry_payload loc)::exp.pexp_attributes}
+    else exp
+    }
+
+  (* List style rules like this often need a special precendence
+     such as below_BAR in order to let the entire list "build up"
+   *)
+  | FUN optional_expr_extension match_cases(expr) %prec below_BAR
+    { $2 (mkexp (Pexp_function $3)) }
+  | SWITCH optional_expr_extension simple_expr_no_constructor
+    LBRACE match_cases(seq_expr) RBRACE
+    { $2 (mkexp (Pexp_match ($3, $5))) }
+  | TRY optional_expr_extension simple_expr_no_constructor
+    LBRACE match_cases(seq_expr) RBRACE
+    { $2 (mkexp (Pexp_try ($3, $5))) }
+  | TRY optional_expr_extension simple_expr_no_constructor WITH error
+    { syntax_error_exp (mklocation $startpos($5) $endpos($5)) "Invalid try with"}
+  | IF optional_expr_extension parenthesized_expr
+       simple_expr ioption(preceded(ELSE,expr))
+    { $2 (mkexp (Pexp_ifthenelse($3, $4, $5))) }
+  | WHILE optional_expr_extension parenthesized_expr simple_expr
+    { $2 (mkexp (Pexp_while($3, $4))) }
+  | FOR optional_expr_extension LPAREN pattern IN expr direction_flag expr RPAREN
+    simple_expr
+    { $2 (mkexp (Pexp_for($4, $6, $8, $7, $10))) }
+  | LPAREN COLONCOLON RPAREN LPAREN expr COMMA expr RPAREN
+    { let loc_colon = mklocation $startpos($2) $endpos($2) in
+      let loc = mklocation $symbolstartpos $endpos in
+      mkexp_cons loc_colon (mkexp ~ghost:true ~loc (Pexp_tuple[$5;$7])) loc
+    }
+  | E as_loc(infix_operator) expr
+    { let op = match $2.txt with
+      | "->" -> {$2 with txt = "|."}
+      | _ -> $2
+      in mkinfix $1 op $3
+    }
+  | E as_loc(infix_operator) error
+    { expecting (with_txt $2 "expression after infix operator") }
+  | as_loc(subtractive) expr %prec prec_unary
+    { mkuminus $1 $2 }
+  | as_loc(additive) expr %prec prec_unary
+    { mkuplus $1 $2 }
+  | as_loc(BANG {"!"}) expr %prec prec_unary
+    { mkexp(Pexp_apply(mkoperator $1, [Nolabel,$2])) }
+  | simple_expr DOT as_loc(label_longident) EQUAL expr
+    { mkexp(Pexp_setfield($1, $3, $5)) }
+  | simple_expr LBRACKET expr RBRACKET EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Pexp_ident(array_function ~loc "Array" "set") in
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp,
+                       [Nolabel,$1; Nolabel,$3; Nolabel,$6]))
+    }
+  | simple_expr DOT LBRACKET expr RBRACKET EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Pexp_ident(array_function ~loc "String" "set") in
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp,
+                       [Nolabel,$1; Nolabel,$4; Nolabel,$7]))
+    }
+  | simple_expr bigarray_access EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      bigarray_set ~loc $1 $2 $4
+    }
+  | as_loc(label) EQUAL expr
+    { mkexp(Pexp_setinstvar($1, $3)) }
+  | ASSERT simple_expr
+    { mkexp (Pexp_assert $2) }
+  | LAZY simple_expr
+    { mkexp (Pexp_lazy $2) }
+  (*
+   * Ternary is just a shortcut for:
+   *
+   *     switch expression { | true => expr1 | false => expr2 }
+   *
+   * The COLON token priority is below QUESTION so that the following parses:
+   *
+   *    x ? y :
+   *    z ? q : r
+   *
+   *  As
+   *
+   *    x ? y :
+   *    (z ? q : r)
+   *
+   *  Instead of:
+   *
+   *    (x ? y :
+   *    z) ? q : r
+   *
+   * When a question mark is seen, *this* parsing rule has lower priority so
+   * that we, instead, shift the qusetion mark so that the *latter* ternary is
+   * recognized first on the top of the stack. (z ? q : r).
+   *)
+  | E QUESTION expr COLON expr
+    { (* Should use ghost expressions, but not sure how that would work with source maps *)
+      (* So ? will become true and : becomes false for now*)
+      let loc_question = mklocation $startpos($2) $endpos($2) in
+      let loc_colon = mklocation $startpos($4) $endpos($4) in
+      let fauxTruePat =
+        Pat.mk ~loc:loc_question (Ppat_construct({txt = Lident "true"; loc = loc_question}, None)) in
+      let fauxFalsePat =
+        Pat.mk ~loc:loc_colon (Ppat_construct({txt = Lident "false"; loc = loc_colon}, None)) in
+      let fauxMatchCaseTrue = Exp.case fauxTruePat $3 in
+      let fauxMatchCaseFalse = Exp.case fauxFalsePat $5 in
+      mkexp (Pexp_match ($1, [fauxMatchCaseTrue; fauxMatchCaseFalse]))
+    }
+  ) {$1};
+
+(*
+ * Much like how patterns are partitioned into pattern/simple_pattern,
+ * expressions are divided into expr/simple_expr.
+ * expr: contains function application, but simple_expr doesn't (unless it's
+ * wrapped in parens).
+ *)
+expr:
+  | unattributed_expr_template(expr) { $1 }
+  | mark_position_exp(
+      attribute expr { {$2 with pexp_attributes = $1 :: $2.pexp_attributes} }
+      %prec attribute_precedence
+    )
+    { $1 }
+;
+
+unattributed_expr:
+  unattributed_expr_template(unattributed_expr) { $1 };
+
+parenthesized_expr:
+  | braced_expr
+    { $1 }
+  | LPAREN DOT RPAREN
+    { let loc = mklocation $startpos $endpos in
+      mkexp_constructor_unit ~uncurried:true loc loc }
+  | LPAREN expr_list RPAREN
+    { may_tuple $startpos $endpos $2 }
+;
+
+%inline array_expr_list:
+  LBRACKETBAR
+  lseparated_list(COMMA, opt_spread(expr_optional_constraint))
+  COMMA?
+  BARRBRACKET
+  { let msg = "Arrays can't use the `...` spread currently. Please use `concat` or other Array helpers." in
+    filter_raise_spread_syntax msg $2
+  };
+
+%inline bigarray_access:
+  DOT LBRACE lseparated_nonempty_list(COMMA, expr) COMMA? RBRACE { $3 }
+
+(* The grammar of simple exprs changes slightly according to context:
+ * - in most cases, calls (like f(x)) are allowed
+ * - in some contexts, calls are forbidden
+ *   (most notably JSX lists and rhs of a SHARPOP extension).
+ *
+ * simple_expr_template contains the generic parts,
+ * simple_expr, simple_expr_no_call and simple_expr_no_constructor the specialized instances.
+ *)
+%inline simple_expr_template(E):
+  | as_loc(val_longident) { mkexp (Pexp_ident $1) }
+  | constant
+    { let attrs, cst = $1 in mkexp ~attrs (Pexp_constant cst) }
+  | jsx                   { $1 }
+  | simple_expr_direct_argument { $1 }
+  | array_expr_list
+    { mkexp (Pexp_array $1) }
+  (* Not sure why this couldn't have just been below_SHARP (Answer: Being
+   * explicit about needing to wait for "as") *)
+  | as_loc(constr_longident) %prec prec_constant_constructor
+    { mkexp (Pexp_construct ($1, None)) }
+  | name_tag %prec prec_constant_constructor
+    { mkexp (Pexp_variant ($1, None)) }
+  | LPAREN expr_list RPAREN
+    { may_tuple $startpos $endpos $2 }
+  | as_loc(LPAREN) expr_list as_loc(error)
+    { unclosed_exp (with_txt $1 "(") (with_txt $3 ")") }
+  | E as_loc(POSTFIXOP)
+    { mkexp(Pexp_apply(mkoperator $2, [Nolabel, $1])) }
+  | as_loc(mod_longident) DOT LPAREN expr_list RPAREN
+    { mkexp(Pexp_open(Fresh, $1, may_tuple $startpos($3) $endpos($5) $4)) }
+  | mod_longident DOT as_loc(LPAREN) expr_list as_loc(error)
+    { unclosed_exp (with_txt $3 "(") (with_txt $5 ")") }
+  | E DOT as_loc(label_longident)
+    { mkexp(Pexp_field($1, $3)) }
+  | as_loc(mod_longident) DOT LBRACE RBRACE
+    { let loc = mklocation $symbolstartpos $endpos in
+      let pat = mkpat (Ppat_var (mkloc "this" loc)) in
+      mkexp(Pexp_open (Fresh, $1,
+                       mkexp(Pexp_object(Cstr.mk pat []))))
+    }
+  | E LBRACKET expr RBRACKET
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Pexp_ident(array_function ~loc "Array" "get") in
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp, [Nolabel,$1; Nolabel,$3]))
+    }
+  | E as_loc(LBRACKET) expr as_loc(error)
+    { unclosed_exp (with_txt $2 "(") (with_txt $4 ")") }
+  | E DOT LBRACKET expr RBRACKET
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Pexp_ident(array_function ~loc "String" "get") in
+      mkexp(Pexp_apply(mkexp ~ghost:true ~loc exp, [Nolabel,$1; Nolabel,$4]))
+    }
+  | E DOT as_loc(LBRACKET) expr as_loc(error)
+    { unclosed_exp (with_txt $3 "[") (with_txt $5 "]") }
+  | E bigarray_access
+    { let loc = mklocation $symbolstartpos $endpos in
+      bigarray_get ~loc $1 $2 }
+  | as_loc(mod_longident) DOT LBRACE record_expr RBRACE
+    { let (exten, fields) = $4 in
+      let loc = mklocation $symbolstartpos $endpos in
+      let rec_exp = mkexp ~loc (Pexp_record (fields, exten)) in
+      mkexp(Pexp_open(Fresh, $1, rec_exp))
+    }
+  | mod_longident DOT as_loc(LBRACE) record_expr as_loc(error)
+    { unclosed_exp (with_txt $3 "{") (with_txt $5 "}") }
+  | as_loc(mod_longident) DOT LBRACE record_expr_with_string_keys RBRACE
+    { let (exten, fields) = $4 in
+      let loc = mklocation $symbolstartpos $endpos in
+      let rec_exp = mkexp ~loc (Pexp_extension (mkloc ("bs.obj") loc,
+             PStr [mkstrexp (mkexp ~loc (Pexp_record(fields, exten))) []]))
+      in
+      mkexp(Pexp_open(Fresh, $1, rec_exp))
+    }
+  | mod_longident DOT as_loc(LBRACE) record_expr_with_string_keys as_loc(error)
+    { unclosed_exp (with_txt $3 "{") (with_txt $5 "}") }
+  | as_loc(mod_longident) DOT LBRACKETBAR expr_list BARRBRACKET
+    { let loc = mklocation $symbolstartpos $endpos in
+      let rec_exp = Exp.mk ~loc ~attrs:[] (Pexp_array $4) in
+      mkexp(Pexp_open(Fresh, $1, rec_exp))
+    }
+  | mod_longident DOT as_loc(LBRACKETBAR) expr_list as_loc(error)
+    { unclosed_exp (with_txt $3 "[|") (with_txt $5 "|]") }
+  (* Parse Module.[<Component> <div/> </Component>] *)
+  | as_loc(mod_longident) DOT LBRACKETLESS jsx_without_leading_less RBRACKET
+    { let seq, ext_opt = [$4], None in
+      let loc = mklocation $startpos($4) $endpos($4) in
+      let list_exp = make_real_exp (mktailexp_extension loc seq ext_opt) in
+      let list_exp = { list_exp with pexp_loc = loc } in
+      mkexp (Pexp_open (Fresh, $1, list_exp))
+    }
+  | as_loc(mod_longident) DOT LBRACKET RBRACKET
+    { let loc = mklocation $startpos($3) $endpos($4) in
+      let list_exp = make_real_exp (mktailexp_extension loc [] None) in
+      let list_exp = { list_exp with pexp_loc = loc } in
+      mkexp (Pexp_open (Fresh, $1, list_exp))
+    }
+  | as_loc(mod_longident) DOT LBRACKET expr_comma_seq_extension RBRACKET
+    { let seq, ext_opt = $4 in
+      let loc = mklocation $startpos($4) $endpos($4) in
+      let list_exp = make_real_exp (mktailexp_extension loc seq ext_opt) in
+      let list_exp = { list_exp with pexp_loc = loc } in
+      mkexp (Pexp_open (Fresh, $1, list_exp))
+    }
+  | as_loc(PREFIXOP) E %prec below_DOT_AND_SHARP
+    { mkexp(Pexp_apply(mkoperator $1, [Nolabel, $2])) }
+  (**
+   * Must be below_DOT_AND_SHARP so that the parser waits for several dots for
+   * nested record access that the bang should apply to.
+   *
+   * !x.y.z should be parsed as !(((x).y).z)
+   *)
+  (*| as_loc(BANG {"!"}) E %prec below_DOT_AND_SHARP
+    { mkexp (Pexp_apply(mkoperator $1, [Nolabel,$2])) }*)
+  | NEW as_loc(class_longident)
+    { mkexp (Pexp_new $2) }
+  | as_loc(mod_longident) DOT LBRACELESS field_expr_list COMMA? GREATERRBRACE
+    { let loc = mklocation $symbolstartpos $endpos in
+      let exp = Exp.mk ~loc ~attrs:[] (Pexp_override $4) in
+      mkexp (Pexp_open(Fresh, $1, exp))
+    }
+  | mod_longident DOT as_loc(LBRACELESS) field_expr_list COMMA? as_loc(error)
+    { unclosed_exp (with_txt $3 "{<") (with_txt $6 ">}") }
+  | E SHARP label
+    { mkexp (Pexp_send($1, $3)) }
+  | E as_loc(SHARPOP) simple_expr_no_call
+    { mkinfixop $1 (mkoperator $2) $3 }
+  | E as_loc(SHARPEQUAL) simple_expr
+    { let op = { $2 with txt = "#=" } in
+      mkinfixop $1 (mkoperator op) $3 }
+  | E as_loc(MINUSGREATER) simple_expr_no_call
+    { mkinfixop $1 (mkoperator {$2 with txt = "|."}) $3 }
+  | as_loc(mod_longident) DOT LPAREN MODULE module_expr COLON package_type RPAREN
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkexp (Pexp_open(Fresh, $1,
+        mkexp ~loc (Pexp_constraint (mkexp ~ghost:true ~loc (Pexp_pack $5),
+                                     mktyp ~ghost:true ~loc (Ptyp_package $7)))))
+    }
+  | mod_longident DOT as_loc(LPAREN) MODULE module_expr COLON as_loc(error)
+    { unclosed_exp (with_txt $3 "(") (with_txt $7 ")")}
+  | extension
+    { mkexp (Pexp_extension $1) }
+;
+
+%inline simple_expr: simple_expr_call { mkexp_app_rev $startpos $endpos $1 };
+
+simple_expr_no_constructor:
+  mark_position_exp(simple_expr_template(simple_expr_no_constructor)) { $1 };
+
+simple_expr_template_constructor:
+  | as_loc(constr_longident)
+    mark_position_exp
+      ( non_labeled_argument_list   { mkexp (Pexp_tuple($1)) }
+      | simple_expr_direct_argument { $1 }
+      )
+    { mkExplicitArityTupleExp (Pexp_construct($1, Some $2))
+    }
+  | name_tag
+    mark_position_exp
+      ( non_labeled_argument_list
+        { (* only wrap in a tuple if there are more than one arguments *)
+          match $1 with
+          | [x] -> x
+          | l -> mkexp (Pexp_tuple(l))
+        }
+      | simple_expr_direct_argument { $1 }
+      )
+    { mkexp(Pexp_variant($1, Some $2)) }
+;
+
+simple_expr_no_call:
+  | mark_position_exp(simple_expr_template(simple_expr_no_call)) { $1 }
+  | simple_expr_template_constructor { $1 }
+;
+
+simple_expr_call:
+  | mark_position_exp(simple_expr_template(simple_expr)) { ($1, []) }
+  | simple_expr_call labeled_arguments
+    { let (body, args) = $1 in
+      (body, List.rev_append $2 args) }
+  | LBRACKET expr_comma_seq_extension RBRACKET
+    { let seq, ext_opt = $2 in
+      let loc = mklocation $startpos($2) $endpos($2) in
+      (make_real_exp (mktailexp_extension loc seq ext_opt), [])
+    }
+  | simple_expr_template_constructor { ($1, []) }
+;
+
+simple_expr_direct_argument:
+  (*
+     Because [< is a special token, the <ident and <> won't be picked up as separate
+     tokens, when a list begins witha JSX tag. So we special case it.
+     (todo: pick totally different syntax for polymorphic variance types to avoid
+     the issue alltogether.
+
+     first token
+     /\
+     [<ident    args />  , remainingitems ]
+     [<>                 , remainingitems ]
+   *)
+  | braced_expr { $1 }
+  | LBRACKETLESS jsx_without_leading_less COMMA expr_comma_seq_extension RBRACKET
+    { let entireLoc = mklocation $startpos($1) $endpos($4) in
+      let (seq, ext_opt) = $4 in
+      mktailexp_extension entireLoc ($2::seq) ext_opt
+    }
+  | LBRACKETLESS jsx_without_leading_less RBRACKET
+    { let entireLoc = mklocation $startpos($1) $endpos($3) in
+      mktailexp_extension entireLoc ($2::[]) None
+    }
+  | LBRACKETLESS jsx_without_leading_less COMMA RBRACKET
+    { let entireLoc = mklocation $startpos($1) $endpos($4) in
+      mktailexp_extension entireLoc [$2] None
+    }
+  | LBRACELESS field_expr_list COMMA? GREATERRBRACE
+    { mkexp (Pexp_override $2) }
+  | as_loc(LBRACELESS) field_expr_list COMMA? as_loc(error)
+    { unclosed_exp (with_txt $1 "{<") (with_txt $4 ">}" ) }
+  | LBRACELESS GREATERRBRACE
+    { mkexp (Pexp_override [])}
+  | LPAREN MODULE module_expr RPAREN
+    { mkexp (Pexp_pack $3) }
+  | LPAREN MODULE module_expr COLON package_type RPAREN
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkexp (Pexp_constraint (mkexp ~ghost:true ~loc (Pexp_pack $3),
+                              mktyp ~ghost:true ~loc (Ptyp_package $5)))
+    }
+  | as_loc(LPAREN) MODULE module_expr COLON as_loc(error)
+    { unclosed_exp (with_txt $1 "(") (with_txt $5 ")") }
+;
+
+%inline non_labelled_expr_comma_list:
+  lseparated_nonempty_list(COMMA, expr_optional_constraint) COMMA? { $1 };
+
+non_labeled_argument_list:
+  | parenthesized(non_labelled_expr_comma_list) { $1 }
+  | LPAREN RPAREN
+    { let loc = mklocation $startpos $endpos in
+      [mkexp_constructor_unit loc loc] }
+;
+
+%inline labelled_expr_comma_list:
+  lseparated_list(COMMA, uncurried_labeled_expr) COMMA? { $1 };
+
+labeled_arguments:
+  | mark_position_exp(simple_expr_direct_argument)
+    { [(Nolabel, $1)] }
+  | parenthesized(labelled_expr_comma_list)
+    { match $1 with
+      | [] -> let loc = mklocation $startpos $endpos in
+              [(Nolabel, mkexp_constructor_unit loc loc)]
+      | xs -> xs
+    }
+  | LPAREN DOT RPAREN
+    { let loc = mklocation $startpos $endpos in
+      [(Nolabel, mkexp_constructor_unit ~uncurried:true loc loc)]
+    }
+;
+
+labeled_expr_constraint:
+  | expr_optional_constraint { fun _punned -> $1 }
+  | type_constraint
+    { fun punned ->
+      let exp = mkexp (Pexp_ident punned) ~loc:punned.loc in
+      match $1 with
+      | typ ->
+        let loc = mklocation punned.loc.loc_start $endpos in
+        ghexp_constraint loc exp typ
+    }
+;
+
+%inline uncurried_labeled_expr:
+  | DOT? labeled_expr {
+    let uncurried = match $1 with | Some _ -> true | None -> false in
+    if uncurried then
+      let (lbl, argExpr) = $2 in
+      let loc = mklocation $startpos $endpos in
+      let up = uncurry_payload ~name:"uncurry" loc in
+      (lbl, {argExpr with pexp_attributes = up::argExpr.pexp_attributes})
+    else $2
+  }
+;
+
+longident_type_constraint:
+ | as_loc(val_longident) type_constraint?
+ { $1, $2 }
+
+labeled_expr:
+  | expr_optional_constraint { (Nolabel, $1) }
+  | TILDE as_loc(either(parenthesized(longident_type_constraint), longident_type_constraint))
+    { (* add(~a, ~b) -> parses ~a & ~b *)
+      let lident_loc, maybe_typ = $2.txt in
+      let exp = mkexp (Pexp_ident lident_loc) ~loc:lident_loc.loc in
+      let labeled_exp = match maybe_typ with
+      | None -> exp
+      | Some typ ->
+          ghexp_constraint $2.loc exp typ
+      in
+      (Labelled (Longident.last lident_loc.txt), labeled_exp)
+    }
+  | TILDE as_loc(val_longident) QUESTION
+    { (* foo(~a?)  -> parses ~a? *)
+      let exp = mkexp (Pexp_ident $2) ~loc:$2.loc in
+      (Optional (Longident.last $2.txt), exp)
+    }
+  | TILDE as_loc(LIDENT) EQUAL optional labeled_expr_constraint
+    { (* foo(~bar=?Some(1)) or add(~x=1, ~y=2) -> parses ~bar=?Some(1) & ~x=1 & ~y=1 *)
+      ($4 $2.txt, $5 { $2 with txt = Lident $2.txt })
+    }
+  | TILDE as_loc(LIDENT) EQUAL optional as_loc(UNDERSCORE)
+    { (* foo(~l =_) *)
+      let loc = $5.loc in
+      let exp = mkexp (Pexp_ident (mkloc (Lident "_") loc)) ~loc in
+      ($4 $2.txt, exp)
+    }
+  | as_loc(UNDERSCORE)
+    { (* foo(_) *)
+      let loc = $1.loc in
+      let exp = mkexp (Pexp_ident (mkloc (Lident "_") loc)) ~loc in
+      (Nolabel, exp)
+    }
+;
+
+%inline and_let_binding:
+  (* AND bindings don't accept a preceeding extension ID, but do accept
+   * preceeding attribute*. These preceeding attribute* will cause an
+   * error if this is an *expression * let binding. Otherwise, they become
+   * attribute* on the structure item for the "and" binding.
+   *)
+  item_attributes AND let_binding_body
+  { let pat, expr = $3 in
+    Vb.mk ~loc:(mklocation $symbolstartpos $endpos) ~attrs:$1 pat expr }
+;
+
+let_bindings: let_binding and_let_binding* { addlbs $1 $2 };
+
+let_binding:
+  (* Form with item extension sugar *)
+  item_attributes LET item_extension_sugar? rec_flag let_binding_body
+  { let loc = mklocation $symbolstartpos $endpos in
+    let pat, expr = $5 in
+    mklbs $3 $4 (Vb.mk ~loc ~attrs:$1 pat expr) loc }
+;
+
+let_binding_body:
+  | simple_pattern_ident type_constraint EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      ($1, ghexp_constraint loc $4 $2) }
+  | simple_pattern_ident fun_def(EQUAL,core_type)
+    { ($1, $2) }
+  | simple_pattern_ident COLON preceded(QUOTE,ident)+ DOT core_type
+      EQUAL mark_position_exp(expr)
+    { let typ = mktyp ~ghost:true (Ptyp_poly($3, $5)) in
+      let loc = mklocation $symbolstartpos $endpos in
+      (mkpat ~ghost:true ~loc (Ppat_constraint($1, typ)), $7)
+    }
+  | simple_pattern_ident COLON TYPE LIDENT+ DOT core_type
+      EQUAL mark_position_exp(expr)
+  (* Because core_type will appear to contain "type constructors" since the
+   * type variables listed in LIDENT+ don't have leading single quotes, we
+   * have to call [varify_constructors] (which is what [wrap_type_annotation]
+   * does among other things) to turn those "type constructors" that correspond
+   * to LIDENT+ into regular type variables. I don't think this should be
+   * done in the parser!
+   *)
+  (* In general, this is a very strange transformation that occurs in the
+   * standard OCaml parser, but producing the same strange transformation, and
+   * being able to recover original code from the result has the benefit that
+   * this syntax will integrate seamlessly with ASTs produced by the standard
+   * OCaml parser.
+   *
+   *  let s : type a . core_type = body
+   *
+   *  LET_BINDING:
+   *  Ppat_constraint(Ppat_var s, Ptyp_poly(newtypes, varified_core_type))
+   *  Pexp_newtype..(a, Pexp_constraint(body, NOT_varified_core_type))
+   *
+   *  When [a] is in the first arg to [PTyp_poly] the second arg [core_type]
+   *  expects to see [a] and ['a] is not allowed anywhere.
+   *  When pretty printing, we must reverse this entire process!
+   *
+   *  All of this is consistent with the Manual which states:
+   *
+   *    let rec f : type t1 t2. t1 * t2 list -> t1 = ...
+   *
+   *  is automatically expanded into
+   *
+   *    let rec f : 't1 't2. 't1 * 't2 list -> 't1 =
+   *      fun (type t1) (type t2) -> (... : t1 * t2 list -> t1)
+   *
+   * So therefore we end up generating the following two forms of parse trees
+   * for the two primary forms of explicitly polymorphic type annotations:
+   *
+   *
+   *           /-----------Ppat_constraint--------\ /-PExp_constraint--\
+   *       let x: locallyAbstractTypes . typeVars       =      exp
+   *
+   *     or
+   *           /-------------Ppat_constraint-----------\     /----PExp_constraint------\
+   *       let x: type abstractTypes . varified_core_type = (exp : core_type_non_varified)
+   *       where carified_core_type must equal (varify_constructors core_type_non_varified)
+   *
+   *     And in the later case
+   *
+   *)
+   { let exp, poly = wrap_type_annotation $4 $6 $8 in
+     let loc = mklocation $symbolstartpos $endpos in
+     (mkpat ~ghost:true ~loc (Ppat_constraint($1, poly)), exp)
+   }
+
+  (* The combination of the following two rules encompass every type of
+   * pattern *except* val_identifier. The fact that we want handle the
+   * val_ident separately as a separate rule in let_binding_body alone justifies the
+   * need for the strange structuring of
+   * [pattern]/[simple_pattern_not_ident]/[simple_pattern] - it allows us
+   * to isolate [val_ident] in the special case of [let_binding_body].
+   *
+   * TODO:
+   * Unfortunately, it means we cannot do: let (myCurriedFunc: int -> int) a -> a;
+   *)
+  | pattern EQUAL expr
+    { ($1, $3) }
+  | simple_pattern_not_ident COLON core_type EQUAL expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      (mkpat ~loc (Ppat_constraint($1, $3)), $5)
+    }
+;
+
+(*
+ * TODO:
+ * In OCaml, the following function binding would be parsed by the function
+ * parsers but would return a non function. Coincidentally, everything just worked.
+ *   let x: int = 10;
+ * Since in Reason, function bindings always use arrows, it's wrong to rely
+ * on function parsers to return non function bindings:
+ *   let x: int -> 10;
+ *   let y (:returnType) -> 20;  (* wat *)
+ *)
+
+%inline match_cases(EXPR): lnonempty_list(match_case(EXPR)) { $1 };
+
+match_case(EXPR):
+  as_loc(BAR) pattern preceded(WHEN,expr)? EQUALGREATER EXPR
+  { let pat = {$2 with ppat_loc =
+      { $2.ppat_loc with
+        loc_start = $1.loc.loc_start
+      }
+    } in
+    Exp.case pat ?guard:$3 $5 }
+;
+
+fun_def(DELIM, typ):
+  labeled_pattern_list
+  preceded(COLON,typ)?
+  either(preceded(DELIM, expr), braced_expr)
+  { let loc = mklocation $startpos $endpos in
+    let (pl, uncurried) = $1 in
+    let exp = List.fold_right mkexp_fun pl
+        (match $2 with
+        | None -> $3
+        | Some ct -> Exp.constraint_ ~loc $3 ct)
+    in
+    if uncurried then
+      {exp with pexp_attributes = (uncurry_payload loc)::exp.pexp_attributes}
+    else exp
+  }
+;
+
+(* At least one comma delimited: Each item optionally annotated. *)
+expr_list:
+  lseparated_nonempty_list(COMMA, expr_optional_constraint) COMMA?
+  { $1 }
+;
+
+(* [x, y, z, ...n] --> ([x,y,z], Some n) *)
+expr_comma_seq_extension:
+  lseparated_nonempty_list(COMMA, opt_spread(expr_optional_constraint)) COMMA?
+  { match List.rev $1 with
+    (* Check if the last expr has been spread with `...` *)
+    | ((dotdotdot, e) as hd)::es ->
+      let (es, ext) = match dotdotdot with
+      | Some _ -> (es, Some e)
+      | None -> (hd::es, None)
+      in
+      let msg = "Lists can only have one `...` spread, at the end.
+Explanation: lists are singly-linked list, where a node contains a value and points to the next node. `[a, ...bc]` efficiently creates a new item and links `bc` as its next nodes. `[...bc, a]` would be expensive, as it'd need to traverse `bc` and prepend each item to `a` one by one. We therefore disallow such syntax sugar.
+Solution: directly use `concat` or other List helpers." in
+      let exprList = filter_raise_spread_syntax msg es in
+      (List.rev exprList, ext)
+    | [] -> [], None
+  }
+;
+
+(**
+ * See note about tuple patterns. There are few cases where expressions may be
+ * type constrained without requiring additional parens, and inside of tuples
+ * are one exception.
+ *)
+expr_optional_constraint:
+  | expr { $1 }
+  | expr type_constraint
+    { ghexp_constraint (mklocation $symbolstartpos $endpos) $1 $2 }
+;
+
+record_expr:
+  | DOTDOTDOT expr_optional_constraint lnonempty_list(preceded(COMMA,
+    opt_spread(lbl_expr))) COMMA?
+    { let exprList = filter_raise_spread_syntax record_exp_spread_msg $3
+      in (Some $2, exprList)
+    }
+  | DOTDOTDOT
+    expr_optional_constraint SEMI
+    lseparated_nonempty_list(COMMA, opt_spread(lbl_expr)) COMMA?
+    { let loc = mklocation $startpos($3) $endpos($3) in
+      raise_record_trailing_semi_error loc
+    }
+  | DOTDOTDOT
+    expr_optional_constraint
+    lnonempty_list(preceded(COMMA, opt_spread(lbl_expr))) SEMI
+    { let loc = mklocation $startpos($4) $endpos($4) in
+      raise_record_trailing_semi_error loc
+    }
+  | non_punned_lbl_expr COMMA?
+    { (None, [$1]) }
+  | non_punned_lbl_expr SEMI
+    { let loc = mklocation $startpos($2) $endpos($2) in
+      raise_record_trailing_semi_error loc }
+  | lbl_expr lnonempty_list(preceded(COMMA, opt_spread(lbl_expr))) COMMA?
+    { let exprList = filter_raise_spread_syntax record_exp_spread_msg $2 in
+      (None, $1 :: exprList) }
+  | lbl_expr lnonempty_list(preceded(COMMA, opt_spread(lbl_expr))) SEMI
+    { let loc = mklocation $startpos($3) $endpos($3) in
+      raise_record_trailing_semi_error loc }
+;
+
+%inline non_punned_lbl_expr:
+  | as_loc(label_longident) COLON expr { ($1, $3) }
+;
+
+%inline punned_lbl_expr:
+  | as_loc(label_longident) { ($1, exp_of_label $1) }
+;
+
+%inline lbl_expr:
+  | non_punned_lbl_expr {$1}
+  | punned_lbl_expr {$1}
+;
+
+record_expr_with_string_keys:
+  | DOTDOTDOT expr_optional_constraint COMMA string_literal_exprs_maybe_punned
+    { (Some $2, $4) }
+  | STRING COLON expr COMMA?
+    { let loc = mklocation $symbolstartpos $endpos in
+      let (s, _, _) = $1 in
+      let lident_lident_loc = mkloc (Lident s) loc in
+      (None, [(lident_lident_loc, $3)])
+    }
+  | string_literal_expr_maybe_punned_with_comma string_literal_exprs_maybe_punned {
+    (None, $1 :: $2)
+  }
+;
+
+string_literal_exprs_maybe_punned:
+  lseparated_nonempty_list(COMMA, string_literal_expr_maybe_punned) COMMA? { $1 };
+
+(* Had to manually inline these two forms for some reason *)
+string_literal_expr_maybe_punned_with_comma:
+  | STRING COMMA
+  { let loc = mklocation $startpos $endpos in
+    let (s, _, _) = $1 in
+    let lident_lident_loc = mkloc (Lident s) loc in
+    let exp = mkexp ~loc (Pexp_ident lident_lident_loc) in
+    (lident_lident_loc, exp)
+  }
+  | STRING COLON expr COMMA
+  { let loc = mklocation $startpos $endpos in
+    let (s, _, _) = $1 in
+    let lident_lident_loc = mkloc (Lident s) loc in
+    let exp = $3 in
+    (lident_lident_loc, exp)
+  }
+;
+string_literal_expr_maybe_punned:
+  STRING preceded(COLON, expr)?
+  { let loc = mklocation $startpos $endpos in
+    let (s, _, _) = $1 in
+    let lident_lident_loc = mkloc (Lident s) loc in
+    let exp = match $2 with
+      | Some x -> x
+      | None -> mkexp ~loc (Pexp_ident lident_lident_loc)
+    in
+    (lident_lident_loc, exp)
+  }
+;
+
+(**
+ * field_expr is distinct from record_expr because labels cannot/shouldn't be scoped.
+ *)
+field_expr:
+  (* Using LIDENT instead of label here, because a reduce/reduce conflict occurs on:
+   *   {blah:x}
+   *
+   * After `blah`, the parser couldn't tell whether to reduce `label` or
+   * `val_ident`. So inlining the terminal here to avoid the whole decision.
+   * Another approach would have been to place the `label` rule at at a precedence
+   * of below_COLON or something.
+   *)
+ | as_loc(LIDENT) COLON expr
+   { ($1, $3) }
+ | LIDENT
+   { let loc = mklocation $symbolstartpos $endpos in
+     let lident_loc = mkloc $1 loc in
+     let lident_lident_loc = mkloc (Lident $1) loc in
+     (lident_loc, mkexp (Pexp_ident lident_lident_loc))
+   }
+;
+
+%inline field_expr_list: lseparated_nonempty_list(COMMA, field_expr) { $1 };
+
+(* Allows for Ptyp_package core types without parens in the context
+ * of a "type_constraint":
+ * let x: module Foo.Bar.Baz = (module FirstClass)
+ *        ^^^^^^^^^^^^^^^^^^
+ *)
+%inline module_constraint_type:
+  mark_position_typ
+  (MODULE package_type
+    { mktyp(Ptyp_package($2)) }
+  ) {$1}
+;
+
+type_constraint:
+  | COLON core_type
+      preceded(COLONGREATER,core_type)?
+    { (Some $2, $3) }
+  | COLONGREATER core_type
+    { (None, Some $2) }
+  | COLON module_constraint_type
+    { (Some $2, None) }
+;
+
+(* Patterns *)
+
+pattern:
+  | pattern_without_or { $1 }
+  | mark_position_pat(pattern BAR pattern { mkpat(Ppat_or($1, $3)) }) { $1 }
+;
+
+%inline pat_comma_list:
+  lseparated_nonempty_list(COMMA, pattern_optional_constraint) COMMA? { $1 };
+
+pattern_constructor_argument:
+  | simple_pattern_direct_argument
+    { [$1] }
+  | parenthesized(pat_comma_list)
+    { $1 }
+;
+
+(**
+* Provides sugar for pattern matching on a constructor pattern with a 'direct' argument.
+* Example:
+* | Foo () => () is sugar for | Foo(()) => ()
+* | Foo [a, b, c] => () is sugar for | Foo([a, b, c]) => ()
+* | Foo [|x, y|] => () is sugar for | Foo([|x, y|]) => ()
+* }
+*)
+simple_pattern_direct_argument:
+mark_position_pat (
+   as_loc(constr_longident)
+    { mkpat(Ppat_construct(mkloc $1.txt $1.loc, None)) }
+  | simple_delimited_pattern { $1 }
+  ) {$1}
+;
+
+pattern_without_or:
+mark_position_pat
+  ( simple_pattern { $1 }
+
+  | pattern_without_or AS as_loc(val_ident)
+    { mkpat(Ppat_alias($1, $3)) }
+
+  | pattern_without_or AS as_loc(error)
+    { expecting_pat (with_txt $3 "identifier") }
+  (**
+    * Parses a (comma-less) list of patterns into a tuple, or a single pattern
+    * (if there is only one item in the list). This is kind of sloppy as there
+    * should probably be a different AST construct for the syntax construct this
+    * is used in (multiple constructor arguments). The things passed to
+    * constructors are not actually tuples either in underlying representation or
+    * semantics (they are not first class).
+    *)
+  | as_loc(constr_longident) pattern_constructor_argument
+    (* the first case is `| Foo(_)` and doesn't need explicit_arity attached. Actually, something like `| Foo(1)` doesn't either, but we
+      keep explicit_arity on the latter anyways because why not. But for `| Foo(_)` in particular, it's convenient to have explicit_arity
+      removed, so that you can have the following shortcut:
+      | Foo _ _ _ _ _
+      vs.
+      | Foo _
+    *)
+    { match is_pattern_list_single_any $2 with
+      | Some singleAnyPat ->
+        mkpat (Ppat_construct($1, Some singleAnyPat))
+      | None ->
+        let loc = mklocation $symbolstartpos $endpos in
+        let argPattern = simple_pattern_list_to_tuple ~loc $2 in
+        mkExplicitArityTuplePat (Ppat_construct($1, Some argPattern))
+    }
+
+  | name_tag simple_pattern { mkpat (Ppat_variant($1, Some $2)) }
+
+  | pattern_without_or as_loc(COLONCOLON) pattern_without_or
+    { raiseSyntaxErrorFromSyntaxUtils $2.loc
+        ":: is not supported in Reason, please use [hd, ...tl] instead" }
+
+  | pattern_without_or COLONCOLON as_loc(error)
+    { expecting_pat (with_txt $3 "pattern") }
+
+  | LPAREN COLONCOLON RPAREN LPAREN pattern_without_or COMMA pattern_without_or RPAREN
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkpat_cons (mkpat ~ghost:true ~loc (Ppat_tuple[$5;$7])) loc
+    }
+
+  | as_loc(LPAREN) COLONCOLON RPAREN LPAREN
+      pattern_without_or COMMA pattern_without_or as_loc(error)
+    { unclosed_pat (with_txt $1 "(") (with_txt $8 ")") }
+
+  | EXCEPTION pattern_without_or %prec prec_constr_appl
+    { mkpat(Ppat_exception $2) }
+
+  | LAZY simple_pattern { mkpat(Ppat_lazy $2) }
+
+  (**
+   * Attribute "attribute" everything to the left of the attribute,
+   * up until the point of to the start of an expression, left paren, left
+   * bracket, comma, bar - whichever comes first.
+   *)
+  | attribute pattern_without_or %prec attribute_precedence
+    { {$2 with ppat_attributes = $1 :: $2.ppat_attributes} }
+
+  ) {$1};
+
+(* A "simple pattern" is either a value identifier, or it is a
+ * simple *non*value identifier.
+ *
+ * A "pattern" (the more general) is the set of all simple patterns,
+ * but also with:
+ * - more information such as `as X`, `lazy` etc.
+ *
+ * "labeled_simple_pattern"s contain the set of all simple_patterns, but also
+ * include patterns suitable in function bindings where labeled arguments are
+ * accepted.
+ *
+ * But, in all patterns, it seems type constraints must be grouped within some
+ * parens or something.
+ *)
+simple_pattern:
+  | simple_pattern_ident
+  | simple_pattern_not_ident { $1 }
+;
+
+simple_pattern_ident:
+  as_loc(val_ident) { mkpat ~loc:$1.loc (Ppat_var $1) }
+;
+
+simple_pattern_not_ident:
+mark_position_pat
+  ( UNDERSCORE
+    { mkpat (Ppat_any) }
+  | signed_constant
+    { let attrs, cst = $1 in mkpat ~attrs (Ppat_constant cst) }
+  | signed_constant DOTDOT signed_constant
+    { mkpat (Ppat_interval (snd $1, snd $3)) }
+  | as_loc(constr_longident)
+    { mkpat (Ppat_construct ($1, None)) }
+  | name_tag
+    { mkpat (Ppat_variant ($1, None)) }
+  | SHARP type_longident
+    { mkpat (Ppat_type ($2)) }
+  | as_loc(LBRACKETBAR) pattern_comma_list SEMI? as_loc(error)
+    { unclosed_pat (with_txt $1 "[|") (with_txt $4 "|]") }
+  | LPAREN lseparated_nonempty_list(COMMA, pattern_optional_constraint) COMMA? RPAREN
+    { match $2 with
+      | [] -> (* This shouldn't be possible *)
+        let loc = mklocation $startpos $endpos in
+        mkpat_constructor_unit loc loc
+      | [hd] -> hd
+      | _ :: _ -> mkpat (Ppat_tuple $2)
+    }
+  | as_loc(LPAREN) pattern as_loc(error)
+    { unclosed_pat (with_txt $1 "(") (with_txt $3 ")") }
+  | as_loc(LPAREN) pattern COLON core_type as_loc(error)
+    { unclosed_pat (with_txt $1 "(") (with_txt $5 ")") }
+  | LPAREN pattern COLON as_loc(error)
+    { expecting_pat (with_txt $4 "type") }
+  | LPAREN MODULE as_loc(UIDENT) RPAREN
+    { mkpat(Ppat_unpack($3)) }
+  | simple_pattern_not_ident_
+    { $1 }
+  | extension
+    { mkpat(Ppat_extension $1) }
+  ) {$1};
+
+simple_pattern_not_ident_:
+  | simple_delimited_pattern
+    { $1 }
+  | as_loc(mod_longident) DOT simple_delimited_pattern
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkpat ~loc (Ppat_open ($1, $3))
+    }
+  | as_loc(mod_longident) DOT LPAREN pattern RPAREN
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkpat ~loc (Ppat_open ($1, $4)) }
+  | as_loc(mod_longident) DOT as_loc(LBRACKET RBRACKET {Lident "[]"})
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkpat ~loc (Ppat_open($1, mkpat ~loc:$3.loc (Ppat_construct($3, None)))) }
+  | as_loc(mod_longident) DOT as_loc(LPAREN RPAREN {Lident "()"})
+    { let loc = mklocation $symbolstartpos $endpos in
+      mkpat ~loc (Ppat_open($1, mkpat ~loc:$3.loc (Ppat_construct($3, None)))) }
+
+%inline simple_delimited_pattern:
+  | record_pattern { $1 }
+  | list_pattern   { $1 }
+  | array_pattern  { $1 }
+
+%inline record_pattern:
+    LBRACE lbl_pattern_list RBRACE
+    { let (fields, closed) = $2 in mkpat (Ppat_record (fields, closed)) }
+  | as_loc(LBRACE) lbl_pattern_list as_loc(error)
+    { unclosed_pat (with_txt $1 "{") (with_txt $3 "}") }
+;
+
+%inline list_pattern:
+    LBRACKET pattern_comma_list_extension RBRACKET
+    { make_real_pat (mktailpat_extension (mklocation $startpos($2) $endpos($2)) $2) }
+  | as_loc(LBRACKET) pattern_comma_list_extension as_loc(error)
+    { unclosed_pat (with_txt $1 "[") (with_txt $3 "]") }
+;
+
+%inline array_pattern:
+    LBRACKETBAR loption(terminated(pattern_comma_list,COMMA?)) BARRBRACKET
+    { mkpat (Ppat_array $2) }
+;
+
+pattern_optional_constraint:
+mark_position_pat
+  ( pattern                 { $1 }
+  | pattern COLON core_type
+    { mkpat(Ppat_constraint($1, $3)) }
+  (* If we kill the `let module …` syntax, this can be placed inside pattern.
+   * Allows parsing of
+   *  let foo = (type a, module X: X_t with type t = a) => X.a;
+   *                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   * The `module` keyword after the colon is optional, because `module X`
+   * clearly indicates that we're dealing with a Ppat_unpack here.
+   *)
+  | MODULE as_loc(UIDENT) COLON MODULE? package_type
+    { mkpat(
+        Ppat_constraint(
+          mkpat(Ppat_unpack($2)),
+          let loc = match $4 with
+          | Some _ -> mklocation $startpos($4) $endpos($5)
+          | None -> mklocation $startpos($5) $endpos($5)
+          in
+          mktyp ~loc (Ptyp_package($5)))) }
+  ) {$1};
+;
+
+%inline pattern_comma_list:
+  lseparated_nonempty_list(COMMA, opt_spread(pattern))
+  { let msg = "Array's `...` spread is not supported in pattern matches.
+Explanation: such spread would create a subarray; out of performance concern, our pattern matching currently guarantees to never create new intermediate data.
+Solution: if it's to validate the first few elements, use a `when` clause + Array size check + `get` checks on the current pattern. If it's to obtain a subarray, use `Array.sub` or `Belt.Array.slice`." in
+    filter_raise_spread_syntax msg $1 };
+
+(* [x, y, z, ...n] --> ([x,y,z], Some n) *)
+pattern_comma_list_extension:
+  lseparated_nonempty_list(COMMA, opt_spread(pattern)) COMMA?
+  { match List.rev $1 with
+    (* spread syntax is only allowed at the end *)
+    | ((dotdotdot, p) as hd)::ps ->
+      let (ps, spreadPat) = match dotdotdot with
+      | Some _ -> (ps, Some p)
+      | None -> (hd::ps, None)
+      in
+      let msg = "List pattern matches only supports one `...` spread, at the end.
+Explanation: a list spread at the tail is efficient, but a spread in the middle would create new list(s); out of performance concern, our pattern matching currently guarantees to never create new intermediate data." in
+      let patList = filter_raise_spread_syntax msg ps in
+      (List.rev patList, spreadPat)
+    | [] -> [], None
+  };
+;
+
+_lbl_pattern_list:
+  | opt_spread(lbl_pattern)                            { ([$1], Closed) }
+  | opt_spread(lbl_pattern) COMMA                      { ([$1], Closed) }
+  | opt_spread(lbl_pattern) COMMA UNDERSCORE COMMA?    { ([$1], Open)   }
+  | opt_spread(lbl_pattern) COMMA _lbl_pattern_list
+    { let (fields, closed) = $3 in $1 :: fields, closed }
+;
+
+%inline lbl_pattern_list:
+  _lbl_pattern_list
+  { let (fields, closed) = $1 in
+    (filter_raise_spread_syntax record_pat_spread_msg fields, closed)
+  }
+;
+
+lbl_pattern:
+  | as_loc(label_longident) COLON pattern { ($1,$3) }
+  | as_loc(label_longident)               { ($1, pat_of_label $1) }
+  | as_loc(label_longident) AS as_loc(val_ident)
+    { (* punning with alias eg. {ReasonReact.state as prevState}
+       *  -> {ReasonReact.state: state as prevState} *)
+      ($1, mkpat(Ppat_alias(pat_of_label $1, $3)))
+    }
+;
+
+(* Primitive declarations *)
+
+primitive_declaration: nonempty_list(STRING { let (s, _, _) = $1 in s }) {$1};
+
+(* Type declarations
+
+   The rule for declaring multiple types, 'type t = ... and u = ...', is
+   written in a "continuation-passing-style". In pseudo-code:
+
+   Rather than having rules like:
+     (1) "TYPE one_type (AND one_type)*"
+
+   It looks like:
+     (2) "TYPE types" where "types = one_type (AND types)?".
+
+   This give more context to prevent ambiguities when parsing attributes.
+   Because attributes can appear before AND (1), the parser should
+   decide very early whether to reduce "one_type", so that an attribute can
+   get attached to AND.
+
+   Previously, only [@..] could occur inside "one_type" and only [@@...] before
+   AND.  Now we only have [@..].
+
+   With style (2), we can inline the relevant part of "one_type"
+   (see type_declaration_kind) to parse attributes as needed and take a
+   decision only when arriving at AND.
+*)
+
+type_declarations:
+  item_attributes TYPE nonrec_flag type_declaration_details
+  { let (ident, params, constraints, kind, priv, manifest), endpos, and_types = $4 in
+    let loc = mklocation $startpos($2) endpos in
+    let ty = Type.mk ident ~params:params ~cstrs:constraints
+             ~kind ~priv ?manifest ~attrs:$1 ~loc in
+    ($3, ty :: and_types)
+  }
+;
+
+and_type_declaration:
+  | { [] }
+  | item_attributes AND type_declaration_details
+    { let (ident, params, cstrs, kind, priv, manifest), endpos, and_types = $3 in
+      let loc = mklocation $symbolstartpos endpos in
+      Type.mk ident ~params ~cstrs ~kind ~priv ?manifest ~attrs:$1 ~loc
+      :: and_types
+    }
+;
+
+type_declaration_details:
+  | as_loc(UIDENT) type_variables_with_variance type_declaration_kind
+    { raiseSyntaxErrorFromSyntaxUtils $1.loc
+        "a type name must start with a lower-case letter or an underscore" }
+  | as_loc(LIDENT) type_variables_with_variance type_declaration_kind
+    { let (kind, priv, manifest), constraints, endpos, and_types = $3 in
+      (($1, $2, constraints, kind, priv, manifest), endpos, and_types) }
+;
+
+type_declaration_kind:
+  | EQUAL private_flag constructor_declarations
+    { let (cstrs, constraints, endpos, and_types) = $3 in
+      ((Ptype_variant (cstrs), $2, None), constraints, endpos, and_types) }
+  | EQUAL core_type EQUAL private_flag constructor_declarations
+    { let (cstrs, constraints, endpos, and_types) = $5 in
+      ((Ptype_variant cstrs, $4, Some $2), constraints, endpos, and_types) }
+  | type_other_kind constraints and_type_declaration
+    { ($1, $2, $endpos($2), $3) }
+;
+
+%inline constraints:
+  | { [] }
+  | preceded(CONSTRAINT, constrain)+ { $1 }
+;
+
+type_other_kind:
+  | (*empty*)
+    { (Ptype_abstract, Public, None) }
+  | EQUAL private_flag core_type
+    { (Ptype_abstract, $2, Some $3) }
+  | EQUAL private_flag item_attributes record_declaration
+    { (Ptype_record (prepend_attrs_to_labels $3 $4), $2, None) }
+  | EQUAL DOTDOT
+    { (Ptype_open, Public, None) }
+  | EQUAL core_type EQUAL DOTDOT
+    { (Ptype_open, Public, Some $2) }
+  | EQUAL core_type EQUAL private_flag item_attributes record_declaration
+    { (Ptype_record (prepend_attrs_to_labels $5 $6), $4, Some $2) }
+;
+
+type_variables_with_variance_comma_list:
+  lseparated_nonempty_list(COMMA, type_variable_with_variance) COMMA? {$1}
+;
+
+type_variables_with_variance:
+  loption(parenthesized(type_variables_with_variance_comma_list))
+  { $1 }
+;
+
+type_variable_with_variance:
+  embedded
+  ( QUOTE ident       { (mktyp (Ptyp_var $2) , Invariant    ) }
+  | UNDERSCORE        { (mktyp (Ptyp_any)    , Invariant    ) }
+  | PLUS QUOTE ident  { (mktyp (Ptyp_var $3) , Covariant    ) }
+  | PLUS UNDERSCORE   { (mktyp (Ptyp_any)    , Covariant    ) }
+  | MINUS QUOTE ident { (mktyp (Ptyp_var $3) , Contravariant) }
+  | MINUS UNDERSCORE  { (mktyp Ptyp_any      , Contravariant) }
+  )
+  { let first, second = $1 in
+    let ptyp_loc =
+        {first.ptyp_loc with loc_start = $symbolstartpos; loc_end = $endpos}
+    in
+    ({first with ptyp_loc}, second)
+  }
+;
+
+type_parameter: type_variance type_variable { ($2, $1) };
+
+type_variance:
+  | (* empty *) { Invariant }
+  | PLUS        { Covariant }
+  | MINUS       { Contravariant }
+;
+
+type_variable:
+mark_position_typ
+  (QUOTE ident { mktyp (Ptyp_var $2) })
+  { $1 };
+
+constructor_declarations:
+  either(constructor_declaration,bar_constructor_declaration)
+  constructor_declarations_aux
+  { let (cstrs, constraints, endpos, and_types) = $2 in
+    ($1 :: cstrs, constraints, endpos, and_types)
+  }
+;
+
+constructor_declarations_aux:
+  | bar_constructor_declaration constructor_declarations_aux
+    { let (cstrs, constraints, endpos, and_types) = $2 in
+      ($1 :: cstrs, constraints, endpos, and_types)
+    }
+  | constraints and_type_declaration
+    { ([], $1, $endpos($1), $2) }
+;
+
+bar_constructor_declaration:
+  item_attributes BAR constructor_declaration
+  { {$3 with pcd_attributes = $1 @ $3.pcd_attributes} }
+;
+
+constructor_declaration:
+  item_attributes as_loc(constr_ident) generalized_constructor_arguments
+  { let args, res = $3 in
+    let loc = mklocation $symbolstartpos $endpos in
+    Type.constructor ~attrs:$1 $2 ~args ?res ~loc }
+;
+
+(* Why are there already attribute* on the extension_constructor_declaration? *)
+str_exception_declaration:
+  item_attributes EXCEPTION
+    either(extension_constructor_declaration, extension_constructor_rebind)
+  { {$3 with pext_attributes = $3.pext_attributes @ $1} }
+;
+
+sig_exception_declaration:
+  item_attributes EXCEPTION
+    extension_constructor_declaration
+  { {$3 with pext_attributes = $3.pext_attributes @ $1} }
+;
+
+generalized_constructor_arguments:
+  constructor_arguments? preceded(COLON,core_type)?
+  { ((match $1 with None -> Pcstr_tuple [] | Some x -> x), $2) }
+;
+
+constructor_arguments_comma_list:
+  lseparated_nonempty_list(COMMA, core_type) COMMA? {$1}
+;
+
+constructor_arguments:
+  | object_record_type { Pcstr_tuple [$1] }
+  | record_declaration { Pcstr_record $1 }
+  | parenthesized(constructor_arguments_comma_list)
+    { Pcstr_tuple $1 }
+;
+
+record_label_declaration:
+  | item_attributes mutable_flag as_loc(LIDENT)
+    { let loc = mklocation $symbolstartpos $endpos in
+      Type.field $3 (mkct $3) ~attrs:$1 ~mut:$2 ~loc
+    }
+  | item_attributes mutable_flag as_loc(LIDENT) COLON poly_type
+    { let loc = mklocation $symbolstartpos $endpos in
+      Type.field $3 $5 ~attrs:$1 ~mut:$2 ~loc
+    }
+;
+
+record_declaration:
+  LBRACE lseparated_nonempty_list(COMMA, record_label_declaration) COMMA? RBRACE
+  { $2 }
+;
+
+
+(* Type Extensions *)
+
+str_type_extension:
+  attrs = item_attributes
+  TYPE flag = nonrec_flag
+    ident = as_loc(itype_longident)
+    params = type_variables_with_variance
+  PLUSEQ priv = embedded(private_flag)
+  constructors =
+    attributed_ext_constructors(either(extension_constructor_declaration, extension_constructor_rebind))
+  { if flag <> Recursive then
+      not_expecting $startpos(flag) $endpos(flag) "nonrec flag";
+    Te.mk ~params ~priv ~attrs ident constructors
+  }
+;
+
+sig_type_extension:
+  attrs = item_attributes
+  TYPE flag = nonrec_flag
+    ident = as_loc(itype_longident)
+    params = type_variables_with_variance
+  PLUSEQ priv = embedded(private_flag)
+  constructors =
+    attributed_ext_constructors(extension_constructor_declaration)
+  { if flag <> Recursive then
+      not_expecting $startpos(flag) $endpos(flag) "nonrec flag";
+    Te.mk ~params ~priv ~attrs ident constructors
+  }
+;
+
+%inline attributed_ext_constructor(X):
+  item_attributes BAR item_attributes X { {$4 with pext_attributes = List.concat [$1; $3; $4.pext_attributes]} }
+  (* Why is item_attributes duplicated?
+     To be consistent with attributes on (poly)variants/gadts.
+     So we can place the attribute after the BAR.
+     Example:
+      type water +=
+        pri
+        | [@foo] MineralWater;
+  *)
+;
+
+attributed_ext_constructors(X):
+  | X attributed_ext_constructor(X)* { $1 :: $2 }
+  | attributed_ext_constructor(X)+ { $1 }
+;
+
+extension_constructor_declaration:
+  as_loc(constr_ident) generalized_constructor_arguments
+  { let args, res = $2 in
+    let loc = mklocation $symbolstartpos $endpos in
+    Te.decl $1 ~args ?res ~loc
+  }
+;
+
+extension_constructor_rebind:
+  as_loc(constr_ident) EQUAL as_loc(constr_longident)
+  { let loc = mklocation $symbolstartpos $endpos in
+    Te.rebind $1 $3 ~loc
+  }
+;
+
+(* "with" constraints (additional type equations over signature components) *)
+
+with_constraint:
+  | TYPE as_loc(label_longident) type_variables_with_variance
+      EQUAL embedded(private_flag) core_type constraints
+    { let loc = mklocation $symbolstartpos $endpos in
+      let typ = Type.mk {$2 with txt=Longident.last $2.txt}
+                  ~params:$3 ~cstrs:$7 ~manifest:$6 ~priv:$5 ~loc in
+      Pwith_type ($2, typ)
+    }
+    (* used label_longident instead of type_longident to disallow
+       functor applications in type path *)
+  | TYPE as_loc(label_longident) type_variables_with_variance
+      COLONEQUAL core_type
+    { let last = match $2.txt with
+        | Lident s -> s
+        | _ -> not_expecting $startpos($2) $endpos($2) "Long type identifier"
+      in
+      let loc = mklocation $symbolstartpos $endpos in
+      Pwith_typesubst (Type.mk {$2 with txt=last} ~params:$3 ~manifest:$5 ~loc)
+    }
+  | MODULE as_loc(mod_longident) EQUAL as_loc(mod_ext_longident)
+      { Pwith_module ($2, $4) }
+  | MODULE as_loc(UIDENT) COLONEQUAL as_loc(mod_ext_longident)
+      { Pwith_modsubst ($2, $4) }
+;
+
+(* Polymorphic types *)
+poly_type:
+mark_position_typ
+  ( core_type
+    { $1 }
+  | preceded(QUOTE,ident)+ DOT core_type
+    { mktyp(Ptyp_poly($1, $3)) }
+  ) {$1};
+
+(**
+  * OCaml types before:
+  * -------------------
+  * core_type ::=
+  *   core_type2
+  *   core_type2 as ident
+  *
+  * core_type2 ::=
+  *   simple_core_type_or_tuple
+  *   ?ident: core_type2 -> core_type2
+  *   ?ident: core_type2 -> core_type2
+  *   ident: core_type2 -> core_type2
+  *   core_type2 -> core_type2
+  *
+  * simple_core_type_or_tuple ::=
+  *   simple_core_type
+  *   simple_core_type * simple_core_type_list   (*Reason deprecates this*)
+  *
+  * simple_core_type_list ::=                    (*Reason might be able to deprecate this*)
+  *   simple_core_type
+  *   simple_core_type_list STAR simple_core_type
+  *
+  * simple_core_type ::=
+  *   simple_core_type
+  *   simple_core_type2
+  *   ( core_type)      (*core_type_comma_list of len 1*)
+  *
+  * simple_core_type2 ::=
+  *  'ident
+  *  Long.ident
+  *  simple_core_type2 Long.ident
+  *  (core_type, core_type) Long.ident
+  *  <method1: ... method_2: ...>
+  *  <>
+  *  {method1: .. method2: ..}
+  *  # class_longident #
+  *  simple_core_type2 # class_longident
+  *  (core_type, core_type) # class_longident
+  *  (module package_type)
+  *  [%]
+  *  bunch of other stuff
+  *
+  * Reason types where tuples require grouping:
+  * -------------------
+  * Simple types are implicitly non-arrowed.
+  * Non arrowed types may be shown in the trailing positino of the curried sugar
+  * function/functor bindings, but it doesn't have to be simple.
+  *
+  * let x ... :non_arrowed_core_type => ..
+  *
+  * - A better name for core_type2 would be arrowed_core_type
+  * - A better name for core_type would be aliased_arrowed_core_type
+  * core_type ::=
+  *   core_type2
+  *   core_type2 as ident
+  *
+  * core_type2 ::=
+  *   non_arrowed_core_type
+  *   ident::? non_arrowed_core_type => non_arrowed_core_type
+  *   ident:: non_arrowed_core_type => non_arrowed_core_type
+  *   core_type2 => core_type2
+  *
+  * non_arrowed_core_type ::=
+  *    non_arrowed_non_simple_core_type
+  *    simple_core_type
+  *
+  * non_arrowed_non_simple_core_type ::=
+  *   type_longident non_arrowed_simple_core_type_list
+  *   # class_longident
+  *   simple_core_type # class_longident
+  *   [core_type_comma_list] # class_longident
+  *
+  * simple_core_type ::=
+  *   <>
+  *   ()
+  *   {}
+  *
+  *
+  *  'ident
+  *  Long.ident
+  *  simple_core_type Long.ident
+  *  Long.ident non_arrowed_simple_core_type_list
+  *  <method1: ... method_2: ...>
+  *  <>
+  *  {method1: .. method2: ..}
+  *  # class_longident #
+  *  simple_core_type # class_longident
+  *  (core_type, core_type) # class_longident
+  *  (module package_type)
+  *  [%]
+  *  bunch of other stuff
+  *)
+
+(** Potentially includes:
+ * - arrows
+ * - space separated type applications
+ * - "as" aliases
+ *)
+core_type:
+mark_position_typ
+  (* For some reason, when unifying Functor type syntax (using EQUALGREATER),
+   * there was a shift reduce conflict likely caused by
+   * type module MyFunctor = {type x = blah => foo } => SomeSig
+   * That should *not* be a shift reduce conflict (on =>), and it's not clear
+   * why the shift reduce conflict showed up in core_type2. Either way, this
+   * seems to resolve the issue. If removing the below_EQUALGREATER, the shift
+   * reduce conflict is actually caused by the new Functor type annotations
+   * even though *nothing* will point towards that.
+   * If switching to Menhir, this may not be needed.
+   *)
+  (
+    core_type2
+    { $1 }
+  | core_type2 AS QUOTE ident
+    { mktyp(Ptyp_alias($1, $4)) }
+  ) {$1};
+
+(**
+ *
+ * core_type is basically just core_type2 but with a single AS x potentially
+ * appended.
+ * core_type2 Potentially includes:
+ * - arrows
+ * - space separated type applications
+ * - Polymorphic type variable application
+ *)
+core_type2:
+  item_attributes ct = unattributed_core_type
+  { match $1 with
+    | [] -> ct
+    | attrs ->
+      let loc_start = $symbolstartpos and loc_end = $endpos in
+      let ptyp_loc = {ct.ptyp_loc with loc_start; loc_end} in
+      let ptyp_attributes = attrs @ ct.ptyp_attributes in
+      {ct with ptyp_attributes; ptyp_loc}
+  }
+;
+
+unattributed_core_type:
+  | non_arrowed_simple_core_type { $1 }
+  | arrowed_simple_core_type { $1 }
+;
+
+(* arrowed: because it contains =>
+ * simple: it doesn't need to be wrapped in parens *)
+arrowed_simple_core_type:
+  | ES6_FUN arrow_type_parameters EQUALGREATER core_type2
+    { List.fold_right mktyp_arrow $2 $4 }
+  | as_loc(labelled_arrow_type_parameter_optional) EQUALGREATER core_type2
+    { mktyp_arrow ($1, false) $3 }
+  | basic_core_type EQUALGREATER core_type2
+    { mktyp (Ptyp_arrow (Nolabel, $1, $3)) }
+;
+
+labelled_arrow_type_parameter_optional:
+  | TILDE LIDENT COLON protected_type EQUAL optional
+    { ($6 $2, $4) }
+;
+
+arrow_type_parameter:
+  | protected_type  { (Nolabel, $1) }
+  | TILDE LIDENT COLON protected_type
+    { (Labelled $2, $4) }
+  | labelled_arrow_type_parameter_optional { $1 }
+;
+
+%inline uncurried_arrow_type_parameter:
+    DOT? as_loc(arrow_type_parameter)
+  { let uncurried = match $1 with | Some _ -> true | None -> false in
+    match $2.txt with
+    | (Labelled _, _) when uncurried ->
+        raise Reason_syntax_util.(Error($2.loc, (Syntax_error "An uncurried function type with labelled arguments is not supported at the moment.")))
+    | _ -> ($2, uncurried)
+  }
+
+%inline arrow_type_parameter_comma_list:
+    | lseparated_nonempty_list(COMMA, uncurried_arrow_type_parameter) COMMA? {$1}
+
+arrow_type_parameters:
+ | LPAREN arrow_type_parameter_comma_list RPAREN { $2 }
+;
+
+(* Among other distinctions, "simple" core types can be used in Variant types:
+ * type myType = Count of anySimpleCoreType. Core types (and simple core types)
+ * don't include variant declarations (`constructor_declarations`) and don't
+ * include the "faux curried" variant Constructor arguments list.
+ *
+ * In general, "simple" syntax constructs, don't need to be wrapped in
+ * parens/braces when embedded in lists of those very constructs.
+ *
+ * A [simple_core_type] *can* be wrapped in parens, but
+ * it doesn't have to be.
+ *)
+
+(* The name [core_type] was taken. [non_arrowed_core_type] is the same as
+ * [simple_core_type] but used in cases
+ * where application needn't be wrapped in additional parens *)
+(* Typically, other syntax constructs choose to allow either
+ * [simple_core_type] or
+ * [non_arrowed_non_simple_core_type] depending on whether or not
+ * they are in a context that expects space separated lists of types to carry
+ * particular meaning outside of type constructor application.
+ *
+ * type x = SomeConstructor x y;
+ *)
+non_arrowed_core_type:
+  | non_arrowed_simple_core_type
+    { $1 }
+  | attribute non_arrowed_core_type
+    { {$2 with ptyp_attributes = $1 :: $2.ptyp_attributes} }
+;
+
+%inline type_parameter_comma_list:
+  | lseparated_nonempty_list(COMMA, protected_type) COMMA? {$1}
+;
+
+type_parameters:
+  | parenthesized(type_parameter_comma_list) { $1 }
+;
+
+(* "protected" stands for an environment where non-simple grammar
+ * is actually simple. non-simple => parens, simple => no-parens necessary
+ * For examples, in lists the ( and ) combined with , form a "protected"
+ * environment for non-simple types.
+ * in tuples: (int, string, float) ||-> int, string, float are protected
+ * in functions args: (int, string) => float ||-> int, string are protected *)
+protected_type:
+  | MODULE package_type {
+      let loc = mklocation $symbolstartpos $endpos in
+      { (mktyp(Ptyp_package $2)) with ptyp_loc = loc }
+    }
+  | core_type { $1 }
+;
+
+non_arrowed_simple_core_types:
+mark_position_typ
+  ( type_parameters
+    { match $1 with
+      | [one] -> one
+      | many -> mktyp (Ptyp_tuple many)
+    }
+  ) {$1};
+
+non_arrowed_simple_core_type:
+  | non_arrowed_simple_core_types       { $1 }
+  | mark_position_typ(basic_core_type) { $1 }
+;
+
+basic_core_type:
+mark_position_typ
+  ( type_longident type_parameters
+    { mktyp(Ptyp_constr($1, $2)) }
+  | SHARP as_loc(class_longident) type_parameters
+    { mktyp(Ptyp_class($2, $3)) }
+  | QUOTE ident
+    { mktyp(Ptyp_var $2) }
+  | SHARP as_loc(class_longident)
+    { mktyp(Ptyp_class($2, [])) }
+  | UNDERSCORE
+    { mktyp(Ptyp_any) }
+  | type_longident
+    { mktyp(Ptyp_constr($1, [])) }
+  | object_record_type
+    { $1 }
+  | LBRACKET row_field_list RBRACKET
+    { mktyp(Ptyp_variant ($2, Closed, None)) }
+  | LBRACKETGREATER loption(row_field_list) RBRACKET
+    { mktyp(Ptyp_variant ($2, Open, None)) }
+  | LBRACKETLESS row_field_list loption(preceded(GREATER, name_tag+)) RBRACKET
+    { mktyp(Ptyp_variant ($2, Closed, Some $3)) }
+  | extension
+    { mktyp(Ptyp_extension $1) }
+  ) {$1};
+
+object_record_type:
+  | LBRACE RBRACE
+    { syntax_error () }
+  | LBRACE DOT string_literal_labels RBRACE
+    { (* `{. "foo": bar}` -> `Js.t({. foo: bar})` *)
+      let loc = mklocation $symbolstartpos $endpos in
+      mkBsObjTypeSugar ~loc ~closed:Closed $3
+    }
+  | LBRACE DOTDOT string_literal_labels RBRACE
+    { (* `{.. "foo": bar}` -> `Js.t({.. foo: bar})` *)
+      let loc = mklocation $symbolstartpos $endpos in
+      mkBsObjTypeSugar ~loc ~closed:Open $3
+    }
+  | LBRACE DOT loption(object_label_declarations) RBRACE
+    { mktyp (Ptyp_object ($3, Closed)) }
+  | LBRACE DOTDOT loption(object_label_declarations) RBRACE
+    { mktyp (Ptyp_object ($3, Open)) }
+;
+
+object_label_declaration:
+  | item_attributes as_loc(LIDENT)
+    { ($2.txt, $1, mkct $2) }
+  | item_attributes LIDENT COLON poly_type
+    { ($2, $1, $4) }
+;
+
+object_label_declarations:
+  lseparated_nonempty_list(COMMA, object_label_declaration) COMMA? { $1 };
+
+string_literal_label:
+  item_attributes STRING COLON poly_type
+  { let (label, _raw, _delim) = $2 in (label, $1, $4) }
+;
+
+string_literal_labels:
+  lseparated_nonempty_list(COMMA, string_literal_label) COMMA? { $1 };
+
+package_type:
+  module_type { package_type_of_module_type $1 }
+;
+
+row_field_list:
+  | row_field bar_row_field* { $1 :: $2 }
+  | bar_row_field bar_row_field* { $1 :: $2 }
+;
+
+row_field:
+  | tag_field             { $1 }
+  | non_arrowed_core_type { Rinherit $1 }
+;
+
+bar_row_field:
+  item_attributes BAR row_field
+  { match $3 with
+    | Rtag (name, attrs, amp, typs) ->
+        Rtag (name, $1 @ attrs, amp, typs)
+    | Rinherit typ ->
+        Rinherit {typ with ptyp_attributes = $1 @ typ.ptyp_attributes}
+  }
+;
+
+tag_field:
+  | item_attributes name_tag
+      boption(AMPERSAND)
+      separated_nonempty_list(AMPERSAND, non_arrowed_simple_core_types)
+    { Rtag ($2, $1, $3, $4) }
+  | item_attributes name_tag
+    { Rtag ($2, $1, true, []) }
+;
+
+(* Constants *)
+
+constant:
+  | INT          { let (n, m) = $1 in ([], Pconst_integer (n, m)) }
+  | CHAR         { ([], Pconst_char $1) }
+  | FLOAT        { let (f, m) = $1 in ([], Pconst_float (f, m)) }
+  | STRING       {
+    let (s, raw, d) = $1 in
+    let attr = match raw with
+      | None -> []
+      | Some raw ->
+        let constant = Ast_helper.Exp.constant (Pconst_string (raw, None)) in
+        [Location.mknoloc "reason.raw_literal", PStr [mkstrexp constant []]]
+    in
+    (attr, Pconst_string (s, d))
+  }
+;
+
+signed_constant:
+  | constant     { $1 }
+  | MINUS INT    { let (n, m) = $2 in ([], Pconst_integer("-" ^ n, m)) }
+  | MINUS FLOAT  { let (f, m) = $2 in ([], Pconst_float("-" ^ f, m)) }
+  | PLUS INT     { let (n, m) = $2 in ([], Pconst_integer (n, m)) }
+  | PLUS FLOAT   { let (f, m) = $2 in ([], Pconst_float(f, m)) }
+;
+
+(* Identifiers and long identifiers *)
+
+ident: UIDENT | LIDENT { $1 };
+
+val_ident:
+  | LIDENT                 { $1 }
+  | LPAREN operator RPAREN { $2 }
+;
+
+%inline infix_operator:
+  | INFIXOP0          { $1 }
+  | INFIXOP1          { $1 }
+  | INFIXOP2          { $1 }
+  | INFIXOP3          { $1 }
+  (* SLASHGREATER is INFIXOP3 but we needed to call it out specially *)
+  | SLASHGREATER      { "/>" }
+  | INFIXOP4          { $1 }
+  | PLUS              { "+" }
+  | PLUSDOT           { "+." }
+  | MINUS             { "-" }
+  | MINUSDOT          { "-." }
+  | STAR              { "*" }
+  | LESS              { "<" }
+  | GREATER           { ">" }
+  | OR                { "or" }
+  | BARBAR            { "||" }
+  | AMPERSAND         { "&" }
+  | AMPERAMPER        { "&&" }
+  | COLONEQUAL        { ":=" }
+  | PLUSEQ            { "+=" }
+  | PERCENT           { "%" }
+  (* We don't need to (and don't want to) consider </> an infix operator for now
+     because our lexer requires that "</>" be expressed as "<\/>" because
+     every star and slash after the first character must be escaped.
+  *)
+  (* Also, we don't want to consider <> an infix operator because the Reason
+     operator swapping requires that we express that as != *)
+  | LESSDOTDOTGREATER { "<..>" }
+  | GREATER GREATER   { ">>" }
+  | GREATERDOTDOTDOT { ">..." }
+;
+
+operator:
+  | PREFIXOP          { $1 }
+  | POSTFIXOP         { $1 }
+  | BANG              { "!" }
+  | infix_operator    { $1 }
+;
+%inline constr_ident:
+  | UIDENT            { $1 }
+  | LBRACKET RBRACKET { "[]" }
+  | LPAREN RPAREN     { "()" }
+  | COLONCOLON        { "::" }
+(*  | LPAREN COLONCOLON RPAREN { "::" } *)
+  | FALSE             { "false" }
+  | TRUE              { "true" }
+;
+
+val_longident:
+  | val_ident                     { Lident $1 }
+  | mod_longident DOT val_ident   { Ldot($1, $3) }
+;
+
+constr_longident:
+  | mod_longident %prec below_DOT { $1 }
+  | LBRACKET RBRACKET             { Lident "[]" }
+  | LPAREN RPAREN                 { Lident "()" }
+  | FALSE                         { Lident "false" }
+  | TRUE                          { Lident "true" }
+;
+
+label_longident:
+  | LIDENT                        { Lident $1 }
+  | mod_longident DOT LIDENT      { Ldot($1, $3) }
+;
+
+type_longident: as_loc(itype_longident) { $1 };
+
+%inline itype_longident:
+  | LIDENT                        { Lident $1 }
+  | mod_ext_longident DOT LIDENT  { Ldot($1, $3) }
+;
+
+mod_longident:
+  | UIDENT                        { Lident $1 }
+  | mod_longident DOT UIDENT      { Ldot($1, $3) }
+;
+
+mod_ext_longident: imod_ext_longident { $1 }
+
+%inline imod_ext_longident:
+  | UIDENT                        { Lident $1 }
+  | mod_ext_longident DOT UIDENT  { Ldot($1, $3) }
+  | mod_ext_apply                 { $1 }
+;
+
+mod_ext_apply:
+  imod_ext_longident
+  parenthesized(lseparated_nonempty_list(COMMA, mod_ext_longident))
+  { if not !Clflags.applicative_functors then
+      raise Syntaxerr.(Error(Applicative_path(mklocation $startpos $endpos)));
+    List.fold_left (fun p1 p2 -> Lapply (p1, p2)) $1 $2
+  }
+;
+
+mty_longident:
+  | ident                        { Lident $1 }
+  | mod_ext_longident DOT ident  { Ldot($1, $3) }
+;
+
+clty_longident:
+  | LIDENT                       { Lident $1 }
+  | mod_ext_longident DOT LIDENT { Ldot($1, $3) }
+;
+
+class_longident:
+  | LIDENT                       { Lident $1 }
+  | mod_longident DOT LIDENT     { Ldot($1, $3) }
+;
+
+(* Toplevel directives *)
+
+toplevel_directive:
+  SHARP ident embedded
+          ( (* empty *)   { Pdir_none }
+          | STRING        { let (s, _, _) = $1 in Pdir_string s }
+          | INT           { let (n, m) = $1 in Pdir_int (n, m) }
+          | val_longident { Pdir_ident $1 }
+          | mod_longident { Pdir_ident $1 }
+          | FALSE         { Pdir_bool false }
+          | TRUE          { Pdir_bool true }
+          )
+  { Ptop_dir($2, $3) }
+;
+
+(* Miscellaneous *)
+
+opt_LET_MODULE: MODULE { () } | LET MODULE { () };
+
+%inline name_tag: BACKQUOTE ident { $2 };
+
+%inline label: LIDENT { $1 };
+
+rec_flag:
+  | (* empty *)   { Nonrecursive }
+  | REC           { Recursive }
+;
+
+nonrec_flag:
+  | (* empty *)   { Recursive }
+  | NONREC        { Nonrecursive }
+;
+
+direction_flag:
+  | TO            { Upto }
+  | DOWNTO        { Downto }
+;
+
+%inline private_flag:
+  | (* empty *)   { Public }
+  | PRI           { Private }
+;
+
+mutable_flag:
+  | (* empty *)   { Immutable }
+  | MUTABLE       { Mutable }
+;
+
+virtual_flag:
+  | (* empty *)   { Concrete }
+  | VIRTUAL       { Virtual }
+;
+
+mutable_or_virtual_flags:
+  | (* empty *)   { Immutable, Concrete }
+  | VIRTUAL mutable_flag { $2, Virtual }
+  | MUTABLE virtual_flag { Mutable, $2 }
+;
+
+override_flag:
+  | (* empty *)   { Fresh }
+  | BANG          { Override }
+;
+
+subtractive:
+  | MINUS         { "-"  }
+  | MINUSDOT      { "-." }
+;
+
+additive:
+  | PLUS          { "+"  }
+  | PLUSDOT       { "+." }
+;
+
+single_attr_id:
+  | LIDENT      { $1 }
+  | UIDENT      { $1 }
+  | AND         { "and" }
+  | AS          { "as" }
+  | ASSERT      { "assert" }
+  | BEGIN       { "begin" }
+  | CLASS       { "class" }
+  | CONSTRAINT  { "constraint" }
+  | DO          { "do" }
+  | DONE        { "done" }
+  | DOWNTO      { "downto" }
+  | ELSE        { "else" }
+  | END         { "end" }
+  | EXCEPTION   { "exception" }
+  | EXTERNAL    { "external" }
+  | FALSE       { "false" }
+  | FOR         { "for" }
+  | FUN         { "fun" }
+  | FUNCTION    { "function" }
+  | FUNCTOR     { "functor" }
+  | IF          { "if" }
+  | IN          { "in" }
+  | INCLUDE     { "include" }
+  | INHERIT     { "inherit" }
+  | INITIALIZER { "initializer" }
+  | LAZY        { "lazy" }
+  | LET         { "let" }
+  | SWITCH      { "switch" }
+  | MODULE      { "module" }
+  | MUTABLE     { "mutable" }
+  | NEW         { "new" }
+  | NONREC      { "nonrec" }
+  | OBJECT      { "object" }
+  | OF          { "of" }
+  | OPEN        { "open" }
+  | OR          { "or" }
+  | PRI         { "private" }
+  | REC         { "rec" }
+  | SIG         { "sig" }
+  | STRUCT      { "struct" }
+  | THEN        { "then" }
+  | TO          { "to" }
+  | TRUE        { "true" }
+  | TRY         { "try" }
+  | TYPE        { "type" }
+  | VAL         { "val" }
+  | VIRTUAL     { "virtual" }
+  | WHEN        { "when" }
+  | WHILE       { "while" }
+  | WITH        { "with" }
+(* mod/land/lor/lxor/lsl/lsr/asr are not supported for now *)
+;
+
+attr_id:
+  | as_loc(single_attr_id) { $1 }
+  | single_attr_id DOT attr_id { mkloc ($1 ^ "." ^ $3.txt) (mklocation $symbolstartpos $endpos) }
+;
+
+attribute:
+  | LBRACKETAT attr_id payload RBRACKET { ($2, $3) }
+  | DOCSTRING { doc_attr $1 (mklocation $symbolstartpos $endpos) }
+;
+
+(* Inlined to avoid having to deal with buggy $symbolstartpos *)
+%inline located_attributes: as_loc(attribute)+ { $1 }
+
+(* Inlined to avoid having to deal with buggy $symbolstartpos *)
+%inline item_attributes:
+  | { [] }
+  | located_attributes { List.map (fun x -> x.txt) $1 }
+;
+
+item_extension_sugar:
+  PERCENT attr_id { ([], $2) }
+;
+
+extension:
+  LBRACKETPERCENT attr_id payload RBRACKET { ($2, $3) }
+;
+
+item_extension:
+  LBRACKETPERCENTPERCENT attr_id payload RBRACKET { ($2, $3) }
+;
+
+payload:
+  | structure                       { PStr $1 }
+  | COLON signature                 { PSig $2 }
+  | COLON core_type                 { PTyp $2 }
+  | QUESTION pattern                { PPat ($2, None) }
+  | QUESTION pattern WHEN expr      { PPat ($2, Some $4) }
+
+  (* Allow parsing of [@test.call x => x]
+   * By putting this rule here, a reduce/reduce conflict can be avoided
+   * If we put the "simple_pattern_ident EQUALGREATER expr" inside the
+   * unattributed_expr_template, the following ambiguity pops up:
+   *  BAR pattern option(preceded(WHEN,expr)) EQUALGREATER expr
+   *        WHEN expr
+   *             simple_pattern_ident EQUALGREATER expr // lookahead token appears
+   *             val_ident .
+   *
+   *  BAR pattern option(preceded(WHEN,expr)) EQUALGREATER expr // lookahead token appears
+   *        WHEN expr // lookahead token is inherited
+   *             simple_expr_call // lookahead token is inherited
+   *             val_longident // lookahead token is inherited
+   *             val_ident .
+   *  Since where in a payload here, there's no ambiguity when putting
+   *  the es6-style function (single arg, no parens) at this level.
+   *)
+  | simple_pattern_ident EQUALGREATER expr
+    { let loc = mklocation $symbolstartpos $endpos in
+      let expr = Exp.fun_ ~loc Nolabel None $1 $3 in
+      PStr([mkstrexp expr []])
+    }
+;
+
+optional:
+  | { fun x -> Labelled x }
+  | QUESTION { fun x -> Optional x }
+;
+
+%inline mark_position_mod(X): x = X
+  { {x with pmod_loc = {x.pmod_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_cty(X): x = X
+  { {x with pcty_loc = {x.pcty_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_ctf(X): x = X
+  { {x with pctf_loc = {x.pctf_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_exp(X): x = X
+  { {x with pexp_loc = {x.pexp_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_typ(X): x = X
+  { {x with ptyp_loc = {x.ptyp_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_mty(X): x = X
+  { {x with pmty_loc = {x.pmty_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_str(X): x = X
+  { {x with pstr_loc = {x.pstr_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_cl(X): x = X
+  { {x with pcl_loc = {x.pcl_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_cf(X): x = X
+   { {x with pcf_loc = {x.pcf_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline mark_position_pat(X): x = X
+   { {x with ppat_loc = {x.ppat_loc with loc_start = $symbolstartpos; loc_end = $endpos}} }
+;
+
+%inline as_loc(X): x = X
+  { mkloc x (mklocation $symbolstartpos $endpos) }
+;
+
+either(X,Y):
+  | X { $1 }
+  | Y { $1 }
+;
+
+%inline opt_spread(X):
+  | DOTDOTDOT? X
+    { let dotdotdot = match $1 with
+      | Some _ -> Some (mklocation $startpos($1) $endpos($2))
+      | None -> None
+      in
+      (dotdotdot, $2)
+    }
+  ;
+
+%inline lnonempty_list(X): X llist_aux(X) { $1 :: List.rev $2 };
+
+%inline llist(X): llist_aux(X) { List.rev $1 };
+
+llist_aux(X):
+  | (* empty *) { [] }
+  | llist_aux(X) X { $2 :: $1 }
+;
+
+%inline lseparated_list(sep, X):
+  | (* empty *) { [] }
+  | lseparated_nonempty_list(sep, X) { $1 };
+
+%inline lseparated_nonempty_list(sep, X):
+  lseparated_nonempty_list_aux(sep, X) { List.rev $1 };
+
+lseparated_nonempty_list_aux(sep, X):
+  | X { [$1] }
+  | lseparated_nonempty_list_aux(sep, X) sep X { $3 :: $1 }
+;
+
+%inline lseparated_two_or_more(sep, X):
+  X sep lseparated_nonempty_list(sep, X) { $1 :: $3 };
+
+%inline parenthesized(X): delimited(LPAREN, X, RPAREN) { $1 };
+
+%%

--- a/tools/liquidity/reason/reason_pprint_ast.ml
+++ b/tools/liquidity/reason/reason_pprint_ast.ml
@@ -1,0 +1,8027 @@
+(*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *  Forked from OCaml, which is provided under the license below:
+ *
+ *  Xavier Leroy, projet Cristal, INRIA Rocquencourt
+ *
+ *  Copyright © 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006 Inria
+ *
+ *  Permission is hereby granted, free of charge, to the Licensee obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense
+ *  under any license of the Licensee's choice, and/or sell copies of the
+ *  Software, subject to the following conditions:
+ *
+ *  1.	Redistributions of source code must retain the above copyright notice
+ *  and the following disclaimer.
+ *  2.	Redistributions in binary form must reproduce the above copyright
+ *  notice, the following disclaimer in the documentation and/or other
+ *  materials provided with the distribution.
+ *  3.	All advertising materials mentioning features or use of the Software
+ *  must display the following acknowledgement: This product includes all or
+ *  parts of the Caml system developed by Inria and its contributors.
+ *  4.	Other than specified in clause 3, neither the name of Inria nor the
+ *  names of its contributors may be used to endorse or promote products
+ *  derived from the Software without specific prior written permission.
+ *
+ *  Disclaimer
+ *
+ *  This software is provided by Inria and contributors “as is” and any express
+ *  or implied warranties, including, but not limited to, the implied
+ *  warranties of merchantability and fitness for a particular purpose are
+ *  disclaimed. in no event shall Inria or its contributors be liable for any
+ *  direct, indirect, incidental, special, exemplary, or consequential damages
+ *  (including, but not limited to, procurement of substitute goods or
+ *  services; loss of use, data, or profits; or business interruption) however
+ *  caused and on any theory of liability, whether in contract, strict
+ *  liability, or tort (including negligence or otherwise) arising in any way
+ *  out of the use of this software, even if advised of the possibility of such
+ *  damage.
+ *
+ *)
+
+(* TODO more fine-grained precedence pretty-printing *)
+
+open Ast_404
+open Asttypes
+open Location
+open Longident
+open Parsetree
+open Easy_format
+open Reason_syntax_util
+open Reason_attributes
+
+module Comment = Reason_comment
+module Layout = Reason_layout
+module WhitespaceRegion = Layout.WhitespaceRegion
+module Range = Reason_location.Range
+
+let source_map = Layout.source_map
+
+exception NotPossible of string
+
+let commaTrail = Layout.SepFinal (",", Reason_syntax_util.TrailingCommaMarker.string)
+let commaSep = Layout.Sep (",")
+
+type ruleInfoData = {
+  reducePrecedence: precedence;
+  shiftPrecedence: precedence;
+}
+
+and ruleCategory =
+  (* Printing will be parsed with very high precedence, so not much need to
+     worry about ensuring it will reduce correctly. In short, you can put
+     `FunctionApplication` content anywhere around an infix identifier without
+     wrapping in parens. For example `myFunc x y z` or `if x {y} else {z}`
+     The layout is kept in list form only to allow for elegant wrapping rules
+     to take into consideration the *number* of high precedence parsed items. *)
+  | FunctionApplication of Layout.t list
+  (* Care should be taken to ensure the rule that caused it to be parsed will
+     reduce again on the printed output - context should carefully consider
+     wrapping in parens according to the ruleInfoData. *)
+  | SpecificInfixPrecedence of ruleInfoData * resolvedRule
+  (* Not safe to include anywhere between infix operators without wrapping in
+     parens. This describes expressions like `fun x => x` which doesn't fit into
+     our simplistic algorithm for printing function applications separated by infix.
+
+     It might be possible to include these in between infix, but there are
+     tricky rules to determining when these must be guarded by parens (it
+     depends highly on context that is hard to reason about). It's so nuanced
+     that it's easier just to always wrap them in parens.  *)
+  | PotentiallyLowPrecedence of Layout.t
+  (* Simple means it is clearly one token (such as (anything) or [anything] or identifier *)
+  | Simple of Layout.t
+
+(* Represents a ruleCategory where the precedence has been resolved.
+ * The precedence of a ruleCategory gets resolved in `ensureExpression` or
+ * `ensureContainingRule`. The result is either a plain Layout.t (where
+ * parens probably have been applied) or an InfixTree containing the operator and
+ * a left & right resolvedRule. The latter indicates that the precedence has been resolved,
+ * but the actual formatting is deferred to a later stadium.
+ * Think `let x = foo |> f |> z |>`, which requires a certain formatting style when
+ * things break over multiple lines. *)
+and resolvedRule =
+  | LayoutNode of Layout.t
+  | InfixTree of string * resolvedRule * resolvedRule
+
+and associativity =
+  | Right
+  | Nonassoc
+  | Left
+
+and precedenceEntryType =
+  | TokenPrecedence
+  | CustomPrecedence
+
+and precedence =
+  | Token of string
+  | Custom of string
+
+(* Describes the "fixity" of a token, and stores its *printed* representation
+   should it be rendered as infix/prefix (This rendering may be different than
+   how it is stored in the AST). *)
+and tokenFixity =
+  (* Such as !simple_expr and ~!simple_expr. These function applications are
+     considered *almost* "simple" because they may be allowed anywhere a simple
+     expression is accepted, except for when on the left hand side of a
+     dot/send. *)
+  | AlmostSimplePrefix of string
+  | UnaryPlusPrefix of string
+  | UnaryMinusPrefix of string
+  | UnaryNotPrefix of string
+  | UnaryPostfix of string
+  | Infix of string
+  | Normal
+
+(* Type which represents a resolvedRule's InfixTree flattened *)
+type infixChain =
+  | InfixToken of string
+  | Layout of Layout.t
+
+(* Helpers for dealing with extension nodes (%expr) *)
+
+let expression_extension_sugar x =
+  if x.pexp_attributes != [] then None
+  else match x.pexp_desc with
+    | Pexp_extension (name, PStr [{pstr_desc = Pstr_eval(expr, [])}])
+      when name.txt <> "bs.obj" ->
+      Some (name, expr)
+    | _ -> None
+
+let expression_immediate_extension_sugar x =
+  match expression_extension_sugar x with
+  | None -> (None, x)
+  | Some (name, expr) ->
+    match expr.pexp_desc with
+    | Pexp_for _ | Pexp_while _ | Pexp_ifthenelse _
+    | Pexp_function _ | Pexp_newtype _
+    | Pexp_try _ | Pexp_match _ ->
+      (Some name, expr)
+    | _ -> (None, x)
+
+let expression_not_immediate_extension_sugar x =
+  match expression_immediate_extension_sugar x with
+  | (Some _, _) -> None
+  | (None, _) -> expression_extension_sugar x
+
+let add_extension_sugar keyword = function
+  | None -> keyword
+  | Some str -> keyword ^ "%" ^ str.txt
+
+let string_equal : string -> string -> bool = (=)
+
+let longident_same l1 l2 =
+  let rec equal l1 l2 =
+    match l1, l2 with
+    | Lident l1, Lident l2 -> string_equal l1 l2
+    | Ldot (path1, l1), Ldot (path2, l2) ->
+      equal path1 path2 && string_equal l1 l2
+    | Lapply (l11, l12), Lapply (l21, l22) ->
+      equal l11 l21 && equal l12 l22
+    | _ -> false
+  in
+  equal l1.txt l2.txt
+
+(* A variant of List.for_all2 that returns false instead of failing on lists
+   of different size *)
+let for_all2' pred l1 l2 =
+  List.length l1 = List.length l2 &&
+  List.for_all2 pred l1 l2
+
+(*
+   Checks to see if two types are the same modulo the process of varification
+   which turns abstract types into type variables of the same name.
+   For example, [same_ast_modulo_varification] would consider (a => b) and ('a
+   => 'b) to have the same ast. This is useful in recovering syntactic sugar
+   for explicit polymorphic types with locally abstract types.
+
+   Does not compare attributes, or extensions intentionally.
+
+   TODO: This has one more issue: We need to compare only accepting t1's type
+   variables, to be considered compatible with t2's type constructors - not the
+   other way around.
+ *)
+let same_ast_modulo_varification_and_extensions t1 t2 =
+  let rec loop t1 t2 = match (t1.ptyp_desc, t2.ptyp_desc) with
+    (* Importantly, cover the case where type constructors (of the form [a])
+       are converted to type vars of the form ['a].
+     *)
+    | (Ptyp_constr({txt=Lident s1}, []), Ptyp_var s2) -> string_equal s1 s2
+    (* Now cover the case where type variables (of the form ['a]) are
+       converted to type constructors of the form [a].
+     *)
+    | (Ptyp_var s1, Ptyp_constr({txt=Lident s2}, [])) -> string_equal s1 s2
+    (* Now cover the typical case *)
+    | (Ptyp_constr(longident1, lst1), Ptyp_constr(longident2, lst2))  ->
+      longident_same longident1 longident2 &&
+      for_all2' loop lst1 lst2
+    | (Ptyp_any, Ptyp_any) -> true
+    | (Ptyp_var x1, Ptyp_var x2) -> string_equal x1 x2
+    | (Ptyp_arrow (label1, core_type1, core_type1'), Ptyp_arrow (label2, core_type2, core_type2')) ->
+      begin
+         match label1, label2 with
+         | Nolabel, Nolabel -> true
+         | Labelled s1, Labelled s2 -> string_equal s1 s2
+         | Optional s1, Optional s2 -> string_equal s1 s2
+         | _ -> false
+      end &&
+      loop core_type1 core_type2 &&
+      loop core_type1' core_type2'
+    | (Ptyp_tuple lst1, Ptyp_tuple lst2) -> for_all2' loop lst1 lst2
+    | (Ptyp_object (lst1, o1), Ptyp_object (lst2, o2)) ->
+      let tester = fun (s1, _, t1) (s2, _, t2) ->
+        string_equal s1 s2 &&
+        loop t1 t2
+      in
+      for_all2' tester lst1 lst2 && o1 = o2
+    | (Ptyp_class (longident1, lst1), Ptyp_class (longident2, lst2)) ->
+      longident_same longident1 longident2 &&
+      for_all2' loop lst1 lst2
+    | (Ptyp_alias(core_type1, string1), Ptyp_alias(core_type2, string2)) ->
+      loop core_type1 core_type2 &&
+      string_equal string1 string2
+    | (Ptyp_variant(row_field_list1, flag1, lbl_lst_option1), Ptyp_variant(row_field_list2, flag2, lbl_lst_option2)) ->
+      for_all2' rowFieldEqual row_field_list1 row_field_list2 &&
+      flag1 = flag2 &&
+      lbl_lst_option1 = lbl_lst_option2
+    | (Ptyp_poly (string_lst1, core_type1), Ptyp_poly (string_lst2, core_type2))->
+      for_all2' string_equal string_lst1 string_lst2 &&
+      loop core_type1 core_type2
+    | (Ptyp_package(longident1, lst1), Ptyp_package (longident2, lst2)) ->
+      longident_same longident1 longident2 &&
+      for_all2' testPackageType lst1 lst2
+    | (Ptyp_extension (s1, _), Ptyp_extension (s2, _)) ->
+      string_equal s1.txt s2.txt
+    | _ -> false
+  and testPackageType (lblLongIdent1, ct1) (lblLongIdent2, ct2) =
+    longident_same lblLongIdent1 lblLongIdent2 &&
+    loop ct1 ct2
+  and rowFieldEqual f1 f2 = match (f1, f2) with
+    | ((Rtag(label1, _, flag1, lst1)), (Rtag (label2, _, flag2, lst2))) ->
+      string_equal label1 label2 &&
+      flag1 = flag2 &&
+      for_all2' loop lst1 lst2
+    | (Rinherit t1, Rinherit t2) -> loop t1 t2
+    | _ -> false
+  in
+  loop t1 t2
+
+let expandLocation pos ~expand:(startPos, endPos) =
+  { pos with
+    loc_start = {
+      pos.loc_start with
+        Lexing.pos_cnum = pos.loc_start.Lexing.pos_cnum + startPos
+    };
+    loc_end = {
+      pos.loc_end with
+        Lexing.pos_cnum = pos.loc_end.Lexing.pos_cnum + endPos
+    }
+  }
+
+(* Computes the location of the attribute with the lowest line number
+ * that isn't ghost. Useful to determine the start location of an item
+ * in the parsetree that has attributes.
+ * If there are no valid attributes, defaults to the passed location.
+ * 1| [@attr]           --> notice how the "start" is determined
+ * 2| let f = ...           by the attr on line 1, not the lnum of the `let`
+ *)
+let rec firstAttrLoc loc = function
+  | ((attrLoc, _) : Ast_404.Parsetree.attribute) ::attrs ->
+      if attrLoc.loc.loc_start.pos_lnum < loc.loc_start.pos_lnum
+         && not attrLoc.loc.loc_ghost
+      then
+        firstAttrLoc attrLoc.loc attrs
+      else
+        firstAttrLoc loc attrs
+  | [] -> loc
+
+let extractLocationFromValBindList expr vbs =
+  let rec extract loc = function
+    | x::xs ->
+        let {pvb_expr} = x in
+        let loc = {loc with loc_end = pvb_expr.pexp_loc.loc_end} in
+        extract loc xs
+    | [] -> loc
+  in
+  let loc = match vbs with
+    | x::xs ->
+        let {pvb_pat; pvb_expr} = x in
+        let loc = {pvb_pat.ppat_loc with loc_end = pvb_expr.pexp_loc.loc_end} in
+        extract loc xs
+    | [] -> expr.pexp_loc
+  in
+  { loc with loc_start = expr.pexp_loc.loc_start }
+
+let extractLocValBinding {pvb_pat; pvb_expr; pvb_attributes;} =
+  let estimatedLoc = firstAttrLoc pvb_pat.ppat_loc pvb_attributes in
+  {estimatedLoc with loc_end = pvb_expr.pexp_loc.loc_end}
+
+let extractLocModuleBinding {pmb_expr; pmb_attributes} =
+  let estimatedLoc = firstAttrLoc pmb_expr.pmod_loc pmb_attributes in
+  {estimatedLoc with loc_end = pmb_expr.pmod_loc.loc_end}
+
+let extractLocModDecl {pmd_type; pmd_attributes} =
+  let estimatedLoc = firstAttrLoc pmd_type.pmty_loc pmd_attributes in
+  {estimatedLoc with loc_end = pmd_type.pmty_loc.loc_end}
+
+let rec sequentialIfBlocks x =
+  match x with
+    | Some ({pexp_desc=Pexp_ifthenelse (e1, e2, els)}) -> (
+       let (nestedIfs, finalExpression) = (sequentialIfBlocks els) in
+       ((e1, e2)::nestedIfs, finalExpression)
+      )
+    | Some e -> ([], Some e)
+    | None -> ([], None)
+
+(*
+  TODO: IDE integration beginning with Vim:
+
+  - Create recovering version of parser that creates regions of "unknown"
+    content in between let sequence bindings (anything between semicolons,
+    really).
+  - Use Easy_format's "style" features to tag each known node.
+  - Turn those style annotations into editor highlight commands.
+  - Editors have a set of keys that retrigger the parsing/rehighlighting
+    process (typically newline/semi/close-brace).
+  - On every parsing/rehighlighting, this pretty printer can be used to
+    determine the highlighting of recovered regions, and the editor plugin can
+    relegate highlighting of malformed regions to the editor which mostly does
+    so based on token patterns.
+
+*)
+
+(*
+     @avoidSingleTokenWrapping
+
+  +-----------------------------+
+  |+------+                     |     Another label
+  || let ( \                    |
+  ||    a  | Label              |
+  ||    o  |                    |     The thing to the right of any label must be a
+  ||    p _+ label RHS          |     list in order for it to wrap correctly. Lists
+  ||  ): /   v                  |     will wrap if they need to/can. NON-lists will
+  |+--+ sixteenTuple = echoTuple|(    wrap (indented) even though they're no lists!
+  +---/ 0,\---------------------+     To prevent a single item from wrapping, make
+        0,                            an unbreakable list via ensureSingleTokenSticksToLabel.
+        0
+      );                              In general, the best approach for indenting
+                                      let bindings is to keep building up labels from
+                                      the "let", always ensuring things that you want
+                                      to wrap will either be lists or guarded in
+                                      [ensureSingleTokenSticksToLabel].
+                                      If you must join several lists together (via =)
+                                      (or colon), ensure that joining is done via
+                                      [makeList] (which won't break), and that new
+                                      list is always appended to the left
+                                      hand side of the label. (So that the right hand
+                                      side may always be the untouched list that you want
+                                      to wrap with aligned closing).
+                                      Always make sure rhs of the label are the
+
+                                      Creating nested labels will preserve the original
+                                      indent location ("let" in this
+                                      case) as long as that nesting is
+                                      done on the left hand side of the labels.
+
+*)
+
+(*
+    Table 2.1. Precedence and associativity.
+    Precedence from highest to lowest: From RWOC, modified to include !=
+    ---------------------------------------
+
+    Operator prefix	Associativity
+    !..., ?..., ~...	                              Prefix
+    ., .(, .[	-
+    function application, constructor, assert, lazy	Left associative
+    -, -.                                           Prefix
+    **..., lsl, lsr, asr                            Right associative
+    *..., /..., %..., mod, land, lor, lxor          Left associative
+    +..., -...                                      Left associative
+    ::                                              Right associative
+    @..., ^...                                      Right associative
+---
+    !=                                              Left associative (INFIXOP0 listed first in lexer)
+    =..., <..., >..., |..., &..., $...              Left associative (INFIXOP0)
+    =, <, >                                         Left associative (IN SAME row as INFIXOP0 listed after)
+---
+    &, &&                                           Right associative
+    or, ||                                          Right associative
+    ,                                               -
+    :=, =                                         	Right associative
+    if                                              -
+    ;                                               Right associative
+
+
+   Note: It would be much better if &... and |... were in separate precedence
+   groups just as & and | are. This way, we could encourage custom infix
+   operators to use one of the two precedences and no one would be confused as
+   to precedence (leading &, | are intuitive). Two precedence classes for the
+   majority of infix operators is totally sufficient.
+
+   TODO: Free up the (&) operator from pervasives so it can be reused for
+   something very common such as string concatenation or list appending.
+
+   let x = tail & head;
+ *)
+
+(* "Almost Simple Prefix" function applications parse with the rule:
+
+   `PREFIXOP simple_expr %prec below_DOT_AND_SHARP`, which in turn is almost
+   considered a "simple expression" (it's acceptable anywhere a simple
+   expression is except in a couple of edge cases.
+
+   "Unary Prefix" function applications parse with the rule:
+
+   `MINUS epxr %prec prec_unary_minus`, which in turn is considered an
+   "expression" (not simple). All unary operators are mapped into an identifier
+   beginning with "~".
+
+   TODO: Migrate all "almost simple prefix" to "unsary prefix". When `!`
+   becomes "not", then it will make more sense that !myFunc (arg) is parsed as
+   !(myFunc arg) instead of (!myFunc) arg.
+
+ *)
+let almost_simple_prefix_symbols  = [ '!'; '?'; '~'] ;;
+(* Subset of prefix symbols that have special "unary precedence" *)
+let unary_minus_prefix_symbols  = [ "~-"; "~-."] ;;
+let unary_plus_prefix_symbols  = ["~+"; "~+." ] ;;
+let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
+                      '$'; '%'; '\\'; '#' ]
+
+let special_infix_strings =
+  ["asr"; "land"; "lor"; "lsl"; "lsr"; "lxor"; "mod"; "or"; ":="; "!="; "!=="]
+
+let updateToken = "="
+let sharpOpEqualToken = "#="
+let pipeFirstToken = "->"
+let requireIndentFor = [updateToken; ":="]
+
+let namedArgSym = "~"
+
+let requireNoSpaceFor tok =
+  tok = pipeFirstToken || (tok.[0] = '#' && tok <> "#=")
+
+let funToken = "fun"
+
+let getPrintableUnaryIdent s =
+  if List.mem s unary_minus_prefix_symbols ||
+     List.mem s unary_plus_prefix_symbols
+  then String.sub s 1 (String.length s -1)
+  else s
+
+(* determines if the string is an infix string.
+   checks backwards, first allowing a renaming postfix ("_102") which
+   may have resulted from Pexp -> Texp -> Pexp translation, then checking
+   if all the characters in the beginning of the string are valid infix
+   characters. *)
+let printedStringAndFixity = function
+  | s when List.mem s special_infix_strings -> Infix s
+  | "^" -> UnaryPostfix "^"
+  | s when List.mem s.[0] infix_symbols -> Infix s
+  (* Correctness under assumption that unary operators are stored in AST with
+     leading "~" *)
+  | s when List.mem s.[0] almost_simple_prefix_symbols &&
+           not (List.mem s special_infix_strings) &&
+           not (s = "?") -> (
+      (* What *kind* of prefix fixity? *)
+      if List.mem s unary_plus_prefix_symbols then
+        UnaryPlusPrefix (getPrintableUnaryIdent s)
+      else if List.mem s unary_minus_prefix_symbols then
+        UnaryMinusPrefix (getPrintableUnaryIdent s)
+      else if s = "!" then
+        UnaryNotPrefix s
+      else
+        AlmostSimplePrefix s
+  )
+  | _ -> Normal
+
+
+(* Also, this doesn't account for != and !== being infixop!!! *)
+let isSimplePrefixToken s = match printedStringAndFixity s with
+  | AlmostSimplePrefix _ | UnaryPostfix "^" -> true
+  | _ -> false
+
+
+(* Convenient bank of information that represents the parser's precedence
+   rankings.  Each instance describes a precedence table entry. The function
+   tests either a token string encountered by the parser, or (in the case of
+   `CustomPrecedence`) the string name of a custom rule precedence declared
+   using %prec *)
+let rules = [
+  [
+    (TokenPrecedence, (fun s -> (Left, s = pipeFirstToken)));
+    (TokenPrecedence, (fun s -> (Left, s.[0] = '#' &&
+                                       s <> sharpOpEqualToken &&
+                                       s <> "#")));
+    (TokenPrecedence, (fun s -> (Left, s = ".")));
+    (CustomPrecedence, (fun s -> (Left, s = "prec_lbracket")));
+  ];
+  [
+    (CustomPrecedence, (fun s -> (Nonassoc, s = "prec_functionAppl")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, isSimplePrefixToken s)));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Left, s = sharpOpEqualToken)));
+  ];
+  [
+    (CustomPrecedence, (fun s -> (Nonassoc, s = "prec_unary")));
+  ];
+  (* Note the special case for "*\*", BARBAR, and LESSMINUS, AMPERSAND(s) *)
+  [
+    (TokenPrecedence, (fun s -> (Right, s = "**")));
+    (TokenPrecedence, (fun s -> (Right, String.length s > 1 && s.[0] == '*' && s.[1] == '\\' && s.[2] == '*')));
+    (TokenPrecedence, (fun s -> (Right, s = "lsl")));
+    (TokenPrecedence, (fun s -> (Right, s = "lsr")));
+    (TokenPrecedence, (fun s -> (Right, s = "asr")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '*' && (String.length s == 1 || s != "*\\*"))));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '/')));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '%' )));
+    (TokenPrecedence, (fun s -> (Left, s = "mod" )));
+    (TokenPrecedence, (fun s -> (Left, s = "land" )));
+    (TokenPrecedence, (fun s -> (Left, s = "lor" )));
+    (TokenPrecedence, (fun s -> (Left, s = "lxor" )));
+  ];
+  [
+    (* Even though these use the same *tokens* as unary plus/minus at parse
+       time, when unparsing infix -/+, the CustomPrecedence rule would be
+       incorrect to use, and instead we need a rule that models what infix
+       parsing would use - just the regular token precedence without a custom
+       precedence. *)
+    (TokenPrecedence,
+    (fun s -> (
+      Left,
+      if String.length s > 1 && s.[0] == '+' && s.[1] == '+' then
+        (*
+          Explicitly call this out as false because the other ++ case below
+          should have higher *lexing* priority. ++operator_chars* is considered an
+          entirely different token than +(non_plus_operator_chars)*
+        *)
+        false
+      else
+        s.[0] == '+'
+    )));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '-' && s <> pipeFirstToken)));
+    (TokenPrecedence, (fun s -> (Left, s = "!" )));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s = "::")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s.[0] == '@')));
+    (TokenPrecedence, (fun s -> (Right, s.[0] == '^')));
+    (TokenPrecedence, (fun s -> (Right, String.length s > 1 && s.[0] == '+' && s.[1] == '+')));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '=' && not (s = "=") && not (s = "=>"))));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '<' && not (s = "<"))));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '>' && not (s = ">"))));
+    (TokenPrecedence, (fun s -> (Left, s = "!=")));  (* Not preset in the RWO table! *)
+    (TokenPrecedence, (fun s -> (Left, s = "!==")));  (* Not preset in the RWO table! *)
+    (TokenPrecedence, (fun s -> (Left, s = "==")));
+    (TokenPrecedence, (fun s -> (Left, s = "===")));
+    (TokenPrecedence, (fun s -> (Left, s = "<")));
+    (TokenPrecedence, (fun s -> (Left, s = ">")));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '|' && not (s = "||"))));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '&' && not (s = "&") && not (s = "&&"))));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '$')));
+  ];
+  [
+    (CustomPrecedence, (fun s -> (Left, s = funToken)));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s = "&")));
+    (TokenPrecedence, (fun s -> (Right, s = "&&")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s = "or")));
+    (TokenPrecedence, (fun s -> (Right, s = "||")));
+  ];
+  [
+    (* The Left shouldn't ever matter in practice. Should never get in a
+       situation with two consecutive infix ? - the colon saves us. *)
+    (TokenPrecedence, (fun s -> (Left, s = "?")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s = ":=")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s = updateToken)));
+  ];
+  (* It's important to account for ternary ":" being lower precedence than "?" *)
+  [
+    (TokenPrecedence, (fun s -> (Right, s = ":")))
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Nonassoc, s = "=>")));
+  ];
+]
+
+(* remove all prefixing backslashes, e.g. \=== becomes === *)
+let without_prefixed_backslashes str =
+  if str = "" then str
+  else if String.get str 0 = '\\' then String.sub str 1 (String.length str - 1)
+  else str
+
+let indexOfFirstMatch ~prec lst =
+  let rec aux n = function
+    | [] -> None
+    | [] :: tl -> aux (n + 1) tl
+    | ((kind, tester) :: hdTl) :: tl ->
+      match prec, kind with
+      | Token str, TokenPrecedence | Custom str, CustomPrecedence ->
+        let associativity, foundMatch = tester str in
+        if foundMatch
+        then Some (associativity, n)
+        else aux n (hdTl::tl)
+      | _ -> aux n (hdTl::tl)
+  in
+  aux 0 lst
+
+(* Assuming it's an infix function application. *)
+let precedenceInfo ~prec =
+  (* Removes prefixed backslashes in order to do proper conversion *)
+  let prec = match prec with
+    | Token str -> Token (without_prefixed_backslashes str)
+    | Custom _ -> prec
+  in
+  indexOfFirstMatch ~prec rules
+
+let isLeftAssociative ~prec = match precedenceInfo ~prec with
+  | None -> false
+  | Some (Left, _) -> true
+  | Some (Right, _) -> false
+  | Some (Nonassoc, _) -> false
+
+let isRightAssociative ~prec = match precedenceInfo ~prec with
+  | None -> false
+  | Some (Right, _) -> true
+  | Some (Left, _) -> false
+  | Some (Nonassoc, _) -> false
+
+let higherPrecedenceThan c1 c2 =
+  match ((precedenceInfo ~prec:c1), (precedenceInfo ~prec:c2)) with
+  | (_, None)
+  | (None, _) ->
+    let (str1, str2) = match (c1, c2) with
+      | (Token s1, Token s2) -> ("Token " ^ s1, "Token " ^ s2)
+      | (Token s1, Custom s2) -> ("Token " ^ s1, "Custom " ^ s2)
+      | (Custom s1, Token s2) -> ("Custom " ^ s1, "Token " ^ s2)
+      | (Custom s1, Custom s2) -> ("Custom " ^ s1, "Custom " ^ s2)
+    in
+    raise (NotPossible ("Cannot determine precedence of two checks " ^ str1 ^ " vs. " ^ str2))
+  | (Some (_, p1), Some (_, p2)) -> p1 < p2
+
+let printedStringAndFixityExpr = function
+  | {pexp_desc = Pexp_ident {txt=Lident l}} -> printedStringAndFixity l
+  | _ -> Normal
+
+(* which identifiers are in fact operators needing parentheses *)
+let needs_parens txt =
+  match printedStringAndFixity txt with
+  | Infix _ -> true
+  | UnaryPostfix _ -> true
+  | UnaryPlusPrefix _ -> true
+  | UnaryMinusPrefix _ -> true
+  | UnaryNotPrefix _ -> true
+  | AlmostSimplePrefix _ -> true
+  | Normal -> false
+
+(* some infixes need spaces around parens to avoid clashes with comment
+   syntax. This isn't needed for comment syntax /* */ *)
+let needs_spaces txt =
+  txt.[0]='*' || txt.[String.length txt - 1] = '*'
+
+let rec orList = function (* only consider ((A|B)|C)*)
+  | {ppat_desc = Ppat_or (p1, p2)} -> (orList p1) @ (orList p2)
+  | x -> [x]
+
+let override = function
+  | Override -> "!"
+  | Fresh -> ""
+
+(* variance encoding: need to sync up with the [parser.mly] *)
+let type_variance = function
+  | Invariant -> ""
+  | Covariant -> "+"
+  | Contravariant -> "-"
+
+type construct =
+  [ `cons of expression list
+  | `list of expression list
+  | `nil
+  | `normal
+  | `simple of Longident.t
+  | `tuple ]
+
+let view_expr x =
+  match x.pexp_desc with
+  | Pexp_construct ( {txt= Lident "()"},_) -> `tuple
+  | Pexp_construct ( {txt= Lident "[]"},_) -> `nil
+  | Pexp_construct ( {txt= Lident"::"},Some _) ->
+    let rec loop exp acc = match exp with
+      | {pexp_desc=Pexp_construct ({txt=Lident "[]"},_)} ->
+        (List.rev acc,true)
+      | {pexp_desc=
+          Pexp_construct ({txt=Lident "::"},
+                           Some ({pexp_desc= Pexp_tuple([e1;e2])}))} ->
+        loop e2 (e1::acc)
+      | e -> (List.rev (e::acc),false) in
+    let (ls,b) = loop x []  in
+    if b
+    then `list ls
+    else `cons ls
+  | Pexp_construct (x,None) -> `simple x.txt
+  | _ -> `normal
+
+let is_simple_list_expr x =
+  match view_expr x with
+  | `list _ | `cons _ -> true
+  | _ -> false
+
+let is_simple_construct : construct -> bool = function
+  | `nil | `tuple | `list _ | `simple _ | `cons _  -> true
+  | `normal -> false
+
+let uncurriedTable = Hashtbl.create 42
+
+(* Determines if a list of expressions contains a single unit construct
+ * e.g. used to check: MyConstructor() -> exprList == [()]
+ * useful to determine if MyConstructor(()) should be printed as MyConstructor()
+ * *)
+let is_single_unit_construct exprList =
+  match exprList with
+  | x::[] ->
+    let view = view_expr x in
+    (match view with
+    | `tuple -> true
+    | _ -> false)
+  | _ -> false
+
+let detectTernary l = match l with
+  | [{
+      pc_lhs={ppat_desc=Ppat_construct ({txt=Lident "true"}, _)};
+      pc_guard=None;
+      pc_rhs=ifTrue
+    };
+    {
+      pc_lhs={ppat_desc=Ppat_construct ({txt=Lident "false"}, _)};
+      pc_guard=None;
+      pc_rhs=ifFalse
+    }] -> Some (ifTrue, ifFalse)
+  | _ -> None
+type funcApplicationLabelStyle =
+  (* No attaching to the label, but if the entire application fits on one line,
+     the entire application will appear next to the label as you 'd expect. *)
+  | NeverWrapFinalItem
+  (* Attach the first term if there are exactly two terms involved in the
+     application.
+
+     let x = firstTerm (secondTerm_1 secondTerm_2) thirdTerm;
+
+     Ideally, we'd be able to attach all but the last argument into the label any
+     time all but the last term will fit - and *not* when (attaching all but
+     the last term isn't enough to prevent a wrap) - But there's no way to tell
+     ahead of time if it would prevent a wrap.
+
+     However, the number two is somewhat convenient. This models the
+     indentation that you'd prefer in non-curried syntax languages like
+     JavaScript, where application only ever has two terms.
+  *)
+  | WrapFinalListyItemIfFewerThan of int
+
+type formatSettings = {
+  (* Whether or not to expect that the original parser that generated the AST
+     would have annotated constructor argument tuples with explicit arity to
+     indicate that they are multiple arguments. (True if parsed in original
+     OCaml AST, false if using Reason parser).
+  *)
+  constructorTupleImplicitArity: bool;
+  space: int;
+
+  (* For curried arguments in function *definitions* only: Number of [space]s
+     to offset beyond the [let] keyword. Default 1.
+  *)
+  listsRecordsIndent: int;
+
+  indentWrappedPatternArgs: int;
+
+  indentMatchCases: int;
+
+  (* Amount to indent in label-like constructs such as wrapped function
+     applications, etc - or even record fields. This is not the same concept as an
+     indented curried argument list. *)
+  indentAfterLabels: int;
+
+  (* Amount to indent after the opening brace of switch/try.
+     Here's an example of what it would look like w/ [trySwitchIndent = 2]:
+     Sticks the expression to the last item in a sequence in several [X | Y | Z
+     => expr], and forces X, Y, Z to be split onto several lines. (Otherwise,
+     sticking to Z would result in hanging expressions).  TODO: In the first case,
+     it's clear that we want patterns to have an "extra" indentation with matching
+     in a "match". Create extra config param to pass to [self#pattern] for extra
+     indentation in this one case.
+
+      switch x {
+      | TwoCombos
+          (HeresTwoConstructorArguments x y)
+          (HeresTwoConstructorArguments a b) =>
+          ((a + b) + x) + y;
+      | Short
+      | AlsoHasARecord a b {x, y} => (
+          retOne,
+          retTwo
+        )
+      | AlsoHasARecord a b {x, y} =>
+        callMyFunction
+          withArg
+          withArg
+          withArg
+          withArg;
+      }
+  *)
+  trySwitchIndent: int;
+
+
+  (* In the case of two term function application (when flattened), the first
+     term should become part of the label, and the second term should be able to wrap
+     This doesn't effect n != 2.
+
+       [true]
+       let x = reallyShort allFitsOnOneLine;
+       let x = someFunction {
+         reallyLongObject: true,
+         thatWouldntFitOnThe: true,
+         firstLine: true
+       };
+
+       [false]
+       let x = reallyShort allFitsOnOneLine;
+       let x =
+        someFunction
+          {
+            reallyLongObject: true,
+            thatWouldntFitOnThe: true,
+            firstLine: true
+          };
+  *)
+  funcApplicationLabelStyle: funcApplicationLabelStyle;
+
+  funcCurriedPatternStyle: funcApplicationLabelStyle;
+
+  width: int;
+
+  assumeExplicitArity: bool;
+
+  constructorLists: string list;
+}
+
+let defaultSettings = {
+  constructorTupleImplicitArity = false;
+  space = 1;
+  listsRecordsIndent = 2;
+  indentWrappedPatternArgs = 2;
+  indentMatchCases = 2;
+  indentAfterLabels = 2;
+  trySwitchIndent = 0;
+  funcApplicationLabelStyle = WrapFinalListyItemIfFewerThan 3;
+  (* WrapFinalListyItemIfFewerThan is currently a bad idea for curried
+     arguments: It looks great in some cases:
+
+        let myFun (a:int) :(
+          int,
+          string
+        ) => (a, "this is a");
+
+     But horrible in others:
+
+        let myFun
+            {
+              myField,
+              yourField
+            } :someReturnType => myField + yourField;
+
+        let myFun
+            {            // Curried arg wraps
+              myField,
+              yourField
+            } : (       // But the last is "listy" so it docks
+          int,          // To the [let].
+          int,
+          int
+        ) => myField + yourField;
+
+     We probably want some special listy label docking/wrapping mode for
+     curried function bindings.
+
+  *)
+  funcCurriedPatternStyle = NeverWrapFinalItem;
+  width = 80;
+  assumeExplicitArity = false;
+  constructorLists = [];
+}
+let configuredSettings = ref defaultSettings
+
+let configure ~width ~assumeExplicitArity ~constructorLists = (
+  configuredSettings := {defaultSettings with width; assumeExplicitArity; constructorLists}
+)
+
+let createFormatter () =
+let module Formatter = struct
+
+let settings = !configuredSettings
+
+
+(* How do we make
+   this a label?
+
+   /---------------------\
+   let myVal = (oneThing, {
+   field: [],
+   anotherField: blah
+   });
+
+   But in this case, this wider region a label?
+   /------------------------------------------------------\
+   let myVal = callSomeFunc (oneThing, {field: [], anotherField: blah}, {
+   boo: 'hi'
+   });
+
+   This is difficult. You must form a label from the preorder traversal of every
+   node - except the last encountered in the traversal. An easier heuristic is:
+
+   - The last argument to a functor application is expanded.
+
+   React.CreateClass SomeThing {
+   let render {props} => {
+   };
+   }
+
+   - The last argument to a function application is expanded on the same line.
+   - Only if it's not curried with another invocation.
+   -- Optionally: "only if everything else is an atom"
+   -- Optionally: "only if there are no other args"
+
+   React.createClass someThing {
+   render: fn x => y,
+   }
+
+   !!! NOT THIS
+   React.createClass someThing {
+   render: fn x => y,
+   }
+   somethingElse
+*)
+
+let isArityClear attrs =
+  (!configuredSettings).assumeExplicitArity ||
+  List.exists
+    (function
+      | ({txt="explicit_arity"}, _) -> true
+      | _ -> false
+    )
+    attrs
+
+let default_indent_body =
+  settings.listsRecordsIndent * settings.space
+
+let makeList
+    ?listConfigIfCommentsInterleaved
+    ?listConfigIfEolCommentsInterleaved
+    ?(break=Layout.Never)
+    ?(wrap=("", ""))
+    ?(inline=(true, false))
+    ?(sep=Layout.NoSep)
+    ?(indent=default_indent_body)
+    ?(sepLeft=true)
+    ?(preSpace=false)
+    ?(postSpace=false)
+    ?(pad=(false,false))
+    lst =
+  let config =
+    { Layout.
+      listConfigIfCommentsInterleaved; listConfigIfEolCommentsInterleaved;
+      break; wrap; inline; sep; indent; sepLeft; preSpace; postSpace; pad;
+    }
+  in
+  Layout.Sequence (config, lst)
+
+let makeAppList = function
+  | [hd] -> hd
+  | l -> makeList ~inline:(true, true) ~postSpace:true ~break:IfNeed l
+
+let makeTup ?(wrap=("", ""))?(trailComma=true) ?(uncurried = false) l =
+  let (lwrap, rwrap) = wrap in
+  let lparen = lwrap ^ (if uncurried then "(. " else "(") in
+  makeList
+    ~wrap:(lparen, ")" ^ rwrap)
+    ~sep:(if trailComma then commaTrail else commaSep)
+    ~postSpace:true
+    ~break:IfNeed l
+
+let ensureSingleTokenSticksToLabel x =
+  let listConfigIfCommentsInterleaved cfg =
+    let inline = (true, true) and postSpace = true and indent = 0 in
+    {cfg with Layout.break=Always_rec; postSpace; indent; inline}
+  in
+  makeList ~listConfigIfCommentsInterleaved [x]
+
+let unbreakLabelFormatter formatter =
+  let newFormatter labelTerm term =
+    match formatter labelTerm term with
+    | Easy_format.Label ((labelTerm, settings), term) ->
+       Easy_format.Label ((labelTerm,
+                           {settings with label_break = `Never}),
+                          term)
+    | _ -> failwith "not a label"
+  in newFormatter
+
+let inlineLabel labelTerm term =
+  let settings = {
+    label_break = `Never;
+    space_after_label = true;
+    indent_after_label = 0;
+    label_style = Some "inlineLabel";
+  } in
+  Easy_format.Label ((labelTerm, settings), term)
+
+
+(* Just for debugging: Set debugWithHtml = true *)
+let debugWithHtml = ref false
+
+let html_escape_string s =
+  let buf = Buffer.create (2 * String.length s) in
+  for i = 0 to String.length s - 1 do
+    match s.[i] with
+        '&' -> Buffer.add_string buf "&amp;"
+      | '<' -> Buffer.add_string buf "&lt;"
+      | '>' -> Buffer.add_string buf "&gt;"
+      | c -> Buffer.add_char buf c
+  done;
+  Buffer.contents buf
+
+let html_escape = `Escape_string html_escape_string
+
+let html_style = [
+  "atom", { Easy_format.tag_open = "<a>"; tag_close = "</a>" };
+  "body", { tag_open = "<lb>"; tag_close = "</lb>" };
+  "list", { tag_open = "<l>"; tag_close = "</l>" };
+  "op", { tag_open = "<op>"; tag_close = "</op>" };
+  "cl", { tag_open = "<cl>"; tag_close = "</cl>" };
+  "sep", { tag_open = "<sep>"; tag_close = "</sep>" };
+  "label", { tag_open = "<la>"; tag_close = "</la>" };
+]
+
+let easyLabel
+    ?(break=`Auto) ?(space=false) ?(indent=settings.indentAfterLabels)
+    labelTerm term =
+  let settings = {
+    label_break = break;
+    space_after_label = space;
+    indent_after_label = indent;
+    label_style = Some "label";
+  } in
+  Easy_format.Label ((labelTerm, settings), term)
+
+let label ?break ?space ?indent (labelTerm:Layout.t) (term:Layout.t) =
+  Layout.Label (easyLabel ?break ?indent ?space, labelTerm, term)
+
+let atom ?loc str =
+  let style = { Easy_format.atom_style = Some "atomClss" } in
+  source_map ?loc (Layout.Easy (Easy_format.Atom(str, style)))
+
+(** Take x,y,z and n and generate [x, y, z, ...n] *)
+let makeES6List ?wrap:((lwrap,rwrap)=("", "")) lst last =
+  makeList
+    ~wrap:(lwrap ^ "[", "]" ^ rwrap)
+    ~break:IfNeed ~postSpace:true ~sep:commaTrail
+    (lst @ [makeList [atom "..."; last]])
+
+let makeNonIndentedBreakingList lst =
+    (* No align closing: So that semis stick to the ends of every break *)
+  makeList ~break:Always_rec ~indent:0 ~inline:(true, true) lst
+
+(* Like a <span> could place with other breakableInline lists without upsetting final semicolons *)
+let makeSpacedBreakableInlineList lst =
+  makeList ~break:IfNeed ~inline:(true, true) ~postSpace:true lst
+
+let makeCommaBreakableListSurround opn cls lst =
+  makeList ~break:IfNeed ~postSpace:true ~sep:(Sep ",") ~wrap:(opn, cls) lst
+
+(* TODO: Allow configuration of spacing around colon symbol *)
+
+let formatPrecedence ?(inline=false) ?(wrap=("(", ")")) ?loc formattedTerm =
+  source_map ?loc (makeList ~inline:(true, inline) ~wrap ~break:IfNeed [formattedTerm])
+
+let wrap fn term =
+  ignore (Format.flush_str_formatter ());
+  fn Format.str_formatter term;
+  atom (Format.flush_str_formatter ())
+
+(* Don't use `trim` since it kills line return too? *)
+let rec beginsWithStar_ line length idx =
+  if idx = length then false else
+    match String.get line idx with
+    | '*' -> true
+    | '\t' | ' ' -> beginsWithStar_ line length (idx + 1)
+    | _ -> false
+
+let beginsWithStar line = beginsWithStar_ line (String.length line) 0
+
+let rec numLeadingSpace_ line length idx accum =
+  if idx = length then accum else
+    match String.get line idx with
+    | '\t' | ' ' -> numLeadingSpace_ line length (idx + 1) (accum + 1)
+    | _ -> accum
+
+let numLeadingSpace line = numLeadingSpace_ line (String.length line) 0 0
+
+(* Computes the smallest leading spaces for non-empty lines *)
+let smallestLeadingSpaces strs =
+  let rec smallestLeadingSpaces curMin strs = match strs with
+    | [] -> curMin
+    | ""::tl -> smallestLeadingSpaces curMin tl
+    | hd::tl ->
+      let leadingSpace = numLeadingSpace hd in
+      let nextMin = min curMin leadingSpace in
+      smallestLeadingSpaces nextMin tl
+  in
+  smallestLeadingSpaces 99999 strs
+
+let rec isSequencey = function
+  | Layout.SourceMap (_, sub) -> isSequencey sub
+  | Layout.Sequence _ -> true
+  | Layout.Label (_, _, _) -> false
+  | Layout.Easy (Easy_format.List _) -> true
+  | Layout.Easy _ -> false
+  | Layout.Whitespace (_, sub) -> isSequencey sub
+
+let inline ?(preSpace=false) ?(postSpace=false) labelTerm term =
+  makeList [labelTerm; term]
+    ~inline:(true, true) ~postSpace ~preSpace ~indent:0 ~break:Layout.Never
+
+let breakline labelTerm term =
+  makeList [labelTerm; term]
+    ~inline:(true, true) ~indent:0 ~break:Always_rec
+
+let insertBlankLines n term =
+  if n = 0
+  then term
+  else makeList ~inline:(true, true) ~indent:0 ~break:Always_rec
+      (Array.to_list (Array.make n (atom "")) @ [term])
+
+let string_after s n = String.sub s n (String.length s - n)
+
+(* This is a special-purpose functions only used by `formatComment_`. Notice we
+skip a char below during usage because we know the comment starts with `/*` *)
+let rec lineZeroMeaningfulContent_ line length idx accum =
+  if idx = length then None
+  else
+    let ch = String.get line idx in
+    if ch = '\t' || ch = ' ' || ch = '*' then
+      lineZeroMeaningfulContent_ line length (idx + 1) (accum + 1)
+    else Some accum
+
+let lineZeroMeaningfulContent line =
+  lineZeroMeaningfulContent_ line (String.length line) 1 0
+
+let formatComment_ txt =
+  let commLines =
+    Reason_syntax_util.split_by ~keep_empty:true (fun x -> x = '\n')
+      (Comment.wrap txt)
+  in
+  match commLines with
+  | [] -> atom ""
+  | [hd] ->
+    atom hd
+  | zero::one::tl ->
+    let attemptRemoveCount = (smallestLeadingSpaces (one::tl)) in
+    let leftPad =
+      if beginsWithStar one then 1
+      else match lineZeroMeaningfulContent zero with
+        | None -> 1
+        | Some num -> num + 1
+    in
+    let padNonOpeningLine s =
+      let numLeadingSpaceForThisLine = numLeadingSpace s in
+      if String.length s == 0 then ""
+      else (String.make leftPad ' ') ^
+           (string_after s (min attemptRemoveCount numLeadingSpaceForThisLine)) in
+    let lines = zero :: List.map padNonOpeningLine (one::tl) in
+    makeList ~inline:(true, true) ~indent:0 ~break:Always_rec (List.map atom lines)
+
+let formatComment comment =
+  source_map ~loc:(Comment.location comment) (formatComment_ comment)
+
+let rec append ?(space=false) txt = function
+  | Layout.SourceMap (loc, sub) ->
+    Layout.SourceMap (loc, append ~space txt sub)
+  | Sequence (config, l) when snd config.wrap <> "" ->
+    let sep = if space then " " else "" in
+    Sequence ({config with wrap=(fst config.wrap, snd config.wrap ^ sep ^ txt)}, l)
+  | Sequence (config, []) ->
+    Sequence (config, [atom txt])
+  | Sequence ({sep=NoSep} as config, l)
+  | Sequence ({sep=Sep("")} as config, l) ->
+    let len = List.length l in
+    let sub = List.mapi (fun i layout ->
+        (* append to the end of the list *)
+        if i + 1 = len then
+          append ~space txt layout
+        else
+          layout
+      ) l in
+    Sequence (config, sub)
+  | Label (formatter, left, right) ->
+    Label (formatter, left, append ~space txt right)
+  | Whitespace(info, sub) ->
+      Whitespace(info, append ~space txt sub)
+  | layout ->
+    inline ~postSpace:space layout (atom txt)
+
+let appendSep spaceBeforeSep sep layout =
+  append (if spaceBeforeSep then " " ^ sep else sep) layout
+
+let rec flattenCommentAndSep ?spaceBeforeSep:(spaceBeforeSep=false) ?sepStr = function
+  | Layout.SourceMap (loc, sub) ->
+     Layout.SourceMap (loc, flattenCommentAndSep ~spaceBeforeSep ?sepStr sub)
+  | Layout.Whitespace(info, sub) ->
+     Layout.Whitespace(info, flattenCommentAndSep ~spaceBeforeSep ?sepStr sub)
+  | layout ->
+     begin
+       match sepStr with
+       | None -> layout
+       | Some sep -> appendSep spaceBeforeSep sep layout
+     end
+
+let rec preOrderWalk f layout =
+  match f layout with
+  | Layout.Sequence (listConfig, sublayouts) ->
+    let newSublayouts = List.map (preOrderWalk f) sublayouts in
+    Layout.Sequence (listConfig, newSublayouts)
+  | Layout.Label (formatter, left, right) ->
+    let newLeftLayout = preOrderWalk f left in
+    let newRightLayout = preOrderWalk f right in
+    Layout.Label (formatter, newLeftLayout, newRightLayout)
+  | Layout.SourceMap (loc, sub) ->
+    Layout.SourceMap (loc, preOrderWalk f sub)
+  | Layout.Easy _ as layout -> layout
+  | Layout.Whitespace (info, sub) ->
+      Layout.Whitespace(info, preOrderWalk f sub)
+
+(** Recursively unbreaks a layout to make sure they stay within the same line *)
+let unbreaklayout = preOrderWalk (function
+  | Layout.Sequence (listConfig, sublayouts) ->
+    Layout.Sequence ({listConfig with break=Layout.Never}, sublayouts)
+  | Layout.Label (formatter, left, right) ->
+    Layout.Label (unbreakLabelFormatter formatter, left, right)
+  | layout -> layout
+)
+
+(** [consolidateSeparator layout] walks the [layout], extract separators out of each
+ *  list and insert them into PrintTree as separated items
+ *)
+let consolidateSeparator l = preOrderWalk (function
+  | Sequence (listConfig, sublayouts) when listConfig.sep != NoSep && listConfig.sepLeft ->
+     (* TODO: Support !sepLeft, and this should apply to the *first* separator if !sepLeft.  *)
+     let sublayoutsLen = List.length sublayouts in
+     let mapSublayout i layout =
+        match (listConfig.sep, (i + 1 = sublayoutsLen)) with
+        | (NoSep, _) -> raise (NotPossible "We already covered this case. This shouldn't happen.")
+        | (Sep _, true) -> layout
+        | (SepFinal (sepStr, _), false)
+        | (Sep sepStr, false) ->
+          flattenCommentAndSep ~spaceBeforeSep:listConfig.preSpace ~sepStr:sepStr layout
+        | (SepFinal (_, finalSepStr), true) ->
+          flattenCommentAndSep ~spaceBeforeSep:listConfig.preSpace ~sepStr:finalSepStr layout
+     in
+     let layoutsWithSepAndComment = List.mapi mapSublayout sublayouts in
+     let sep = Layout.NoSep in
+     let preSpace = false in
+     Sequence ({listConfig with sep; preSpace}, layoutsWithSepAndComment)
+  | layout -> layout
+) l
+
+
+(** [insertLinesAboveItems layout] walks the [layout] and insert empty lines *)
+let insertLinesAboveItems items = preOrderWalk (function
+  | Whitespace(region, sub) ->
+      insertBlankLines (WhitespaceRegion.newlines region) sub
+  | layout -> layout
+) items
+
+let insertCommentIntoWhitespaceRegion comment region subLayout =
+  let cl = Comment.location comment in
+  let range = WhitespaceRegion.range region in
+  (* append the comment to the list of inserted comments in the whitespace region *)
+  let nextRegion = WhitespaceRegion.addComment region comment in
+  let formattedComment = formatComment comment in
+  match WhitespaceRegion.comments region with
+  (* the comment inserted into the whitespace region is the first in the region *)
+  | [] ->
+      (*
+       * 1| let a = 1;
+       * 2|
+       * 3| /* comment at end of whitespace region */
+       * 4| let b = 2;
+       *)
+      if range.lnum_end = cl.loc_end.pos_lnum then
+        let subLayout = breakline formattedComment subLayout in
+        Layout.Whitespace(nextRegion, subLayout)
+
+      (*
+       * 1| let a = 1;
+       * 2| /* comment at start of whitespace region */
+       * 3|
+       * 4| let b = 2;
+       *)
+      else if range.lnum_start = cl.loc_start.pos_lnum then
+        let subLayout = breakline formattedComment (insertBlankLines 1 subLayout) in
+        let nextRegion = WhitespaceRegion.modifyNewlines nextRegion 0 in
+        Whitespace(nextRegion, subLayout)
+
+      (*
+       * 1| let a = 1;
+       * 2|
+       * 3| /* comment floats in whitespace region */
+       * 4|
+       * 5| let b = 2;
+       *)
+      else
+        let subLayout = breakline formattedComment (insertBlankLines 1 subLayout) in
+        Whitespace(nextRegion, subLayout)
+
+  (* The whitespace region contains already inserted comments *)
+  | prevComment::_cs ->
+      let pcl = Comment.location prevComment in
+      (* check if the comment is attached to the start of the region *)
+      let attachedToStartRegion = cl.loc_start.pos_lnum = range.lnum_start in
+      let nextRegion =
+        (*
+         * 1| let a = 1;
+         * 2| /* comment sits on the beginning of the region */
+         * 3| /* previous comment */
+         * 4|
+         * 5| let b = 2;
+         *)
+        if attachedToStartRegion then
+          (* we don't want a newline between `let a = 1` and the `comment sits
+           * on the beginning of the region` comment*)
+          WhitespaceRegion.modifyNewlines nextRegion 0
+        (*
+         * 1| let a = 1;
+         * 2|
+         * 3| /* comment isn't located at the beginnin of a region*/
+         * 4| /* previous comment */
+         * 5|
+         * 6| let b = 2;
+         *)
+        else
+          nextRegion
+      in
+      (*
+       * 1| let a = 1;
+       * 2| /* comment */
+       * 3|                      --> whitespace between
+       * 4| /* previous comment */
+       * 5| let b = 1;
+       *)
+      if Reason_location.hasSpaceBetween pcl cl then
+      (* pcl.loc_start.pos_lnum - cl.loc_end.pos_lnum > 1 then *)
+        let subLayout = breakline formattedComment (insertBlankLines 1 subLayout) in
+        let withComment = Layout.Whitespace(nextRegion, subLayout) in
+        withComment
+
+      (*
+       * 1| let a = 1;
+       * 2|
+       * 3| /* comment */          | no whitespace between `comment`
+       * 4| /* previous comment */ | and `previous comment`
+       * 5| let b = 1;
+       *)
+      else
+        let subLayout = breakline formattedComment subLayout in
+        let withComment =  Layout.Whitespace(nextRegion, subLayout) in
+        withComment
+
+(**
+ * prependSingleLineComment inserts a single line comment right above layout
+ *)
+let rec prependSingleLineComment comment layout =
+  match layout with
+  | Layout.SourceMap (loc, sub) ->
+     Layout.SourceMap (loc, prependSingleLineComment comment sub)
+  | Sequence (config, hd::tl) when config.break = Always_rec->
+     Sequence(config, (prependSingleLineComment comment hd)::tl)
+  | Whitespace(info, sub) ->
+      insertCommentIntoWhitespaceRegion comment info sub
+  | layout ->
+      breakline (formatComment comment) layout
+
+(* breakAncestors break ancestors above node, but not comment attachment itself.*)
+let appendComment ~breakAncestors layout comment =
+  let text = Comment.wrap comment in
+  let layout = match layout with
+  | Layout.Whitespace(info, sublayout) ->
+    Layout.Whitespace(info, makeList ~break:Layout.Never ~postSpace:true [sublayout; atom text])
+  | layout ->
+      makeList ~break:Layout.Never ~postSpace:true [layout; atom text]
+  in
+  if breakAncestors then
+    makeList ~inline:(true, true) ~postSpace:false ~preSpace:true ~indent:0
+      ~break:Always_rec [layout]
+  else
+    layout
+
+(**
+ * [looselyAttachComment layout comment] preorderly walks the layout and
+ * find a place where the comment can be loosely attached to
+ *)
+let rec looselyAttachComment ~breakAncestors layout comment =
+  let location = Comment.location comment in
+  match layout with
+  | Layout.SourceMap (loc, sub) ->
+     Layout.SourceMap (loc, looselyAttachComment ~breakAncestors sub comment)
+  | Layout.Whitespace (info, sub) ->
+     Layout.Whitespace(info, looselyAttachComment ~breakAncestors sub comment)
+  | Easy _ ->
+     inline ~postSpace:true layout (formatComment comment)
+  | Sequence (listConfig, subLayouts)
+    when List.exists (Layout.contains_location ~location) subLayouts ->
+     (* If any of the subLayout strictly contains this comment, recurse into to it *)
+    let recurse_sublayout layout =
+      if Layout.contains_location layout ~location
+      then begin
+        looselyAttachComment ~breakAncestors layout comment
+      end
+      else layout
+    in
+    Sequence (listConfig, List.map recurse_sublayout subLayouts)
+  | Sequence (listConfig, subLayouts) when subLayouts == [] ->
+    (* If there are no subLayouts (empty body), create a Sequence of just the comment *)
+    Sequence (listConfig, [formatComment comment])
+  | Sequence (listConfig, subLayouts) ->
+    let (beforeComment, afterComment) =
+      Reason_syntax_util.pick_while (Layout.is_before ~location) subLayouts in
+    let newSubLayout = match List.rev beforeComment with
+      | [] ->
+        Reason_syntax_util.map_first (prependSingleLineComment comment) afterComment
+      | hd :: tl ->
+        List.rev_append
+          (appendComment ~breakAncestors hd comment :: tl) afterComment
+    in
+    Sequence (listConfig, newSubLayout)
+  | Label (formatter, left, right) ->
+    let newLeft, newRight =
+      match (Layout.get_location left, Layout.get_location right) with
+      | (None, None) ->
+        (left, looselyAttachComment ~breakAncestors right comment)
+      | (_, Some loc2) when location_contains loc2 location ->
+        (left, looselyAttachComment ~breakAncestors right comment)
+      | (Some loc1, _) when location_contains loc1 location ->
+        (looselyAttachComment ~breakAncestors left comment, right)
+      | (Some loc1, Some _) when location_is_before location loc1 ->
+        (prependSingleLineComment comment left, right)
+      | (Some _, Some loc2) when location_is_before location loc2 ->
+        (left, prependSingleLineComment comment right)
+      | _ -> (left, appendComment ~breakAncestors right comment)
+    in
+    Label (formatter, newLeft, newRight)
+
+(**
+ * [insertSingleLineComment layout comment] preorderly walks the layout and
+ * find a place where the SingleLineComment can be fit into
+ *)
+let rec insertSingleLineComment layout comment =
+  let location = Comment.location comment in
+  match layout with
+  | Layout.SourceMap (loc, sub) ->
+    Layout.SourceMap (loc, insertSingleLineComment sub comment)
+  | Layout.Whitespace (info, sub) ->
+      let range = WhitespaceRegion.range info in
+      if Range.containsLoc range location then
+        insertCommentIntoWhitespaceRegion comment info sub
+      else
+        Layout.Whitespace(info, insertSingleLineComment sub comment)
+  | Easy _ ->
+    prependSingleLineComment comment layout
+  | Sequence (listConfig, subLayouts) when subLayouts == [] ->
+    (* If there are no subLayouts (empty body), create a Sequence of just the
+     * comment. We need to be careful when the empty body contains a //-style
+     * comment. Example:
+     *   let make = () => {
+     *     //
+     *   };
+     * It is clear that the sequence needs to always break here, otherwise
+     * we get a parse error: let make = () => { // };
+     * The closing brace and semicolon `};` would become part of the comment…
+     *)
+    let listConfig =
+      if Reason_comment.isLineComment comment then
+        {listConfig with break = Always_rec}
+      else
+        listConfig
+    in
+    Sequence (listConfig, [formatComment comment])
+  | Sequence (listConfig, subLayouts) ->
+    let (beforeComment, afterComment) =
+      Reason_syntax_util.pick_while (Layout.is_before ~location) subLayouts in
+    begin match afterComment with
+      (* Nothing in the list is after comment, attach comment to the statement before the comment *)
+      | [] ->
+        let break sublayout = breakline sublayout (formatComment comment) in
+        Sequence (listConfig, Reason_syntax_util.map_last break beforeComment)
+      | hd::tl ->
+        let afterComment =
+          match Layout.get_location hd with
+          | Some loc when location_contains loc location ->
+            insertSingleLineComment hd comment :: tl
+          | Some loc ->
+            Layout.SourceMap (loc, (prependSingleLineComment comment hd)) :: tl
+          | _ ->
+            prependSingleLineComment comment hd :: tl
+        in
+        Sequence (listConfig, beforeComment @ afterComment)
+    end
+  | Label (formatter, left, right) ->
+    let leftLoc = Layout.get_location left in
+    let rightLoc = Layout.get_location right in
+    let newLeft, newRight = match (leftLoc, rightLoc) with
+      | (None, None) ->
+        (left, insertSingleLineComment right comment)
+      | (_, Some loc2) when location_contains loc2 location ->
+        (left, insertSingleLineComment right comment)
+      | (Some loc1, _) when location_contains loc1 location ->
+        (insertSingleLineComment left comment, right)
+      | (Some loc1, Some _) when location_is_before location loc1 ->
+        (prependSingleLineComment comment left, right)
+      | (Some _, Some loc2) when location_is_before location loc2 ->
+        (left, prependSingleLineComment comment right)
+      | _ ->
+        (left, breakline right (formatComment comment))
+    in
+    Label (formatter, newLeft, newRight)
+
+let rec attachCommentToNodeRight layout comment =
+  match layout with
+  | Layout.Sequence (config, sub) when snd config.wrap <> "" ->
+    (* jwalke: This is quite the abuse of the "wrap" config *)
+    let lwrap, rwrap = config.wrap in
+    let rwrap = rwrap ^ " " ^ Comment.wrap comment in
+    Layout.Sequence ({config with wrap=(lwrap, rwrap)}, sub)
+  | Layout.SourceMap (loc, sub) ->
+    Layout.SourceMap (loc, attachCommentToNodeRight sub comment)
+  | layout -> inline ~postSpace:true layout (formatComment comment)
+
+let rec attachCommentToNodeLeft comment layout =
+  match layout with
+  | Layout.Sequence (config, sub) when snd config.wrap <> "" ->
+    let lwrap, rwrap = config.wrap in
+    let lwrap = Comment.wrap comment ^ " " ^ lwrap in
+    Layout.Sequence ({config with wrap = (lwrap, rwrap)}, sub)
+  | Layout.SourceMap (loc, sub) ->
+    Layout.SourceMap (loc, attachCommentToNodeLeft comment sub )
+  | layout ->
+    Layout.Label (inlineLabel, formatComment comment, layout)
+
+(** [tryPerfectlyAttachComment layout comment] postorderly walk the [layout] and tries
+ *  to perfectly attach a comment with a layout node.
+ *
+ *  Perfectly attach here means a comment's start location is equal to the node's end location
+ *  and vice versa.
+ *
+ *  If the comment can be perfectly attached to any layout node, returns (newLayout, None),
+ *  meaning the comment is consumed. Otherwise returns the (unchangedLayout, Some comment),
+ *  meaning the comment is not consumed.
+ *
+ * "perfect attachment" doesn't make sense for end of line comments:
+ *
+ *       {
+ *         x: 0,
+ *         y: 0
+ *       }
+ *
+ * One of these will be "perfectly attached" to the zero and the other won't.
+ * Why should the comma have such an influence? Trailing commas and semicolons
+ * may be inserted or removed, an we need end-of-line comments to never be
+ * impacted by that. Therefore, never try to "perfectly" attach EOL comments.
+ *)
+let rec tryPerfectlyAttachComment layout = function
+  | None -> (layout, None)
+  | Some comment -> perfectlyAttachComment comment layout
+
+and perfectlyAttachComment comment = function
+  | Layout.Sequence (listConfig, subLayouts) ->
+    let distributeCommentIntoSubLayouts (i, processed, newComment) layout =
+      let (layout, newComment) =
+        tryPerfectlyAttachComment layout newComment in
+      (i + 1, layout::processed, newComment)
+    in
+    let (_, processed, consumed) =
+      List.fold_left
+        distributeCommentIntoSubLayouts
+        (0, [], Some comment) (List.rev subLayouts)
+    in
+    Layout.Sequence (listConfig, processed), consumed
+  | Layout.Label (labelFormatter, left, right) ->
+    let (newRight, comment) = perfectlyAttachComment comment right in
+    let (newLeft, comment) = tryPerfectlyAttachComment left comment in
+    Layout.Label (labelFormatter, newLeft, newRight), comment
+  | Layout.SourceMap (loc, subLayout) ->
+    let commloc = Comment.location comment in
+    if loc.loc_end.Lexing.pos_lnum = loc.loc_start.Lexing.pos_lnum &&
+       commloc.loc_start.Lexing.pos_cnum = loc.loc_end.Lexing.pos_cnum
+    then
+      (Layout.SourceMap (loc, makeList ~inline:(true, true) ~break:Always
+                    [unbreaklayout (attachCommentToNodeRight subLayout comment)]),
+       None)
+    else
+      let (layout, comment) = perfectlyAttachComment comment subLayout in
+      begin match comment with
+        | None -> (Layout.SourceMap (loc, layout), None)
+        | Some comment ->
+          if commloc.loc_end.Lexing.pos_cnum =
+             loc.loc_start.Lexing.pos_cnum  then
+            (Layout.SourceMap (loc, attachCommentToNodeLeft comment layout), None)
+          else if commloc.loc_start.Lexing.pos_cnum = loc.loc_end.Lexing.pos_cnum then
+            (Layout.SourceMap (loc, attachCommentToNodeRight layout comment), None)
+          else
+            (Layout.SourceMap (loc, layout), Some comment)
+      end
+  | Whitespace(info, subLayout) ->
+      begin match perfectlyAttachComment comment subLayout with
+      | (newLayout, None) -> (Whitespace(info, newLayout), None)
+      | (newLayout, Some c) -> (Whitespace(info, newLayout), Some c)
+      end
+  | layout -> (layout, Some comment)
+
+let insertRegularComment layout comment =
+  match perfectlyAttachComment comment layout with
+  | (layout, None) -> layout
+  | (layout, Some _) ->
+      looselyAttachComment ~breakAncestors:false layout comment
+
+let insertEndOfLineComment layout comment =
+  looselyAttachComment ~breakAncestors:true layout comment
+
+let rec partitionComments_ ((singleLines, endOfLines, regulars) as soFar) = function
+  | [] -> soFar
+  | com :: tl ->
+    match Comment.category com with
+    | Comment.EndOfLine ->
+      partitionComments_ (singleLines, (com :: endOfLines), regulars) tl
+    | Comment.SingleLine ->
+      partitionComments_ ((com :: singleLines), endOfLines, regulars) tl
+    | Comment.Regular ->
+      partitionComments_ (singleLines, endOfLines, (com :: regulars)) tl
+
+let partitionComments comments =
+  let (singleLines, endOfLines, regulars) =
+    partitionComments_ ([], [], []) comments in
+  (singleLines, List.rev endOfLines, regulars)
+
+(*
+ * Partition single line comments based on a location into two lists:
+ * - one contains the comments before/same height of that location
+ * - the other contains the comments after the location
+ *)
+let partitionSingleLineComments loc singleLineComments =
+  let (before, after) = List.fold_left (fun (before, after) comment ->
+    let cl = Comment.location comment in
+    let isAfter = loc.loc_end.pos_lnum < cl.loc_start.pos_lnum in
+    if isAfter then
+      (before, comment::after)
+    else
+      (comment::before, after)
+  ) ([], []) singleLineComments
+  in (List.rev before, after)
+
+(*
+ * appends all [singleLineComments] after the [layout].
+ * [loc] marks the end of [layout]
+ *)
+let appendSingleLineCommentsToEnd loc layout singleLineComments =
+  let rec aux prevLoc layout i = function
+    | comment::cs ->
+        let loc = Comment.location comment in
+        let formattedComment = formatComment comment in
+        let commentLayout = if Reason_location.hasSpaceBetween loc prevLoc then
+          insertBlankLines 1 formattedComment
+        else
+          formattedComment
+        in
+        (* The initial layout breaks ugly with `breakline`,
+         * an inline list (that never breaks) fixes this *)
+        let newLayout = if i == 0 then
+          makeList ~inline:(true, true) ~break:Never [layout; commentLayout]
+        else
+          breakline layout commentLayout
+        in
+        aux loc newLayout (i + 1) cs
+    | [] -> layout
+  in
+  aux loc layout 0 singleLineComments
+
+(*
+ * For simplicity, the formatting of comments happens in two parts in context of a source map:
+ * 1) insert the singleLineComments with the interleaving algorithm contained in
+ *    `insertSingleLineComment` for all comments overlapping with the sourcemap.
+ *    A `Layout.Whitespace` node signals an intent to preserve whitespace here.
+ * 2) SingleLineComments after the sourcemap, e.g. at the end of .re/.rei file,
+ *    get attached with `appendSingleLineCommentsToEnd`. Due to the fact there
+ *    aren't any real ocaml ast nodes anymore after the sourcemap (end of a
+ *    file), the printing of the comments can be done in one pass with
+ *    `appendSingleLineCommentsToEnd`. This is more performant and
+ *    simplifies the implementation of comment attachment.
+ *)
+let attachSingleLineComments singleLineComments = function
+  | Layout.SourceMap(loc, subLayout) ->
+      let (before, after) = partitionSingleLineComments loc singleLineComments in
+      let layout = List.fold_left insertSingleLineComment subLayout before in
+      appendSingleLineCommentsToEnd loc layout after
+  | layout ->
+    List.fold_left insertSingleLineComment layout singleLineComments
+
+let format_layout ?comments ppf layout =
+  let easy = match comments with
+    | None -> Layout.to_easy_format layout
+    | Some comments ->
+      let (singleLines, endOfLines, regulars) = partitionComments comments in
+      (* TODO: Stop generating multiple versions of the tree, and instead generate one new tree. *)
+      (* Layout.dump Format.std_formatter layout; *)
+      let layout = List.fold_left insertRegularComment layout regulars in
+      let layout = consolidateSeparator layout in
+      let layout = List.fold_left insertEndOfLineComment layout endOfLines in
+      (* Layout.dump Format.std_formatter layout; *)
+      let layout = attachSingleLineComments singleLines layout in
+      (* Layout.dump Format.std_formatter layout; *)
+      let layout = insertLinesAboveItems layout in
+      let layout = Layout.to_easy_format layout in
+      (* Layout.dump_easy Format.std_formatter layout; *)
+      layout
+  in
+  let buf = Buffer.create 1000 in
+  let fauxmatter = Format.formatter_of_buffer buf in
+  let _ = Format.pp_set_margin fauxmatter settings.width in
+  if debugWithHtml.contents then
+    Easy_format.Pretty.define_styles fauxmatter html_escape html_style;
+  let _ = Easy_format.Pretty.to_formatter fauxmatter easy in
+  let trimmed = Reason_syntax_util.processLineEndingsAndStarts (Buffer.contents buf) in
+  Format.fprintf ppf "%s\n" trimmed;
+  Format.pp_print_flush ppf ()
+
+let partitionFinalWrapping listTester wrapFinalItemSetting x =
+  let rev = List.rev x in
+  match (rev, wrapFinalItemSetting) with
+    | ([], _) -> raise (NotPossible "shouldnt be partitioning 0 label attachments")
+    | (_, NeverWrapFinalItem) -> None
+    | (last::revEverythingButLast, WrapFinalListyItemIfFewerThan max) ->
+        if not (listTester last) || (List.length x) >= max then
+          None
+        else
+          Some (List.rev revEverythingButLast, last)
+
+let semiTerminated term = makeList [term; atom ";"]
+
+(* postSpace is so that when comments are interleaved, we still use spacing rules. *)
+let makeLetSequence letItems =
+  makeList
+    ~break:Always_rec
+    ~inline:(true, false)
+    ~wrap:("{", "}")
+    ~postSpace:true
+    ~sep:(SepFinal (";", ";"))
+    letItems
+
+let makeLetSequenceSingleLine letItems =
+  makeList
+    ~break:IfNeed
+    ~inline:(true, false)
+    ~wrap:("{", "}")
+    ~preSpace:true
+    ~postSpace:true
+    ~sep:(Sep ";")
+    letItems
+
+(* postSpace is so that when comments are interleaved, we still use spacing rules. *)
+let makeUnguardedLetSequence ?(sep=(Layout.SepFinal (";", ";"))) letItems =
+  makeList
+    ~break:Always_rec
+    ~inline:(true, true)
+    ~wrap:("", "")
+    ~indent:0
+    ~postSpace:true
+    ~sep
+    letItems
+
+let formatSimpleAttributed x y =
+  makeList
+    ~wrap:("(", ")")
+    ~break:IfNeed
+    ~indent:0
+    ~postSpace:true
+    (List.concat [y; [x]])
+
+let formatAttributed ?(labelBreak=`Auto) x y =
+  label
+    ~break:labelBreak
+    ~indent:0
+    ~space:true
+    (makeList ~inline:(true, true) ~postSpace:true y)
+    x
+
+(* For when the type constraint should be treated as a separate breakable line item itself
+   not docked to some value/pattern label.
+   fun x
+       y
+       : retType => blah;
+ *)
+let formatJustTheTypeConstraint typ =
+  makeList ~postSpace:false ~sep:(Sep " ") [atom ":"; typ]
+
+let formatTypeConstraint one two =
+  label ~space:true (makeList ~postSpace:false [one; atom ":"]) two
+
+let formatCoerce expr optType coerced =
+  match optType with
+    | None ->
+      label ~space:true (makeList ~postSpace:true [expr; atom ":>"]) coerced
+    | Some typ ->
+      label ~space:true (makeList ~postSpace:true [formatTypeConstraint expr typ; atom ":>"]) coerced
+
+
+(* Standard function application style indentation - no special wrapping
+ * behavior.
+ *
+ * Formats like this:
+ *
+ *   let result =
+ *     someFunc
+ *       (10, 20);
+ *
+ *
+ * Instead of this:
+ *
+ *   let result =
+ *     someFunc (
+ *       10,
+ *       20
+ *     );
+ *
+ * The outer list wrapping fixes #566: format should break the whole
+ * application before breaking arguments.
+ *)
+let formatIndentedApplication headApplicationItem argApplicationItems =
+  makeList ~inline:(true, true) ~postSpace:true ~break:IfNeed [
+    label
+      ~space:true
+      headApplicationItem
+      (makeAppList argApplicationItems)
+  ]
+
+
+(* The loc, is an optional location or the returned app terms *)
+let formatAttachmentApplication finalWrapping (attachTo: (bool * Layout.t) option) (appTermItems, loc) =
+  let partitioning = finalWrapping appTermItems in
+  match partitioning with
+    | None -> (
+        match (appTermItems, attachTo) with
+          | ([], _) -> raise (NotPossible "No app terms")
+          | ([hd], None) -> source_map ?loc hd
+          | ([hd], (Some (useSpace, toThis))) -> label ~space:useSpace toThis (source_map ?loc hd)
+          | (hd::tl, None) ->
+            source_map ?loc (formatIndentedApplication hd tl)
+          | (hd::tl, (Some (useSpace, toThis))) ->
+            label
+              ~space:useSpace
+              toThis
+              (source_map ?loc (formatIndentedApplication hd tl))
+      )
+    | Some (attachedList, wrappedListy) -> (
+        match (attachedList, attachTo) with
+        | ([], Some (useSpace, toThis)) ->
+          label ~space:useSpace toThis (source_map ?loc wrappedListy)
+        | ([], None) ->
+          (* Not Sure when this would happen *)
+          source_map ?loc wrappedListy
+        | (_::_, Some (useSpace, toThis)) ->
+          (* TODO: Can't attach location to this - maybe rewrite anyways *)
+          let attachedArgs = makeAppList attachedList in
+          label ~space:useSpace toThis
+            (label ~space:true attachedArgs wrappedListy)
+        | (_::_, None) ->
+          (* Args that are "attached to nothing" *)
+          let appList = makeAppList attachedList in
+          source_map ?loc (label ~space:true appList wrappedListy)
+      )
+
+(*
+  Preprocesses an expression term for the sake of label attachments ([letx =
+  expr]or record [field: expr]). Function application should have special
+  treatment when placed next to a label. (The invoked function term should
+  "stick" to the label in some cases). In others, the invoked function term
+  should become a new label for the remaining items to be indented under.
+ *)
+let applicationFinalWrapping x =
+  partitionFinalWrapping isSequencey settings.funcApplicationLabelStyle x
+
+let curriedFunctionFinalWrapping x =
+  partitionFinalWrapping isSequencey settings.funcCurriedPatternStyle x
+
+let typeApplicationFinalWrapping typeApplicationItems =
+  partitionFinalWrapping isSequencey settings.funcApplicationLabelStyle typeApplicationItems
+
+
+(* add parentheses to binders when they are in fact infix or prefix operators *)
+let protectIdentifier txt =
+  if not (needs_parens txt) then atom txt
+  else if needs_spaces txt then makeList ~wrap:("(", ")") ~pad:(true, true) [atom txt]
+  else atom ("(" ^ txt ^ ")")
+
+let protectLongIdentifier longPrefix txt =
+  makeList [longPrefix; atom "."; protectIdentifier txt]
+
+let paren b fu ppf x =
+  if b
+  then Format.fprintf ppf "(%a)" fu x
+  else fu ppf x
+
+let constant_string ppf s =
+  Format.fprintf ppf "%S" s
+
+let tyvar ppf str =
+  Format.fprintf ppf "'%s" str
+
+(* In some places parens shouldn't be printed for readability:
+ * e.g. Some((-1)) should be printed as Some(-1)
+ * In `1 + (-1)` -1 should be wrapped in parens for readability
+ *)
+let constant ?raw_literal ?(parens=true) ppf = function
+  | Pconst_char i ->
+    Format.fprintf ppf "%C"  i
+  | Pconst_string (i, None) ->
+    begin match raw_literal with
+      | Some text ->
+        Format.fprintf ppf "\"%s\"" text
+      | None ->
+        Format.fprintf ppf "\"%s\"" (Reason_syntax_util.escape_string i)
+    end
+  | Pconst_string (i, Some delim) ->
+    Format.fprintf ppf "{%s|%s|%s}" delim i delim
+  | Pconst_integer (i, None) ->
+    paren (parens && i.[0] = '-')
+      (fun ppf -> Format.fprintf ppf "%s") ppf i
+  | Pconst_integer (i, Some '\232'..'\237') ->
+    Format.fprintf ppf "%s" i
+  | Pconst_integer (i, Some m) ->
+    paren (parens && i.[0] = '-')
+      (fun ppf (i, m) ->
+         if m = '\231' then
+           Format.fprintf ppf "%stz" i
+         else
+           Format.fprintf ppf "%s%c" i m) ppf (i,m)
+  | Pconst_float (i, None) ->
+    paren (parens && i.[0] = '-')
+      (fun ppf -> Format.fprintf ppf "%s") ppf i
+  | Pconst_float (i, Some m) ->
+    paren (parens && i.[0] = '-')
+      (fun ppf (i,m) ->
+         if m = '\231' then
+           Format.fprintf ppf "%stz" i
+         else
+           Format.fprintf ppf "%s%c" i m
+      ) ppf (i,m)
+
+let is_punned_labelled_expression e lbl = match e.pexp_desc with
+  | Pexp_ident { txt }
+  | Pexp_constraint ({pexp_desc = Pexp_ident { txt }}, _)
+  | Pexp_coerce ({pexp_desc = Pexp_ident { txt }}, _, _)
+    -> txt = Longident.parse lbl
+  | _ -> false
+
+let is_punned_labelled_pattern p lbl = match p.ppat_desc with
+  | Ppat_constraint ({ ppat_desc = Ppat_var _; ppat_attributes = _::_ }, _)
+    -> false
+  | Ppat_constraint ({ ppat_desc = Ppat_var { txt } }, _)
+  | Ppat_var { txt }
+    -> txt = lbl
+  | _ -> false
+
+let isLongIdentWithDot = function
+  | Ldot _ -> true
+  | _ -> false
+
+(* Js.t -> useful for bucklescript sugar `Js.t({. foo: bar})` -> `{. "foo": bar}` *)
+let isJsDotTLongIdent ident = match ident with
+  | Ldot (Lident "Js", "t") -> true
+  | _ -> false
+
+let recordRowIsPunned pld =
+      let name = pld.pld_name.txt in
+      (match pld.pld_type with
+        | { ptyp_desc = (
+            Ptyp_constr (
+              { txt },
+              (* don't pun parameterized types, e.g. {tag: tag 'props} *)
+              [])
+            );
+            (* Don't pun types that have attributes attached, e.g. { foo: [@bar] foo } *)
+            ptyp_attributes = [];
+          _}
+            when
+            (Longident.last txt = name
+              (* Don't pun types from other modules, e.g. type bar = {foo: Baz.foo}; *)
+              && isLongIdentWithDot txt == false) -> true
+        | _ -> false)
+
+let isPunnedJsxArg lbl ident =
+  not (isLongIdentWithDot ident.txt) && (Longident.last ident.txt) = lbl
+
+let is_unit_pattern x = match x.ppat_desc with
+  | Ppat_construct ( {txt= Lident"()"}, None) -> true
+  | _ -> false
+
+let is_ident_pattern x = match x.ppat_desc with
+  | Ppat_var _ -> true
+  | _ -> false
+
+let is_any_pattern x = x.ppat_desc = Ppat_any
+
+let is_direct_pattern x = x.ppat_attributes == [] && match x.ppat_desc with
+  | Ppat_construct ( {txt= Lident"()"}, None) -> true
+  | _ -> false
+
+let isJSXComponent expr =
+  match expr with
+  | ({pexp_desc= Pexp_apply ({pexp_desc=Pexp_ident _}, args); pexp_attributes})
+  | ({pexp_desc= Pexp_apply ({pexp_desc=Pexp_letmodule(_,_,_)}, args); pexp_attributes}) ->
+    let {jsxAttrs} = partitionAttributes pexp_attributes in
+    let hasLabelledChildrenLiteral = List.exists (function
+      | (Labelled "children", _) -> true
+      | _ -> false
+    ) args in
+    let rec hasSingleNonLabelledUnitAndIsAtTheEnd l = match l with
+    | [] -> false
+    | (Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, _)}) :: [] -> true
+    | (Nolabel, _) :: _ -> false
+    | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
+    in
+    if jsxAttrs != []
+       && hasLabelledChildrenLiteral
+       && hasSingleNonLabelledUnitAndIsAtTheEnd args
+    then
+      true
+    else
+      false
+  | _ -> false
+
+(* Some cases require special formatting when there's a function application
+ * with a single argument containing some kind of structure with braces/parens/brackets.
+ * Example: `foo({a: 1, b: 2})` needs to be formatted as
+ *  foo({
+ *    a: 1,
+ *    b: 2
+ *  })
+ *  when the line length dictates breaking. Notice how `({` and `})` 'hug'.
+ *  Also applies to (poly)variants because they can be seen as a form of "function application".
+ *  This function says if a list of expressions fulfills the need to be formatted like
+ *  the example above. *)
+let isSingleArgParenApplication = function
+  | [{pexp_attributes = []; pexp_desc = Pexp_record _}]
+  | [{pexp_attributes = []; pexp_desc = Pexp_tuple _}]
+  | [{pexp_attributes = []; pexp_desc = Pexp_array _}]
+  | [{pexp_attributes = []; pexp_desc = Pexp_object _}] -> true
+  | [{pexp_attributes = []; pexp_desc = Pexp_extension (s, _)}] when s.txt = "bs.obj" -> true
+  | [({pexp_attributes = []} as exp)] when (is_simple_list_expr exp) -> true
+  | _ -> false
+
+(*
+ * Determines if the arguments of a constructor pattern match need
+ * special printing. If there's one argument & they have some kind of wrapping,
+ * they're wrapping need to 'hug' the surrounding parens.
+ * Example:
+ *  switch x {
+ *  | Some({
+ *      a,
+ *      b,
+ *    }) => ()
+ *  }
+ *
+ *  Notice how ({ and }) hug.
+ *  This applies for records, arrays, tuples & lists.
+ *  See `singleArgParenPattern` for the acutal formatting
+ *)
+let isSingleArgParenPattern = function
+  | [{ppat_attributes = []; ppat_desc = Ppat_record _}]
+  | [{ppat_attributes = []; ppat_desc = Ppat_array _}]
+  | [{ppat_attributes = []; ppat_desc = Ppat_tuple _}] -> true
+  | [{ppat_attributes = []; ppat_desc = Ppat_construct (({txt=Lident "::"}), _)}] -> true
+  | _ -> false
+
+(* Flattens a resolvedRule into a list of infixChain nodes.
+ * When foo |> f |> z gets parsed, we get the following tree:
+ *         |>
+ *        /  \
+ *    foo      |>
+ *            /  \
+ *          f      z
+ * To format this recursive tree in a way that allows nice breaking
+ * & respects the print-width, we need some kind of flattened
+ * version of the above tree. `computeInfixChain` transforms the tree
+ * in a flattened version which allows flexible formatting.
+ * E.g. we get
+ *  [LayoutNode foo; InfixToken |>; LayoutNode f; InfixToken |>; LayoutNode z]
+ *)
+let rec computeInfixChain = function
+  | LayoutNode layoutNode -> [Layout layoutNode]
+  | InfixTree (op, leftResolvedRule, rightResolvedRule) ->
+      (computeInfixChain leftResolvedRule) @ [InfixToken op] @ (computeInfixChain rightResolvedRule)
+
+let equalityOperators = ["!="; "!=="; "==="; "=="; ">="; "<="; "<"; ">"]
+
+(* Formats a flattened list of infixChain nodes into a list of layoutNodes
+ * which allow smooth line-breaking
+ * e.g. [LayoutNode foo; InfixToken |>; LayoutNode f; InfixToken |>; LayoutNode z]
+ * becomes
+ * [
+ *   foo
+ * ; |> f        --> label
+ * ; |> z        --> label
+ * ]
+ * If you make a list out of this items, we get smooth line breaking
+ *  foo |> f |> z
+ * becomes
+ *  foo
+ *  |> f
+ *  |> z
+ *  when the print-width forces line breaks.
+ *)
+let formatComputedInfixChain infixChainList =
+  let layout_of_group group currentToken =
+    (* Represents the `foo` in
+     * foo
+     * |> f
+     * |> z *)
+    if List.length group < 2 then
+      makeList ~inline:(true, true) ~sep:(Sep " ") group
+    (* Basic equality operators require special formatting, we can't give it
+     * 'classic' infix operator formatting, otherwise we would get
+     * let example =
+     *  true
+     *  != false
+     *  && "a"
+     *  == "b"
+     *  *)
+    else if List.mem currentToken equalityOperators then
+      let hd = List.hd group in
+      let tl = makeList ~inline:(true, true) ~sep:(Sep " ") (List.tl group) in
+      makeList ~inline:(true, true) ~sep:(Sep " ") ~break:IfNeed [hd; tl]
+    else if currentToken.[0] = '#' then
+      let isSharpEqual = currentToken = sharpOpEqualToken in
+      makeList ~postSpace:isSharpEqual group
+    else
+      (* Represents `|> f` in foo |> f
+       * We need a label here to indent possible closing parens
+       * on the same height as the infix operator
+       * e.g.
+       * >|= (
+       *   fun body =>
+       *     Printf.sprintf
+       *       "okokok" uri meth headers body
+       * )   <-- notice how this closing paren is on the same height as >|=
+       *)
+      label ~break:`Never ~space:true (atom currentToken) (List.nth group 1)
+  in
+  let rec print acc group currentToken l =
+    match l with
+    | x::xs -> (match x with
+      | InfixToken t ->
+          (* = or := *)
+          if List.mem t requireIndentFor then
+            let groupNode =
+              makeList ~inline:(true, true) ~sep:(Sep " ") ((print [] group currentToken []) @ [atom t])
+            in
+            let children =
+              makeList ~inline:(true, true) ~preSpace:true ~break:IfNeed
+                (print [] [] t xs)
+            in
+            print (acc @ [label ~space:true groupNode children]) [] t []
+          (* Represents:
+           * List.map @@
+           * List.length
+           *
+           * Notice how we want the `@@` on the first line.
+           * Extra indent puts pressure on the subsequent line lengths
+           * *)
+          else if t = "@@" then
+            let groupNode =
+              makeList ~inline:(true, true) ~sep:(Sep " ") (group @ [atom t])
+            in
+            print (acc @ [groupNode]) [] t xs
+          (* != !== === == >= <= < > etc *)
+          else if List.mem t equalityOperators then
+            print acc ((print [] group currentToken []) @ [atom t]) t xs
+          else
+            begin if requireNoSpaceFor t then
+              begin if (currentToken = "" || requireNoSpaceFor currentToken) then
+                print acc (group@[atom t]) t xs
+              else
+                (* a + b + foo##bar##baz
+                 * `foo` needs to be picked from the current group
+                 * and inserted into a new one. This way `foo`
+                 * gets the special "chained"-printing:
+                 * foo##bar##baz. *)
+                 begin match List.rev group with
+                 |  hd::tl ->
+                     let acc =
+                       acc @ [layout_of_group (List.rev tl) currentToken]
+                      in
+                     print acc [hd; atom t] t xs
+                 | [] -> print acc (group@[atom t]) t xs
+                 end
+              end
+            else
+              print (acc @ [layout_of_group group currentToken]) [(atom t)] t xs
+            end
+      | Layout layoutNode -> print acc (group @ [layoutNode]) currentToken xs
+      )
+    | [] ->
+      if List.mem currentToken requireIndentFor then
+        acc @ group
+        else
+          acc @ [layout_of_group group currentToken]
+  in
+  let l = print [] [] "" infixChainList in
+  makeList ~inline:(true, true) ~sep:(Sep " ") ~break:IfNeed l
+
+(**
+ * [groupAndPrint] will print every item in [items] according to the function [xf].
+ * [getLoc] will extract the location from an item. Based on the difference
+ * between the location of two items, if there's whitespace between the two
+ * (taken possible comments into account), items get grouped.
+ * Every group designates a series of layout nodes "in need
+ * of whitespace above". A group gets decorated with a Whitespace node
+ * containing enough info to interleave whitespace at a later time during
+ * printing.
+ *)
+let groupAndPrint ~xf ~getLoc ~comments items =
+  let rec group prevLoc curr acc = function
+    (* group items *)
+    | x::xs ->
+        let item = xf x in
+        let loc = getLoc x in
+        (* Get the range between the current and previous item
+         * Example:
+         * 1| let a = 1;
+         * 2|            --> this is the range between the two
+         * 3| let b = 2;
+         * *)
+        let range = Range.makeRangeBetween prevLoc loc in
+        (* If there's whitespace interleaved, append the new layout node
+         * to a new group, otherwise keep it in the current group.
+         * Takes possible comments interleaved into account.
+         *
+         * Example:
+         * 1| let a = 1;
+         * 2|
+         * 3| let b = 2;
+         * 4| let c = 3;
+         * `let b = 2` will mark the start of a new group
+         * `let c = 3` will be added to the group containing `let b = 2`
+         *)
+        if Range.containsWhitespace ~range ~comments () then
+          group loc [(range, item)] ((List.rev curr)::acc) xs
+        else
+          group loc ((range, item)::curr) acc xs
+    (* convert groups into "Layout.Whitespace" *)
+    | [] ->
+        let groups = List.rev ((List.rev curr)::acc) in
+        List.mapi (fun i group -> match group with
+          | curr::xs ->
+              let (range, x) = curr in
+              (* if this is the first group of all "items", the number of
+               * newlines interleaved should be 0, else we collapse all newlines
+               * to 1.
+               *
+               * Example:
+               * module Abc = {
+               *   let a = 1;
+               *
+               *   let b = 2;
+               * }
+               * `let a = 1` should be wrapped in a `Layout.Whitespace` because a
+               * user might put comments above the `let a = 1`.
+               * e.g.
+               * module Abc = {
+               *   /* comment 1 */
+               *
+               *   /* comment 2 */
+               *   let a = 1;
+               *
+               *  A Whitespace-node will automatically take care of the whitespace
+               *  interleaving between the comments.
+               *)
+              let newlines = if i > 0 then 1 else 0 in
+              let region = WhitespaceRegion.make ~range ~newlines () in
+              let firstLayout = Layout.Whitespace(region, x) in
+              (* the first layout node of every group taks care of the
+               * whitespace above a group*)
+              (firstLayout::(List.map snd xs))
+          | [] -> []
+        ) groups
+  in
+  match items with
+  | first::rest ->
+      List.concat (group (getLoc first) [] [] (first::rest))
+  | [] -> []
+
+let printer = object(self:'self)
+  val pipe = false
+  val semi = false
+
+  val inline_braces = false
+  val preserve_braces = true
+
+  (* *Mutable state* in the printer to keep track of all comments
+   * Used when whitespace needs to be interleaved.
+   * The printing algorithm needs to take the comments into account in between
+   * two items, to correctly determine if there's whitespace between two items.
+   * The ast doesn't know if there are comments between two items, since
+   * comments are store separately. The location diff between two items
+   * might indicate whitespace between the two. While in reality there are
+   * comments filling that whitespace. The printer needs access to the comments
+   * for this reason.
+   *
+   * Example:
+   * 1| let a = 1;
+   * 2|
+   * 3|
+   * 4| let b = 2;
+   *  -> here we can just diff the locations between `let a = 1` and `let b = 2`
+   *
+   * 1| let a = 1;
+   * 2| /* a comment */
+   * 3| /* another comment */
+   * 4| let b = 2;
+   *  -> here the location diff will result into false info if we don't include
+   *  the comments in the diffing
+   *)
+  val mutable comments = []
+
+  method comments = comments
+  method trackComment comment = comments <- comment::comments
+
+  (* The test and first branch of ternaries must be guarded *)
+  method under_pipe = {<pipe=true>}
+  method under_semi = {<semi=true>}
+  method reset_semi = {<semi=false>}
+  method reset_pipe = {<pipe=false>}
+  method reset = {<pipe=false;semi=false>}
+
+  method inline_braces = {<inline_braces=true>}
+  method dont_preserve_braces = {<preserve_braces=false>}
+  method reset_request_braces = {<inline_braces=false; preserve_braces=true>}
+
+
+  method longident = function
+    | Lident s -> (protectIdentifier s)
+    | Ldot(longPrefix, s) ->
+        (protectLongIdentifier (self#longident longPrefix) s)
+    | Lapply (y,s) -> makeList [self#longident y; atom "("; self#longident s; atom ")";]
+
+  (* This form allows applicative functors. *)
+  method longident_class_or_type_loc x = self#longident x.txt
+  (* TODO: Fail if observing applicative functors for this form. *)
+  method longident_loc (x:Longident.t Location.loc) =
+    source_map ~loc:x.loc (self#longident x.txt)
+
+  method constant ?raw_literal ?(parens=true) =
+    wrap (constant ?raw_literal ~parens)
+
+  method constant_string = wrap constant_string
+  method tyvar = wrap tyvar
+
+  (* c ['a,'b] *)
+  method class_params_def = function
+    | [] -> atom ""
+    | l -> makeTup (List.map self#type_param l)
+
+  (* This will fall through to the simple version. *)
+  method non_arrowed_core_type x = self#non_arrowed_non_simple_core_type x
+
+  method core_type2 x =
+    let {stdAttrs; uncurried} = partitionAttributes x.ptyp_attributes in
+    let uncurried = uncurried || try Hashtbl.find uncurriedTable x.ptyp_loc with | Not_found -> false in
+    if stdAttrs != [] then
+      formatAttributed
+        (self#non_arrowed_simple_core_type {x with ptyp_attributes = []})
+        (self#attributes stdAttrs)
+    else
+      let x = if uncurried then { x with ptyp_attributes = [] } else x in
+      match x.ptyp_desc with
+        | Ptyp_arrow _ ->
+          let rec allArrowSegments ?(uncurried=false) acc = function
+            | { ptyp_desc = Ptyp_arrow (l, ct1, ct2); ptyp_attributes = []} ->
+              allArrowSegments ~uncurried:false
+                ((l,ct1, false || uncurried) :: acc) ct2
+            | rhs ->
+              let rhs = self#core_type2 rhs in
+              let is_tuple typ = match typ.ptyp_desc with
+                | Ptyp_tuple _ -> true
+                | _ -> false
+              in
+              match acc with
+              | [(Nolabel, lhs, uncurried )] when not (is_tuple lhs) ->
+                  let t = self#non_arrowed_simple_core_type lhs in
+                  let lhs = if uncurried then
+                    makeList ~wrap:("(. ", ")") ~postSpace:true [t]
+                  else t in
+                (lhs, rhs)
+              | acc ->
+                let params = List.rev_map self#type_with_label acc in
+                (makeCommaBreakableListSurround "(" ")" params, rhs)
+          in
+          let (lhs, rhs) = allArrowSegments ~uncurried [] x in
+          let normalized = makeList
+              ~preSpace:true ~postSpace:true ~inline:(true, true)
+              ~break:IfNeed ~sep:(Sep "=>") [lhs; rhs]
+          in source_map ~loc:x.ptyp_loc normalized
+        | Ptyp_poly (sl, ct) ->
+          let ct = self#core_type ct in
+          let poly = match sl with
+          | [] -> ct
+          | sl ->
+            makeList ~break:IfNeed ~postSpace:true [
+              makeList [
+                makeList ~postSpace:true (List.map (fun x -> self#tyvar x) sl);
+                atom ".";
+              ];
+              ct
+            ]
+          in source_map ~loc:x.ptyp_loc poly
+        | _ -> self#non_arrowed_core_type x
+
+  (* Same as core_type2 but can be aliased *)
+  method core_type x =
+    let {stdAttrs; uncurried} = partitionAttributes x.ptyp_attributes in
+    let () = if uncurried then Hashtbl.add uncurriedTable x.ptyp_loc true in
+    if stdAttrs != [] then
+      formatAttributed
+        (self#non_arrowed_simple_core_type {x with ptyp_attributes = []})
+        (self#attributes stdAttrs)
+    else match x.ptyp_desc with
+      | (Ptyp_alias (ct, s)) ->
+        source_map ~loc:x.ptyp_loc
+          (label
+             ~space:true
+             (self#core_type ct)
+             (makeList ~postSpace:true [atom "as"; atom ("'" ^ s)]))
+      | _ -> self#core_type2 x
+
+  method type_with_label (lbl, c, uncurried) =
+    let typ = self#core_type c in
+    let t = match lbl with
+    | Nolabel -> typ
+    | Labelled lbl ->
+        makeList ~sep:(Sep " ") [atom (namedArgSym ^ lbl ^ ":"); typ]
+    | Optional lbl ->
+        makeList ~sep:(Sep " ") [atom (namedArgSym ^ lbl ^ ":"); label typ (atom "=?")]
+    in
+    if uncurried then
+      makeList ~postSpace:true [atom "."; t]
+    else t
+
+  method type_param (ct, a) =
+    makeList [atom (type_variance a); self#core_type ct]
+
+  (* According to the parse rule [type_declaration], the "type declaration"'s
+   * physical location (as indicated by [td.ptype_loc]) begins with the
+   * identifier and includes the constraints. *)
+  method formatOneTypeDef prepend name assignToken ({ptype_params; ptype_kind; ptype_loc} as td) =
+    let (equalInitiatedSegments, constraints) = (self#type_declaration_binding_segments td) in
+    let formattedTypeParams = List.map self#type_param ptype_params in
+    let binding = makeList ~postSpace:true [prepend;name] in
+    (*
+        /-----------everythingButConstraints--------------  | -constraints--\
+       /-innerL---| ------innerR--------------------------\
+      /binding\     /typeparams\ /--equalInitiatedSegments-\
+      type name      'v1    'v1  =  foo = private bar        constraint a = b
+    *)
+
+    let labelWithParams = match formattedTypeParams with
+      | [] -> binding
+      | l -> label binding (makeTup l)
+    in
+    let everythingButConstraints =
+      let nameParamsEquals = makeList ~postSpace:true [labelWithParams; assignToken] in
+      match equalInitiatedSegments with
+        | [] -> labelWithParams
+        | _::_::_::_ -> raise (NotPossible "More than two type segments.")
+        | hd::[] ->
+            formatAttachmentApplication
+              typeApplicationFinalWrapping
+              (Some (true, nameParamsEquals))
+              (hd, None)
+        | hd::hd2::[] ->
+            let first = makeList ~postSpace:true ~break:IfNeed ~inline:(true, true) (hd @ [atom "="]) in
+            (*
+             * Because we want a record as a label with the opening brace on the same line
+             * and the closing brace indented at the beginning, we can't wrap it in a list here
+             * Example:
+             * type doubleEqualsRecord =
+             *  myRecordWithReallyLongName = {   <- opening brace on the same line
+             *    xx: int,
+             *    yy: int
+             *  };                               <- closing brace indentation
+             *)
+            let second = match ptype_kind with
+              | Ptype_record _ -> List.hd hd2
+              | _ -> makeList ~postSpace:true ~break:IfNeed ~inline:(true, true) hd2
+            in
+            label ~space:true nameParamsEquals (
+              label ~space:true first second
+            )
+    in
+    let everything =
+      match constraints with
+        | [] -> everythingButConstraints
+        | hd::tl -> makeList ~break:IfNeed ~postSpace:true ~indent:0 ~inline:(true, true) (everythingButConstraints::hd::tl)
+    in
+    source_map ~loc:ptype_loc everything
+
+  method formatOneTypeExt prepend name assignToken te =
+    let privateAtom = (atom "pri") in
+    let privatize scope lst = match scope with
+      | Public -> lst
+      | Private -> privateAtom::lst in
+    let equalInitiatedSegments =
+      let segments = List.map self#type_extension_binding_segments te.ptyext_constructors in
+      let privatized_segments = privatize te.ptyext_private segments in
+      [makeList ~break:Always_rec ~postSpace:true ~inline:(true, true) privatized_segments] in
+    let formattedTypeParams = List.map self#type_param te.ptyext_params in
+    let binding = makeList ~postSpace:true (prepend::name::[]) in
+    let labelWithParams = match formattedTypeParams with
+      | [] -> binding
+      | l -> label binding (makeTup l)
+    in
+    let everything =
+      let nameParamsEquals = makeList ~postSpace:true [labelWithParams; assignToken] in
+      formatAttachmentApplication
+             typeApplicationFinalWrapping
+             (Some (true, nameParamsEquals))
+             (equalInitiatedSegments, None)
+    in
+    source_map ~loc:te.ptyext_path.loc everything
+
+  method type_extension_binding_segments {pext_kind; pext_loc; pext_attributes; pext_name} =
+    let normalize lst = match lst with
+        | [] -> raise (NotPossible "should not be called")
+        | [hd] -> hd
+        | _::_ -> makeList lst
+      in
+      let add_bar name attrs args =
+        let lbl = begin match args with
+        | None -> name
+        | Some args -> label name args
+        end in
+        if attrs != [] then
+         label ~space:true
+            (makeList
+              ~postSpace:true
+              [
+                atom "|";
+                makeList
+                  ~postSpace:true
+                  ~break:Layout.IfNeed
+                  ~inline:(true, true)
+                  (self#attributes attrs)
+              ]
+            )
+            lbl
+        else
+          makeList ~postSpace:true [atom "|"; lbl]
+      in
+    let sourceMappedName = atom ~loc:pext_name.loc pext_name.txt in
+    let resolved = match pext_kind with
+      | Pext_decl (ctor_args, gadt) ->
+        let formattedArgs = match ctor_args with
+          | Pcstr_tuple [] -> []
+          | Pcstr_tuple args -> [makeTup (List.map self#non_arrowed_non_simple_core_type args)]
+          | Pcstr_record r -> [self#record_declaration r]
+        in
+        let formattedGadt = match gadt with
+        | None -> None
+        | Some x -> Some (
+            makeList [
+              formatJustTheTypeConstraint (self#core_type x)
+            ]
+          )
+        in
+        (formattedArgs, formattedGadt)
+      (* type bar += Foo = Attr.Foo *)
+      | Pext_rebind rebind ->
+        let r = self#longident_loc rebind in
+        (* we put an empty space before the '=': we don't have access to the fact
+         * that we need a space because of the Pext_rebind later *)
+        let prepend = (atom " =") in
+        ([makeList ~postSpace:true [prepend; r]], None)
+    in
+      (*
+        The first element of the tuple represents constructor arguments,
+        the second an optional formatted gadt.
+
+        Case 1: No constructor arguments, neither a gadt
+          type attr = ..;
+          type attr += | Str
+
+        Case 2: No constructor arguments, is a gadt
+          type attr = ..;
+          type attr += | Str :attr
+
+        Case 3: Has Constructor args, not a gadt
+          type attr  = ..;
+          type attr += | Str(string);
+          type attr += | Point(int, int);
+
+        Case 4: Has Constructor args & is a gadt
+          type attr  = ..;
+          type attr += | Point(int, int) :attr;
+      *)
+    let everything = match resolved with
+      | ([], None) -> add_bar sourceMappedName pext_attributes None
+      | ([], Some gadt) -> add_bar sourceMappedName pext_attributes (Some gadt)
+      | (ctorArgs, None) -> add_bar sourceMappedName pext_attributes (Some (normalize ctorArgs))
+      | (ctorArgs, Some gadt) -> add_bar sourceMappedName pext_attributes (Some (normalize (ctorArgs@[gadt])))
+    in
+    source_map ~loc:pext_loc everything
+
+  (* shared by [Pstr_type,Psig_type]*)
+  method type_def_list (rf, l) =
+    (* As oposed to used in type substitution. *)
+    let formatOneTypeDefStandard prepend td =
+      let itm =
+        self#formatOneTypeDef
+          prepend
+          (atom ~loc:td.ptype_name.loc td.ptype_name.txt)
+          (atom "=")
+          td
+      in
+      let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true td.ptype_attributes in
+      let layout = self#attach_std_item_attrs stdAttrs itm in
+      self#attachDocAttrsToLayout
+        ~stdAttrs
+        ~docAttrs
+        ~loc:td.ptype_loc
+        ~layout
+        ()
+    in
+
+    match l with
+      | [] -> raise (NotPossible "asking for type list of nothing")
+      | hd::tl ->
+          let first =
+            match rf with
+            | Recursive -> formatOneTypeDefStandard (atom "type") hd
+            | Nonrecursive ->
+                formatOneTypeDefStandard (atom "type nonrec") hd
+          in
+          match tl with
+            (* Exactly one type *)
+            | [] -> first
+            | _::_ as typeList ->
+                let items = (hd.ptype_loc, first)::(List.map (fun ptyp ->
+                    (ptyp.ptype_loc, formatOneTypeDefStandard (atom "and") ptyp)
+                  ) typeList
+                ) in
+                makeList ~indent:0 ~inline:(true, true) ~break:Always_rec (
+                  groupAndPrint
+                    ~xf:snd
+                    ~getLoc:fst
+                    ~comments:self#comments
+                    items
+                )
+
+  method type_variant_leaf ?opt_ampersand:(a=false) ?polymorphic:(p=false) = self#type_variant_leaf1 a p true
+  method type_variant_leaf_nobar ?opt_ampersand:(a=false) ?polymorphic:(p=false) = self#type_variant_leaf1 a p false
+
+  (* TODOATTRIBUTES: Attributes on the entire variant leaf are likely
+   * not parsed or printed correctly. *)
+  method type_variant_leaf1 opt_ampersand polymorphic print_bar x =
+    let {pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes} = x in
+    let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true pcd_attributes in
+    let ampersand_helper i arg =
+      let ct = self#core_type arg in
+      let ct = match arg.ptyp_desc with
+        | Ptyp_tuple _ -> ct
+        | _ -> makeTup [ct]
+      in
+      if i == 0 && not opt_ampersand then
+        ct
+      else
+        label (atom "&") ct
+    in
+    let args = match pcd_args with
+      | Pcstr_record r -> [self#record_declaration r]
+      | Pcstr_tuple [] -> []
+      | Pcstr_tuple l when polymorphic -> List.mapi ampersand_helper l
+      (* Here's why this works. With the new syntax, all the args, are already inside of
+        a safely guarded place like Constructor(here, andHere). Compare that to the
+        previous syntax Constructor here andHere. In the previous syntax, we needed to
+        require that we print "non-arrowed" types for here, and andHere to avoid
+        something like Constructor a=>b c=>d. In the new syntax, we don't care if here
+        and andHere have unguarded arrow types like a=>b because they're safely
+        separated by commas.
+       *)
+      | Pcstr_tuple l -> [makeTup (List.map self#core_type l)]
+    in
+    let gadtRes = match pcd_res with
+      | None -> None
+      | Some x -> Some (
+          formatJustTheTypeConstraint (self#core_type x)
+        )
+    in
+    let normalize lst = match lst with
+      | [] -> raise (NotPossible "should not be called")
+      | [hd] -> hd
+      | _::_ -> makeList ~inline:(true, true) ~break:IfNeed ~postSpace:true lst
+    in
+    let add_bar constructor =
+      makeList ~postSpace:true (if print_bar then [atom "|"; constructor] else [constructor])
+    in
+    (* In some cases (e.g. inline records) we want the label with bar & the gadt resolution
+     * as a list.
+     *   | If {
+     *       pred: expr bool,
+     *       true_branch: expr 'a,
+     *       false_branch: expr 'a
+     *     }                           ==> end of label
+     *     :expr 'a;                   ==> gadt res
+     * The label & the gadt res form two separate units combined into a list.
+     * This is necessary to properly align the closing '}' on the same height as the 'If'.
+     *)
+    let add_bar_2 ?gadt name args =
+      let lbl = label name args in
+      let fullLbl = match gadt with
+        | Some g -> makeList ~inline:(true, true) ~break:IfNeed [lbl; g]
+        | None -> lbl
+      in
+      add_bar fullLbl
+    in
+
+    let prefix = if polymorphic then "`" else "" in
+    let sourceMappedName = atom ~loc:pcd_name.loc (prefix ^ pcd_name.txt) in
+    let sourceMappedNameWithAttributes =
+      let layout = match stdAttrs with
+      | [] -> sourceMappedName
+      | stdAttrs ->
+        formatAttributed sourceMappedName (self#attributes stdAttrs)
+      in
+      match docAttrs with
+      | [] -> layout
+      | docAttrs ->
+        makeList ~break:Always ~inline:(true, true) [
+          makeList (self#attributes docAttrs);
+          layout
+        ]
+    in
+    let constructorName = makeList ~postSpace:true [sourceMappedNameWithAttributes] in
+    let everything = match (args, gadtRes) with
+      | ([], None) -> add_bar sourceMappedNameWithAttributes
+      | ([], Some gadt) -> add_bar_2 sourceMappedNameWithAttributes gadt
+      | (_::_, None) -> add_bar_2 constructorName (normalize args)
+      | (_::_, Some gadt) ->
+          (match pcd_args with
+            | Pcstr_record _ -> add_bar_2 ~gadt constructorName (normalize args)
+            | _ -> add_bar_2 constructorName ~gadt (normalize args))
+    in
+    source_map ~loc:pcd_loc everything
+
+  method record_declaration ?assumeRecordLoc lbls =
+    let recordRow pld =
+      let hasPunning = recordRowIsPunned pld in
+      let name =
+        if hasPunning
+        then [atom pld.pld_name.txt]
+        else [atom pld.pld_name.txt; atom ":"]
+      in
+      let name = source_map ~loc:pld.pld_name.loc (makeList name) in
+      let withMutable =
+        match pld.pld_mutable with
+        | Immutable -> name
+        | Mutable -> makeList ~postSpace:true [atom "mutable"; name]
+      in
+      let recordRow = if hasPunning then
+          label withMutable (atom "")
+        else
+          label ~space:true withMutable (self#core_type pld.pld_type)
+      in
+      let recordRow = match pld.pld_attributes with
+      | [] -> recordRow
+      | attrs ->
+          let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true attrs in
+        let stdAttrsLayout =
+          makeList ~inline:(true, true) ~postSpace:true (self#attributes stdAttrs)
+        in
+        let docAttrsLayout = makeList ~inline:(true, true) (self#attributes docAttrs) in
+        let children = match (docAttrs, stdAttrs) with
+        | [], [] -> [recordRow]
+        | _, [] -> [docAttrsLayout; recordRow]
+        | [], _ -> [stdAttrsLayout; recordRow]
+        | _, _ ->
+            [docAttrsLayout; stdAttrsLayout; recordRow]
+        in
+        makeList ~inline:(true, true) ~break:Always_rec children
+      in
+      source_map ~loc:pld.pld_loc recordRow
+    in
+    let rows = List.map recordRow lbls in
+    (* if a record has more than 2 rows, always break *)
+    let break =
+      if List.length rows >= 2
+      then Layout.Always_rec
+      else Layout.IfNeed
+    in
+    source_map ?loc:assumeRecordLoc
+      (makeList ~wrap:("{", "}") ~sep:commaTrail ~postSpace:true ~break rows)
+
+  (* Returns the type declaration partitioned into three segments - one
+     suitable for appending to a label, the actual type manifest
+     and the list of constraints. *)
+  method type_declaration_binding_segments x =
+    (* Segments of the type binding (occuring after the type keyword) that
+       should begin with "=". Zero to two total sections.
+       This is just a straightforward reverse mapping from the original parser:
+        type_kind:
+            /*empty*/
+              { (Ptype_abstract, Public, None) }
+          | EQUAL core_type
+              { (Ptype_abstract, Public, Some $2) }
+          | EQUAL PRIVATE core_type
+              { (Ptype_abstract, Private, Some $3) }
+          | EQUAL constructor_declarations
+              { (Ptype_variant(List.rev $2), Public, None) }
+          | EQUAL PRIVATE constructor_declarations
+              { (Ptype_variant(List.rev $3), Private, None) }
+          | EQUAL private_flag BAR constructor_declarations
+              { (Ptype_variant(List.rev $4), $2, None) }
+          | EQUAL DOTDOT
+              { (Ptype_open, Public, None) }
+          | EQUAL private_flag LBRACE label_declarations opt_comma RBRACE
+              { (Ptype_record(List.rev $4), $2, None) }
+          | EQUAL core_type EQUAL private_flag opt_bar constructor_declarations
+              { (Ptype_variant(List.rev $6), $4, Some $2) }
+          | EQUAL core_type EQUAL DOTDOT
+              { (Ptype_open, Public, Some $2) }
+          | EQUAL core_type EQUAL private_flag LBRACE label_declarations opt_comma RBRACE
+              { (Ptype_record(List.rev $6), $4, Some $2) }
+    *)
+    let privateAtom = (atom "pri") in
+    let privatize scope lst = match scope with
+      | Public -> lst
+      | Private -> privateAtom::lst in
+
+    let estimateRecordOpenBracePoint () =
+      match x.ptype_params with
+        | [] -> x.ptype_name.loc.loc_end
+        | _ ->
+          (fst (List.nth x.ptype_params (List.length x.ptype_params - 1))).ptyp_loc.loc_end
+    in
+
+    let equalInitiatedSegments = match (x.ptype_kind, x.ptype_private, x.ptype_manifest) with
+      (* /*empty*/ {(Ptype_abstract, Public, None)} *)
+      | (Ptype_abstract, Public, None) -> [
+
+        ]
+      (* EQUAL core_type {(Ptype_abstract, Public, Some _)} *)
+      | (Ptype_abstract, Public, Some y) -> [
+          [self#core_type y]
+        ]
+      (* EQUAL PRIVATE core_type {(Ptype_abstract, Private, Some $3)} *)
+      | (Ptype_abstract, Private, Some y) -> [
+          [privateAtom; self#core_type y]
+        ]
+      (* EQUAL constructor_declarations {(Ptype_variant _., Public, None)} *)
+      (* This case is redundant *)
+      (* | (Ptype_variant lst, Public, None) -> [ *)
+      (*     [makeSpacedBreakableInlineList (List.map type_variant_leaf lst)] *)
+      (*   ] *)
+      (* EQUAL PRIVATE constructor_declarations {(Ptype_variant _, Private, None)} *)
+      | (Ptype_variant lst, Private, None) -> [
+          [privateAtom; makeList ~break:IfNeed ~postSpace:true ~inline:(true, true) (List.map self#type_variant_leaf lst)]
+        ]
+      (* EQUAL private_flag BAR constructor_declarations {(Ptype_variant _, $2, None)} *)
+      | (Ptype_variant lst, scope, None) ->  [
+          privatize scope [makeList ~break:Always_rec ~postSpace:true ~inline:(true, true) (List.map self#type_variant_leaf lst)]
+        ]
+      (* EQUAL DOTDOT {(Ptype_open, Public, None)} *)
+      | (Ptype_open, Public, None) -> [
+          [atom ".."]
+        ]
+      (* Super confusing how record/variants' manifest is not actually the
+         description of the structure. What's in the manifest in that case is
+         the *second* EQUALS asignment. *)
+
+      (* EQUAL private_flag LBRACE label_declarations opt_comma RBRACE {(Ptype_record _, $2, None)} *)
+      | (Ptype_record lst, scope, None) ->
+          let assumeRecordLoc = {loc_start = estimateRecordOpenBracePoint(); loc_end = x.ptype_loc.loc_end; loc_ghost = false} in
+          [privatize scope [self#record_declaration ~assumeRecordLoc lst]]
+      (* And now all of the forms involving *TWO* equals *)
+      (* Again, super confusing how manifests of variants/records represent the
+         structure after the second equals. *)
+      (* ================================================*)
+
+
+      (* EQUAL core_type EQUAL private_flag opt_bar constructor_declarations {
+         (Ptype_variant _, _, Some _)} *)
+      | (Ptype_variant lst, scope, Some mani) -> [
+          [self#core_type mani];
+          let variant = makeList ~break:IfNeed ~postSpace:true ~inline:(true, true) (List.map self#type_variant_leaf lst) in
+          privatize scope [variant];
+        ]
+
+      (* EQUAL core_type EQUAL DOTDOT {(Ptype_open, Public, Some $2)} *)
+      | (Ptype_open, Public, Some mani) -> [
+          [self#core_type mani];
+          [atom ".."];
+        ]
+      (* EQUAL core_type EQUAL private_flag LBRACE label_declarations opt_comma RBRACE
+           {(Ptype_record _, $4, Some $2)} *)
+      | (Ptype_record lst, scope, Some mani) ->
+          let declaration = self#record_declaration lst in
+          let record = match scope with
+            | Public -> [declaration]
+            | Private -> [label ~space:true privateAtom declaration]
+          in
+          [ [self#core_type mani]; record ]
+
+      (* Everything else is impossible *)
+      (* ================================================*)
+
+      | (_, _, _ ) ->  raise (NotPossible "Encountered impossible type specification")
+    in
+
+    let makeConstraint (ct1, ct2, _) =
+      let constraintEq = makeList ~postSpace:true [
+        atom "constraint";
+        self#core_type ct1;
+        atom "=";
+      ] in
+      label ~space:true constraintEq (self#core_type ct2) in
+    let constraints = List.map makeConstraint x.ptype_cstrs in
+    (equalInitiatedSegments, constraints)
+
+  (* "non-arrowed" means "a type where all arrows are inside at least one level of parens"
+
+    z => z: not a "non-arrowed" type.
+    (a, b): a "non-arrowed" type.
+    (z=>z): a "non-arrowed" type because the arrows are guarded by parens.
+
+    A "non arrowed, non simple" type would be one that is not-arrowed, and also
+    not "simple". Simple means it is "clearly one unit" like (a, b), identifier,
+    "hello", None.
+  *)
+  method non_arrowed_non_simple_core_type x =
+    let {stdAttrs} = partitionAttributes x.ptyp_attributes in
+    if stdAttrs != [] then
+      formatAttributed
+        (self#non_arrowed_simple_core_type {x with ptyp_attributes=[]})
+        (self#attributes stdAttrs)
+    else
+      match x.ptyp_desc with
+      (* This significantly differs from the standard OCaml printer/parser:
+         Type constructors are no longer simple *)
+      | _ -> self#non_arrowed_simple_core_type x
+
+  method type_param_list_element = function
+    | {ptyp_attributes = []; ptyp_desc = Ptyp_package(lid,cstrs)} ->
+        self#typ_package ~mod_prefix:true lid cstrs
+    | t -> self#core_type t
+
+  method non_arrowed_simple_core_type x =
+    let {stdAttrs} = partitionAttributes x.ptyp_attributes in
+    if stdAttrs != [] then
+      formatSimpleAttributed
+        (self#non_arrowed_simple_core_type {x with ptyp_attributes=[]})
+        (self#attributes stdAttrs)
+    else
+      let result =
+        match x.ptyp_desc with
+        (*   LPAREN core_type_comma_list RPAREN %prec below_NEWDOT *)
+        (*       { match $2 with *)
+        (*         | [] -> raise Parse_error *)
+        (*         | one::[] -> one *)
+        (*         | moreThanOne -> mktyp(Ptyp_tuple(List.rev moreThanOne)) } *)
+        | Ptyp_tuple l -> makeTup (List.map self#type_param_list_element l)
+        | Ptyp_object (l, o) -> self#unparseObject l o
+        | Ptyp_package (lid, cstrs) ->
+            self#typ_package ~protect:true ~mod_prefix:true lid cstrs
+        (*   | QUOTE ident *)
+        (*       { mktyp(Ptyp_var $2) } *)
+        | Ptyp_var s -> ensureSingleTokenSticksToLabel (self#tyvar s)
+        (*   | UNDERSCORE *)
+        (*       { mktyp(Ptyp_any) } *)
+        | Ptyp_any -> ensureSingleTokenSticksToLabel (atom "_")
+        (*   | type_longident *)
+        (*       { mktyp(Ptyp_constr(mkrhs $1 1, [])) } *)
+        | Ptyp_constr (li, []) ->
+          (* [ensureSingleTokenSticksToLabel] loses location information which is important
+               when you are embedded inside a list and comments are to be interleaved around you.
+               Therefore, we wrap the result in the correct [SourceMap].  *)
+          source_map ~loc:li.loc
+            (ensureSingleTokenSticksToLabel (self#longident_loc li))
+        | Ptyp_constr (li, l) ->
+            (match l with
+            | [{ptyp_desc = Ptyp_object (_::_ as l, o) }] when isJsDotTLongIdent li.txt ->
+                (* should have one or more rows, Js.t({..}) should print as Js.t({..})
+                 * {..} has a totally different meaning than Js.t({..}) *)
+                self#unparseObject ~withStringKeys:true l o
+            | [{ptyp_desc = Ptyp_object (l, o) }] when not (isJsDotTLongIdent li.txt) ->
+                label (self#longident_loc li)
+                  (self#unparseObject ~wrap:("(",")") l o)
+            | [{ptyp_desc = Ptyp_constr(lii, [{ ptyp_desc = Ptyp_object (_::_ as ll, o)}])}]
+              when isJsDotTLongIdent lii.txt ->
+              label (self#longident_loc li)
+                (self#unparseObject ~withStringKeys:true ~wrap:("(",")") ll o)
+            | _ ->
+              (* small guidance: in `type foo = bar`, we're now at the `bar` part *)
+
+              (* The single identifier has to be wrapped in a [ensureSingleTokenSticksToLabel] to
+                 avoid (@see @avoidSingleTokenWrapping): *)
+              label
+                (self#longident_loc li)
+                (makeTup (
+                  List.map self#type_param_list_element l
+                ))
+            )
+        | Ptyp_variant (l, closed, low) ->
+          let pcd_loc = x.ptyp_loc in
+          let pcd_attributes = x.ptyp_attributes in
+          let pcd_res = None in
+          let variant_helper i rf =
+            match rf with
+              | Rtag (label, attrs, opt_ampersand, ctl) ->
+                let pcd_name = {
+                  txt = label;
+                  loc = pcd_loc;
+                } in
+                let pcd_args = Pcstr_tuple ctl in
+                let all_attrs = List.concat [pcd_attributes; attrs] in
+                self#type_variant_leaf ~opt_ampersand ~polymorphic:true {pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes = all_attrs}
+              | Rinherit ct ->
+                (* '| type' is required if the Rinherit is not the first
+                  row_field in the list
+                 *)
+                if i = 0 then
+                  self#core_type ct
+                else
+                  makeList ~postSpace:true [atom "|"; self#core_type ct] in
+          let (designator, tl) =
+            match (closed,low) with
+              | (Closed,None) -> ("", [])
+              | (Closed,Some tl) -> ("<", tl)
+              | (Open,_) -> (">", []) in
+          let node_list = List.mapi variant_helper l in
+          let ll = (List.map (fun t -> atom ("`" ^ t)) tl) in
+          let tag_list = makeList ~postSpace:true ~break:IfNeed ((atom ">")::ll) in
+          let type_list = if tl != [] then node_list@[tag_list] else node_list in
+          makeList ~wrap:("[" ^ designator,"]") ~pad:(true, false) ~postSpace:true ~break:IfNeed type_list
+        | Ptyp_class (li, []) -> makeList [atom "#"; self#longident_loc li]
+        | Ptyp_class (li, l) ->
+          label
+            (makeList [atom "#"; self#longident_loc li])
+            (makeTup (List.map self#core_type l))
+        | Ptyp_extension e -> self#extension e
+        | Ptyp_arrow (_, _, _)
+        | Ptyp_alias (_, _)
+        | Ptyp_poly (_, _) ->
+            makeList ~wrap:("(",")") ~break:IfNeed [self#core_type x]
+      in
+      source_map ~loc:x.ptyp_loc result
+  (* TODO: ensure that we have a form of desugaring that protects *)
+  (* when final argument of curried pattern is a type constraint: *)
+  (* | COLON non_arrowed_core_type EQUALGREATER expr
+      { mkexp_constraint $4 (Some $2, None) }         *)
+  (*                         \----/   \--/
+                             constraint coerce
+
+                             Creates a ghost expression:
+                             mkexp_constraint | Some t, None -> ghexp(Pexp_constraint(e, t))
+  *)
+
+  method pattern_list_split_cons acc = function
+    | {
+      ppat_desc = Ppat_construct (
+        { txt = Lident("::")},
+        Some {ppat_desc = Ppat_tuple ([pat1; pat2])}
+      ) } ->
+        self#pattern_list_split_cons (pat1::acc) pat2
+    | p -> (List.rev acc), p
+
+  (*
+   * Adds parens to the right sub-tree when it is not a single node:
+   *
+   * A | B                   is formatted as    A | B
+   * A | (B | C)             is formatted as    A | (B | C)
+   *
+   * Also, adds parens to both sub-trees when both of them
+   * are not a single node:
+   * (A | B) | (C | D)       is formatted as    A | B | (C | D)
+   * A | B | (C | D)         is formatted as    A | B | (C | D)
+   * (A | B) | C             is formatted as    A | B | C
+   * A | B | C               is formatted as    A | B | C
+   *
+   *)
+  method or_pattern p1 p2 =
+    let (p1_raw, p2_raw) = (self#pattern p1, self#pattern p2) in
+    let (left, right) =
+      match p2.ppat_desc with
+        | Ppat_or _ -> (p1_raw, formatPrecedence p2_raw)
+        | _ -> (p1_raw, p2_raw)
+    in
+    makeList
+      ~break:IfNeed
+      ~inline:(true, true)
+      ~sep:(Sep "|")
+      ~postSpace:true
+      ~preSpace:true
+      [left; right]
+
+  method pattern_without_or x =
+    (* TODOATTRIBUTES: Handle the stdAttrs here *)
+    let {arityAttrs} = partitionAttributes x.ppat_attributes in
+    match x.ppat_desc with
+      | Ppat_alias (p, s) ->
+          let raw_pattern = (self#pattern p) in
+          let pattern_with_precedence = match p.ppat_desc with
+            | Ppat_or (p1, p2) -> formatPrecedence (self#or_pattern p1 p2)
+            | _ -> raw_pattern
+          in
+          label ~space:true
+            (source_map ~loc:p.ppat_loc pattern_with_precedence)
+            (makeList ~postSpace:true [
+              atom "as";
+              (source_map ~loc:s.loc (protectIdentifier s.txt))
+            ]) (* RA*)
+      | Ppat_variant (l, Some p) ->
+          if arityAttrs != [] then
+            raise (NotPossible "Should never see embedded attributes on poly variant")
+          else
+            source_map ~loc:x.ppat_loc
+              (self#constructor_pattern (atom ("`" ^ l)) p
+                 ~polyVariant:true ~arityIsClear:true)
+      | Ppat_lazy p -> label ~space:true (atom "lazy") (self#simple_pattern p)
+      | Ppat_construct (({txt} as li), po) when not (txt = Lident "::")-> (* FIXME The third field always false *)
+          let formattedConstruction = match po with
+            (* TODO: Check the explicit_arity field on the pattern/constructor
+               attributes to determine if should desugar to an *actual* tuple. *)
+            (* | Some ({ *)
+            (*   ppat_desc=Ppat_tuple l; *)
+            (*   ppat_attributes=[{txt="explicit_arity"; loc}] *)
+            (* }) -> *)
+            (*   label ~space:true (self#longident_loc li) (makeSpacedBreakableInlineList (List.map self#simple_pattern l)) *)
+            | Some pattern ->
+                let arityIsClear = isArityClear arityAttrs in
+                self#constructor_pattern ~arityIsClear (self#longident_loc li) pattern
+            | None ->
+                self#longident_loc li
+          in
+          source_map ~loc:x.ppat_loc formattedConstruction
+      | _ -> self#simple_pattern x
+
+  method pattern x =
+    let {arityAttrs; stdAttrs} = partitionAttributes x.ppat_attributes in
+    if stdAttrs != [] then
+      formatAttributed
+        (* Doesn't need to be simple_pattern because attributes are parse as
+         * appyling to the entire "function application style" syntax preceeding them *)
+        (self#pattern {x with ppat_attributes=arityAttrs})
+        (self#attributes stdAttrs)
+    else match x.ppat_desc with
+      | Ppat_or (p1, p2) ->
+        self#or_pattern p1 p2
+      | _ -> self#pattern_without_or x
+
+  method patternList ?(wrap=("","")) pat =
+    let pat_list, pat_last = self#pattern_list_split_cons [] pat in
+    let pat_list = List.map self#pattern pat_list in
+    match pat_last with
+    | {ppat_desc = Ppat_construct ({txt=Lident "[]"},_)} -> (* [x,y,z] *)
+      let (lwrap, rwrap) = wrap in
+      makeList pat_list
+        ~break:Layout.IfNeed ~sep:commaTrail ~postSpace:true
+        ~wrap:(lwrap ^ "[", "]" ^ rwrap)
+    | _ -> (* x::y *)
+      makeES6List pat_list (self#pattern pat_last) ~wrap
+
+  (* In some contexts the Ptyp_package needs to be protected by parens, or
+   * the `module` keyword needs to be added.
+   * Example: let f = (module Add: S.Z, x) => Add.add(x);
+   *  It's clear that `S.Z` is a module because it constraints the
+   *  `module Add` pattern. No need to add "contract" before `S.Z`.
+   *
+   * Example2:
+   *   type t = (module Console);
+   *   In this case the "contract" keyword needs to be printed to indicate
+   *   usage of a first-class-module.
+   *)
+  method typ_package ?(protect=false) ?(mod_prefix=true) lid cstrs =
+    let packageIdent =
+      let packageIdent = self#longident_loc lid in
+      if mod_prefix then
+        makeList ~postSpace:true [atom "contract"; packageIdent]
+      else packageIdent
+    in
+    let unwrapped_layout = match cstrs with
+    | [] -> packageIdent
+    | cstrs ->
+        label ~space:true
+          (makeList ~postSpace:true [packageIdent; atom "with"])
+          (makeList
+            ~inline:(true, true)
+            ~break:IfNeed
+            ~sep:(Sep " and ")
+            (List.map (fun (s, ct) ->
+              label ~space:true
+                (makeList
+                  ~break:IfNeed ~postSpace:true
+                  [atom "type"; self#longident_loc s; atom "="])
+                (self#core_type ct)
+            ) cstrs))
+    in
+    if protect then
+      makeList ~postSpace:true ~wrap:("(", ")") [unwrapped_layout ]
+    else unwrapped_layout
+
+  method constrained_pattern x = match x.ppat_desc with
+    | Ppat_constraint (p, ct) ->
+        let (pat, typ) = begin match (p, ct) with
+        | (
+            {ppat_desc = Ppat_unpack(unpack)},
+            {ptyp_desc = Ptyp_package (lid, cstrs)}
+          ) ->
+            (makeList ~postSpace:true [atom "contract"; atom unpack.txt],
+             self#typ_package ~mod_prefix:false lid cstrs)
+        | _ ->
+          (self#pattern p, self#core_type ct)
+        end in
+        formatTypeConstraint pat typ
+    | _  -> self#pattern x
+
+  method simple_pattern x =
+    let {arityAttrs; stdAttrs} = partitionAttributes x.ppat_attributes in
+    if stdAttrs != [] then
+      formatSimpleAttributed
+        (self#simple_pattern {x with ppat_attributes=arityAttrs})
+        (self#attributes stdAttrs)
+    else
+      let itm =
+        match x.ppat_desc with
+          | Ppat_construct (({loc; txt=Lident ("()"|"[]" as x)}), _) ->
+              (* Patterns' locations might include a leading bar depending on the
+               * context it was parsed in. Therefore, we need to include further
+               * information about the contents of the pattern such as tokens etc,
+               * in order to get comments to be distributed correctly.*)
+            atom ~loc x
+          | Ppat_construct (({txt=Lident "::"}), _) ->
+            self#patternList x (* LIST PATTERN *)
+          | Ppat_construct (li, None) ->
+            source_map ~loc:x.ppat_loc (self#longident_loc li)
+          | Ppat_any -> atom "_"
+          | Ppat_var ({loc; txt = txt}) ->
+            (*
+               To prevent this:
+
+                 let oneArgShouldWrapToAlignWith
+                   theFunctionNameBinding => theFunctionNameBinding;
+
+               And instead do:
+
+                 let oneArgShouldWrapToAlignWith
+                     theFunctionNameBinding => theFunctionNameBinding;
+
+               We have to do something to the non "listy" patterns. Non listy
+               patterns don't indent the same amount as listy patterns when docked
+               to a label.
+
+               If wrapping the non-listy pattern in [ensureSingleTokenSticksToLabel]
+               you'll get the following (even though it should wrap)
+
+                 let oneArgShouldWrapToAlignWith theFunctionNameBinding => theFunctionNameBinding;
+
+             *)
+            source_map ~loc (protectIdentifier txt)
+          | Ppat_array l ->
+              self#patternArray l
+          | Ppat_unpack s ->
+              makeList ~wrap:("(", ")") ~break:IfNeed ~postSpace:true [atom "contract"; atom s.txt]
+          | Ppat_open (lid, pat) ->
+            (* let someFn Qualified.{ record } = ... *)
+            let needsParens = match pat.ppat_desc with
+              | Ppat_exception _ -> true
+              | _ -> false
+            in
+            let pat = self#simple_pattern pat in
+            label
+              (label (self#longident_loc lid) (atom (".")))
+              (if needsParens then formatPrecedence pat else pat)
+          | Ppat_type li ->
+              makeList [atom "#"; self#longident_loc li]
+          | Ppat_record (l, closed) ->
+             self#patternRecord l closed
+          | Ppat_tuple l ->
+             self#patternTuple l
+          | Ppat_constant c ->
+            let raw_literal, _ = extract_raw_literal x.ppat_attributes in
+            (self#constant ?raw_literal c)
+          | Ppat_interval (c1, c2) ->
+            makeList [self#constant c1; atom ".."; self#constant c2]
+          | Ppat_variant (l, None) -> makeList[atom "`"; atom l]
+          | Ppat_constraint (p, ct) ->
+              formatPrecedence (formatTypeConstraint (self#pattern p) (self#core_type ct))
+          | Ppat_lazy p ->formatPrecedence (label ~space:true (atom "lazy") (self#simple_pattern p))
+          | Ppat_extension e -> self#extension e
+          | Ppat_exception p ->
+              (*
+                An exception pattern with an alias should be wrapped in (...)
+                The rules for what goes to the right of the exception are a little (too) nuanced.
+                It accepts "non simple" parameters, except in the case of `as`.
+                Here we consistently apply "simplification" to the exception argument.
+                Example:
+                  | exception (Sys_error _ as exc) => raise exc
+                 parses correctly while
+                  | Sys_error _ as exc => raise exc
+                 results in incorrect parsing with type error otherwise.
+              *)
+               (makeList ~postSpace:true [atom "exception"; self#simple_pattern p])
+          | _ -> formatPrecedence (self#pattern x) (* May have a redundant sourcemap *)
+        in
+        source_map ~loc:x.ppat_loc itm
+
+  method label_exp lbl opt pat =
+    let term = self#constrained_pattern pat in
+    let param = match lbl with
+      | Nolabel -> term
+      | Labelled lbl | Optional lbl when is_punned_labelled_pattern pat lbl ->
+        makeList [atom namedArgSym; term]
+      | Labelled lbl | Optional lbl ->
+        let lblLayout=
+          makeList ~sep:(Sep " ") ~break:Layout.Never
+            [atom (namedArgSym ^ lbl); atom "as"]
+        in
+        label lblLayout ~space:true term
+    in
+    match opt, lbl with
+    | None, Optional _ -> makeList [param; atom "=?"]
+    | None, _ -> param
+    | Some o, _ -> makeList [param; atom "="; (self#unparseProtectedExpr ~forceParens:true o)]
+
+  method access op cls e1 e2 = makeList [
+    (* Important that this be not breaking - at least to preserve same
+       behavior as stock desugarer. It might even be required (double check
+       in parser.mly) *)
+    e1;
+    atom op;
+    e2;
+    atom cls;
+  ]
+
+
+  method simple_get_application x =
+    let {stdAttrs; jsxAttrs} = partitionAttributes x.pexp_attributes in
+    match (x.pexp_desc, stdAttrs, jsxAttrs) with
+    | (_, _::_, []) -> None (* Has some printed attributes - not simple *)
+    | (Pexp_apply ({pexp_desc=Pexp_ident loc}, l), [], _jsx::_) -> (
+      (* TODO: Soon, we will allow the final argument to be an identifier which
+         represents the entire list. This would be written as
+         `<tag>...list</tag>`. If you imagine there being an implicit [] inside
+         the tag, then it would be consistent with array spread:
+         [...list] evaluates to the thing as list.
+      *)
+      let hasLabelledChildrenLiteral = List.exists (function
+        | (Labelled "children", _) -> true
+        | _ -> false
+      ) l in
+      let rec hasSingleNonLabelledUnitAndIsAtTheEnd l = match l with
+      | [] -> false
+      | (Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, _)}) :: [] -> true
+      | (Nolabel, _) :: _ -> false
+      | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
+      in
+      if hasLabelledChildrenLiteral && hasSingleNonLabelledUnitAndIsAtTheEnd l then
+        let moduleNameList = List.rev (List.tl (List.rev (Longident.flatten loc.txt))) in
+        if moduleNameList != [] then
+          if Longident.last loc.txt = "createElement" then
+            Some (self#formatJSXComponent (String.concat "." moduleNameList) l)
+          else None
+        else Some (self#formatJSXComponent (Longident.last loc.txt) l)
+      else None
+    )
+    | (Pexp_apply (
+        {pexp_desc=
+          Pexp_letmodule(_,
+            ({pmod_desc=Pmod_apply _} as app),
+            {pexp_desc=Pexp_ident loc}
+          )}, l), [], _jsx::_) -> (
+      (* TODO: Soon, we will allow the final argument to be an identifier which
+         represents the entire list. This would be written as
+         `<tag>...list</tag>`. If you imagine there being an implicit [] inside
+         the tag, then it would be consistent with array spread:
+         [...list] evaluates to the thing as list.
+      *)
+      let rec extract_apps args = function
+        | { pmod_desc = Pmod_apply (m1, {pmod_desc=Pmod_ident loc}) } ->
+          let arg = String.concat "." (Longident.flatten loc.txt) in
+          extract_apps (arg :: args) m1
+        | { pmod_desc=Pmod_ident loc } -> (String.concat "." (Longident.flatten loc.txt))::args
+        | _ -> failwith "Functors in JSX tags support only module names as parameters" in
+      let hasLabelledChildrenLiteral = List.exists (function
+        | (Labelled "children", _) -> true
+        | _ -> false
+      ) l in
+      let rec hasSingleNonLabelledUnitAndIsAtTheEnd l = match l with
+      | [] -> false
+      | (Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, _)}) :: [] -> true
+      | (Nolabel, _) :: _ -> false
+      | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
+      in
+      if hasLabelledChildrenLiteral && hasSingleNonLabelledUnitAndIsAtTheEnd l then
+        if List.length (Longident.flatten loc.txt) > 1 then
+          if Longident.last loc.txt = "createElement" then
+            begin match extract_apps [] app with
+              | ftor::args ->
+                let applied = ftor ^ "(" ^ String.concat ", " args ^ ")" in
+                Some (self#formatJSXComponent ~closeComponentName:ftor applied l)
+              | _ -> None
+            end
+          else None
+        else Some (self#formatJSXComponent (Longident.last loc.txt) l)
+      else None
+    )
+    | _ -> None
+
+  (** Detects "sugar expressions" (sugar for array/string setters) and returns their separate
+      parts.  *)
+  method sugar_set_expr_parts e =
+    if e.pexp_attributes != [] then None
+    (* should also check attributes underneath *)
+    else match e.pexp_desc with
+      | Pexp_apply ({pexp_desc=Pexp_ident{txt=Ldot (Lident ("Array"), "set")}}, [(_,e1);(_,e2);(_,e3)]) ->
+        let prec = Custom "prec_lbracket" in
+        let lhs = self#unparseResolvedRule (
+            self#ensureExpression ~reducesOnToken:prec e1
+          ) in
+        Some (self#access "[" "]" lhs (self#unparseExpr e2), e3)
+      | Pexp_apply ({pexp_desc=Pexp_ident {txt=Ldot (Lident "String", "set")}}, [(_,e1);(_,e2);(_,e3)]) ->
+        let prec = Custom "prec_lbracket" in
+        let lhs = self#unparseResolvedRule (
+            self#ensureExpression ~reducesOnToken:prec e1
+          ) in
+        Some ((self#access ".[" "]" lhs (self#unparseExpr e2)), e3)
+      | Pexp_apply (
+        {pexp_desc=Pexp_ident {txt = Ldot (Ldot (Lident "Bigarray", array), "set")}},
+        label_exprs
+      ) -> (
+        match array with
+          | "Genarray" -> (
+            match label_exprs with
+            | [(_,a);(_,{pexp_desc=Pexp_array ls});(_,c)] ->
+              let formattedList = List.map self#unparseExpr ls in
+              let lhs = makeList [self#simple_enough_to_be_lhs_dot_send a; atom "."] in
+              let rhs = makeList ~break:IfNeed ~postSpace:true ~sep:commaSep ~wrap:("{", "}") formattedList
+              in
+              Some (label lhs rhs, c)
+            | _ -> None
+          )
+          | ("Array1"|"Array2"|"Array3") -> (
+            match label_exprs with
+            | (_,a)::rest -> (
+              match List.rev rest with
+              | (_,v)::rest ->
+                let args = List.map snd (List.rev rest) in
+                let formattedList = List.map self#unparseExpr args in
+                let lhs = makeList [self#simple_enough_to_be_lhs_dot_send a; atom "."] in
+                let rhs = makeList ~break:IfNeed ~postSpace:true ~sep:commaSep ~wrap:("{", "}") formattedList in
+                Some (label lhs rhs, v)
+              | _ -> assert false
+            )
+            | _ -> assert false
+          )
+          | _ -> None
+        )
+      | _ -> None
+
+  (*
+
+     How would we know not to print the sequence without { }; protecting the let a?
+
+                            let a
+                             |
+                           sequence
+                          /        \
+                    let a           print a
+                    alert a
+     let res = {
+       let a = something();
+       {                     \
+         alert(a);           | portion to be parsed as a sequence()
+         let a = 20;         | The final ; print(a) causes the entire
+         alert(a);           | portion to be parsed as a sequence()
+       };                    |
+       print (a);            /
+     }
+
+     ******************************************************************
+     Any time the First expression of a sequence is another sequence, or (as in
+     this case) a let, wrapping the first sequence expression in { } is
+     required.
+     ******************************************************************
+  *)
+
+  (**
+     TODO: Configure the optional ability to print the *minimum* number of
+     parens. It's simply a matter of changing [higherPrecedenceThan] to
+     [higherOrEqualPrecedenceThan].
+   *)
+
+  (* The point of the function is to ensure that ~reducesAfterRight:rightExpr will reduce
+     at the proper time when it is reparsed, possibly wrapping it
+     in parenthesis if needed. It ensures a rule doesn't reduce
+     until *after* `reducesAfterRight` gets a chance to reduce.
+     Example: The addition rule which has precedence of rightmost
+     token "+", in `x + a * b` should not reduce until after the a * b gets
+     a chance to reduce. This function would determine the minimum parens to
+     ensure that. *)
+  method ensureContainingRule ~withPrecedence ~reducesAfterRight () =
+    match self#unparseExprRecurse reducesAfterRight with
+    | SpecificInfixPrecedence ({shiftPrecedence}, rightRecurse) ->
+      if higherPrecedenceThan shiftPrecedence withPrecedence then rightRecurse
+      else if (higherPrecedenceThan withPrecedence shiftPrecedence) then
+        LayoutNode (formatPrecedence ~loc:reducesAfterRight.pexp_loc (self#unparseResolvedRule rightRecurse))
+      else (
+        if isRightAssociative ~prec:withPrecedence then
+         rightRecurse
+        else
+          LayoutNode (formatPrecedence ~loc:reducesAfterRight.pexp_loc (self#unparseResolvedRule rightRecurse))
+      )
+    | FunctionApplication itms ->
+      let funApplExpr = formatAttachmentApplication applicationFinalWrapping None (itms, Some reducesAfterRight.pexp_loc)
+      in
+      (* Little hack: need to print parens for the `bar` application in e.g.
+         `foo->other##(bar(baz))` or `foo->other->(bar(baz))`. *)
+      if higherPrecedenceThan withPrecedence (Custom "prec_functionAppl")
+      then LayoutNode (formatPrecedence ~loc:reducesAfterRight.pexp_loc funApplExpr)
+      else LayoutNode funApplExpr
+    | PotentiallyLowPrecedence itm -> LayoutNode (formatPrecedence ~loc:reducesAfterRight.pexp_loc itm)
+    | Simple itm -> LayoutNode itm
+
+  method ensureExpression ~reducesOnToken expr =
+    match self#unparseExprRecurse expr with
+    | SpecificInfixPrecedence ({reducePrecedence}, leftRecurse) ->
+      if higherPrecedenceThan reducePrecedence reducesOnToken then leftRecurse
+      else if higherPrecedenceThan reducesOnToken reducePrecedence then
+        LayoutNode (formatPrecedence ~loc:expr.pexp_loc (self#unparseResolvedRule leftRecurse))
+      else (
+        if isLeftAssociative ~prec:reducesOnToken then
+          leftRecurse
+        else
+          LayoutNode (formatPrecedence ~loc:expr.pexp_loc (self#unparseResolvedRule leftRecurse))
+      )
+    | FunctionApplication itms -> LayoutNode (formatAttachmentApplication applicationFinalWrapping None (itms, Some expr.pexp_loc))
+    | PotentiallyLowPrecedence itm -> LayoutNode (formatPrecedence ~loc:expr.pexp_loc itm)
+    | Simple itm -> LayoutNode itm
+
+  (** Attempts to unparse: The beginning of a more general printing algorithm,
+      that determines how to print based on precedence of tokens and rules.
+      The end goal is that this should be completely auto-generated from the
+      Menhir parsing tables. We could move more and more into this function.
+
+      You could always just call self#expression, but `unparseExpr` will render
+      infix/prefix/unary/terary fixities in their beautiful forms while
+      minimizing parenthesis.
+  *)
+  method unparseExpr x =
+    match self#unparseExprRecurse x with
+    | SpecificInfixPrecedence (_, resolvedRule) ->
+        self#unparseResolvedRule resolvedRule
+    | FunctionApplication itms ->
+        formatAttachmentApplication applicationFinalWrapping None (itms, Some x.pexp_loc)
+    | PotentiallyLowPrecedence itm -> itm
+    | Simple itm -> itm
+
+  (* This method may not even be needed *)
+  method unparseUnattributedExpr x =
+    match partitionAttributes x.pexp_attributes with
+    | {docAttrs = []; stdAttrs = []} -> self#unparseExpr x
+    | _ -> makeList ~wrap:("(",")") [self#unparseExpr x]
+
+  (* ensureExpr ensures that the expression is wrapped in parens
+   * e.g. is necessary in cases like:
+   * let display = (:message=("hello": string)) => 1;
+   * but not in cases like:
+   * let f = (a: bool) => 1;
+   * TODO: in the future we should probably use the type ruleCategory
+   * to 'automatically' ensure the validity of a constraint expr with parens...
+   *)
+  method unparseProtectedExpr ?(forceParens=false) e =
+    let itm =
+      match e with
+      | { pexp_attributes = []; pexp_desc = Pexp_constraint (x, ct)} ->
+        let x = self#unparseExpr x in
+        let children = [x; label ~space:true (atom ":") (self#core_type ct)] in
+        if forceParens then
+          makeList ~wrap:("(", ")") children
+        else makeList children
+      | { pexp_attributes; pexp_desc = Pexp_constant c } ->
+        (* When we have Some(-1) or someFunction(-1, -2), the arguments -1 and -2
+         * pass through this case. In this context they don't need to be wrapped in extra parens
+         * Some((-1)) should be printed as Some(-1). This is in contrast with
+         * 1 + (-1) where we print the parens for readability. *)
+          let raw_literal, pexp_attributes =
+            extract_raw_literal pexp_attributes
+          in
+          let constant = self#constant ?raw_literal ~parens:forceParens c in
+          begin match pexp_attributes with
+          | [] -> constant
+          | attrs ->
+              let formattedAttrs = makeSpacedBreakableInlineList (List.map self#item_attribute attrs) in
+               makeSpacedBreakableInlineList [formattedAttrs; constant]
+          end
+      | {pexp_desc = Pexp_fun _ } -> self#formatPexpFun e
+      | x -> self#unparseExpr x
+    in
+    source_map ~loc:e.pexp_loc itm
+
+  method simplifyUnparseExpr ?(inline=false) ?(wrap=("(", ")")) x =
+    match self#unparseExprRecurse x with
+    | SpecificInfixPrecedence (_, itm) ->
+        formatPrecedence
+          ~inline
+          ~wrap
+          ~loc:x.pexp_loc
+          (self#unparseResolvedRule itm)
+    | FunctionApplication itms ->
+      formatPrecedence
+        ~inline
+        ~wrap
+        ~loc:x.pexp_loc
+        (formatAttachmentApplication applicationFinalWrapping None (itms, Some x.pexp_loc))
+    | PotentiallyLowPrecedence itm ->
+        formatPrecedence
+          ~inline
+          ~wrap
+          ~loc:x.pexp_loc
+          itm
+    | Simple itm -> itm
+
+
+  method unparseResolvedRule  = function
+    | LayoutNode layoutNode -> layoutNode
+    | InfixTree _ as infixTree ->
+      formatComputedInfixChain (computeInfixChain infixTree)
+
+  method unparseExprApplicationItems x =
+    match self#unparseExprRecurse x with
+    | SpecificInfixPrecedence (_, wrappedRule) ->
+        let itm = self#unparseResolvedRule wrappedRule in
+        ([itm], Some x.pexp_loc)
+    | FunctionApplication itms -> (itms, Some x.pexp_loc)
+    | PotentiallyLowPrecedence itm -> ([itm], Some x.pexp_loc)
+    | Simple itm -> ([itm], Some x.pexp_loc)
+
+
+  (* Provides beautiful printing for pipe first sugar:
+   * foo
+   * ->f(a, b)
+   * ->g(c, d)
+   *)
+  method formatPipeFirst e =
+    let module PipeFirstTree = struct
+      type exp = Parsetree.expression
+
+      type flatNode =
+        | Exp of exp
+        | ExpU of exp (* uncurried *)
+        | Args of (Asttypes.arg_label * exp) list
+      type flatT = flatNode list
+
+      type node = {
+        exp: exp;
+        args: (Asttypes.arg_label *exp) list;
+        uncurried: bool;
+      }
+      type t = node list
+
+      let formatNode ?prefix ?(first=false) {exp; args; uncurried} =
+        let formatLayout expr =
+          let formatted = if first then
+            self#ensureExpression ~reducesOnToken:(Token pipeFirstToken) expr
+          else
+            match expr with
+            (* a->foo(x, _) and a->(foo(x, _)) are equivalent under pipe first
+             * (a->foo)(x, _) is unnatural and desugars to
+             *    (__x) => (a |. foo)(x, __x)
+             * Under `->`, it makes more sense to desugar into
+             *  a |. (__x => foo(x, __x))
+             *
+             * Hence we don't need parens in this case.
+             *)
+            | expr when Reason_heuristics.isUnderscoreApplication expr ->
+                LayoutNode (self#unparseExpr expr)
+            | _ ->
+              self#ensureContainingRule
+                ~withPrecedence:(Token pipeFirstToken) ~reducesAfterRight:expr ()
+          in
+          self#unparseResolvedRule formatted
+        in
+        let parens = match (exp.pexp_desc) with
+        | Pexp_apply (e,_) -> printedStringAndFixityExpr e = UnaryPostfix "^"
+        | _ -> false
+        in
+        let layout = match args with
+        | [] ->
+          let e = formatLayout exp in
+          (match prefix with
+          | Some l -> makeList [l; e]
+          | None -> e)
+        | args ->
+            let fakeApplExp =
+              let loc_end = match List.rev args with
+                | (_, e)::_ -> e.pexp_loc.loc_end
+                | _ -> exp.pexp_loc.loc_end
+              in
+              {exp with pexp_loc = { exp.pexp_loc with loc_end = loc_end } }
+            in
+            makeList (
+              self#formatFunAppl
+                ?prefix
+                ~jsxAttrs:[]
+                ~args
+                ~funExpr:exp
+                ~applicationExpr:fakeApplExp
+                ~uncurried
+                ()
+            )
+        in
+        if parens then
+          formatPrecedence layout
+        else layout
+    end in
+    (* Imagine: foo->f(a, b)->g(c,d)
+     * The corresponding parsetree looks more like:
+     *   (((foo->f)(a,b))->g)(c, d)
+     * The extra Pexp_apply nodes, e.g. (foo->f), result into a
+     * nested/recursive ast which is pretty inconvenient in terms of printing.
+     * For printing purposes we actually want something more like:
+     *  foo->|f(a,b)|->|g(c, d)|
+     * in order to provide to following printing:
+     *  foo
+     *  ->f(a, b)
+     *  ->g(c, d)
+     * The job of "flatten" is to turn the inconvenient, nested ast
+     *  (((foo->f)(a,b))->g)(c, d)
+     * into
+     *  [Exp foo; Exp f; Args [a; b]; Exp g; Args [c; d]]
+     * which can be processed for printing purposes.
+     *)
+    let rec flatten ?(uncurried=false) acc = function
+      | {pexp_desc = Pexp_apply(
+          {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+          [Nolabel, arg1; Nolabel, arg2]
+         )} ->
+          flatten ((PipeFirstTree.Exp arg2)::acc) arg1
+      | {pexp_attributes;
+         pexp_desc = Pexp_apply(
+          {pexp_desc = Pexp_apply(
+           {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+             [Nolabel, arg1; Nolabel, arg2]
+           )},
+           args
+         )} as e ->
+          let args = PipeFirstTree.Args args in
+          begin match pexp_attributes with
+          | [{txt = "bs"}, PStr []] ->
+            flatten ((PipeFirstTree.ExpU arg2)::args::acc) arg1
+          | [] ->
+              (* the uncurried attribute might sit on the Pstr_eval
+               * enclosing the Pexp_apply*)
+              if uncurried then
+                flatten ((PipeFirstTree.ExpU arg2)::args::acc) arg1
+              else
+                flatten ((PipeFirstTree.Exp arg2)::args::acc) arg1
+          | _ ->
+            (PipeFirstTree.Exp e)::acc
+          end
+      | {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})} -> acc
+      | arg -> ((PipeFirstTree.Exp arg)::acc)
+    in
+    (* Given: foo->f(a, b)->g(c, d)
+     * We get the following PipeFirstTree.flatNode list:
+     *   [Exp foo; Exp f; Args [a; b]; Exp g; Args [c; d]]
+     * The job of `parse` is to turn the "flat representation"
+     * (a.k.a. PipeFirstTree.flastNode list) into a more convenient structure
+     * that allows us to express the segments: "foo" "f(a, b)" "g(c, d)".
+     * PipeFirstTree.t expresses those segments.
+     *  [{exp = foo; args = []}; {exp = f; args = [a; b]}; {exp = g; args = [c; d]}]
+     *)
+    let rec parse acc = function
+    | (PipeFirstTree.Exp e)::(PipeFirstTree.Args args)::xs ->
+        parse ((PipeFirstTree.{exp = e; args; uncurried = false})::acc) xs
+    | (PipeFirstTree.ExpU e)::(PipeFirstTree.Args args)::xs ->
+        parse ((PipeFirstTree.{exp = e; args; uncurried = true})::acc) xs
+    | (PipeFirstTree.Exp e)::xs ->
+        parse ((PipeFirstTree.{exp = e; args = []; uncurried = false})::acc) xs
+    | _ -> List.rev acc
+    in
+    (* Given: foo->f(. a,b);
+     * The uncurried attribute doesn't sit on the Pexp_apply, but sits on
+     * the top level Pstr_eval. We don't have access to top-level context here,
+     * hence the lookup in the global uncurriedTable to correctly determine
+     * if we need to print uncurried. *)
+    let uncurried = try Hashtbl.find uncurriedTable e.pexp_loc with
+      | Not_found -> false
+    in
+    (* Turn
+     *  foo->f(a, b)->g(c, d)
+     * into
+     *  [Exp foo; Exp f; Args [a; b]; Exp g; Args [c; d]]
+     *)
+    let (flatNodes : PipeFirstTree.flatT) = flatten ~uncurried [] e in
+    (* Turn
+     *  [Exp foo; Exp f; Args [a; b]; Exp g; Args [c; d]]
+     * into
+     *  [{exp = foo; args = []}; {exp = f; args = [a; b]}; {exp = g; args = [c; d]}]
+     *)
+    let (pipetree : PipeFirstTree.t) = parse [] flatNodes in
+    (* Turn
+     *  [{exp = foo; args = []}; {exp = f; args = [a; b]}; {exp = g; args = [c; d]}]
+     * into
+     *  [foo; ->f(a, b); ->g(c, d)]
+     *)
+    let pipeSegments = match pipetree with
+    (* Special case printing of
+     * foo->bar(
+     *  aa,
+     *  bb,
+     * )
+     *
+     *  We don't want
+     *  foo
+     *  ->bar(
+     *      aa,
+     *      bb
+     *    )
+     *
+     *  Notice how `foo->bar` shouldn't break, it wastes space and is
+     *  inconsistent with
+     *  foo.bar(
+     *    aa,
+     *    bb,
+     *  )
+     *)
+    | [({exp = {pexp_desc = Pexp_ident _ }} as hd); last] ->
+        let prefix = Some (
+          makeList [PipeFirstTree.formatNode ~first:true hd; atom "->"]
+        ) in
+        [PipeFirstTree.formatNode ?prefix last]
+    | hd::tl ->
+        let hd = PipeFirstTree.formatNode ~first:true hd in
+        let tl = List.map (fun node ->
+          makeList [atom "->"; PipeFirstTree.formatNode node]
+        ) tl in
+        hd::tl
+    | [] -> []
+    in
+    (* Provide nice breaking for: [foo; ->f(a, b); ->g(c, d)]
+     * foo
+     * ->f(a, b)
+     * ->g(c, d)
+     *)
+    makeList ~break:IfNeed ~inline:(true, true) pipeSegments
+
+  (*
+   * Replace (__x) => foo(__x) with foo(_)
+   *)
+  method process_underscore_application x =
+    let process_application expr =
+      let process_arg (l,e) = match e.pexp_desc with
+        | Pexp_ident ({ txt = Lident "__x"} as id) ->
+          let pexp_desc = Pexp_ident {id with txt = Lident "_"} in
+          (l, {e with pexp_desc})
+        | _ ->
+          (l,e) in
+      match expr.pexp_desc with
+      | Pexp_apply (e_fun, args) ->
+        let pexp_desc = Pexp_apply (e_fun, List.map process_arg args) in
+        {expr with pexp_desc}
+      | _ ->
+        expr in
+    match x.pexp_desc with
+    | Pexp_fun (Nolabel, None, {ppat_desc = Ppat_var {txt="__x"}},
+        ({pexp_desc = Pexp_apply _} as e)) ->
+      process_application e
+    | Pexp_fun (l, eo, p, e) ->
+       let e_processed = self#process_underscore_application e in
+       if e == e_processed then
+         x
+       else
+         {x with pexp_desc = Pexp_fun (l, eo, p, e_processed)}
+    | _ ->
+      x
+
+  method unparseExprRecurse x =
+    let x = self#process_underscore_application x in
+    (* If there are any attributes, render unary like `(~-) x [@ppx]`, and infix like `(+) x y [@attr]` *)
+
+    let {arityAttrs; stdAttrs; jsxAttrs; stylisticAttrs; uncurried} =
+      partitionAttributes ~allowUncurry:(Reason_heuristics.bsExprCanBeUncurried x) x.pexp_attributes
+    in
+    let stylisticAttrs = Reason_attributes.maybe_remove_stylistic_attrs stylisticAttrs preserve_braces in
+    let () = if uncurried then Hashtbl.add uncurriedTable x.pexp_loc true in
+    let x = {x with pexp_attributes = (stylisticAttrs @ arityAttrs @ stdAttrs @ jsxAttrs) } in
+    (* If there's any attributes, recurse without them, then apply them to
+       the ends of functions, or simplify infix printings then append. *)
+    if stdAttrs != [] then
+      let withoutVisibleAttrs = {x with pexp_attributes=(stylisticAttrs @ arityAttrs @ jsxAttrs)} in
+      let attributesAsList = (List.map self#attribute stdAttrs) in
+      let itms = match self#unparseExprRecurse withoutVisibleAttrs with
+        | SpecificInfixPrecedence ({reducePrecedence}, wrappedRule) ->
+            let itm = self#unparseResolvedRule wrappedRule in
+            (match reducePrecedence with
+             (* doesn't need wrapping; we know how to parse *)
+             | Custom "prec_lbracket" | Token "." -> [itm]
+             | _ -> [formatPrecedence ~loc:x.pexp_loc itm])
+        | FunctionApplication itms -> itms
+        | PotentiallyLowPrecedence itm -> [formatPrecedence ~loc:x.pexp_loc itm]
+        | Simple itm -> [itm]
+      in
+      FunctionApplication [
+        makeList
+          ~break:IfNeed
+          ~inline:(true, true)
+          ~indent:0
+          ~postSpace:true
+          (List.concat [attributesAsList; itms])
+      ]
+    else
+    match self#simplest_expression x with
+    | Some se -> Simple se
+    | None ->
+    match x.pexp_desc with
+    | Pexp_apply (e, ls) -> (
+      let ls = List.map (fun (l,expr) -> (l, self#process_underscore_application expr)) ls in
+      match (e, ls) with
+      | (e, _) when Reason_heuristics.isPipeFirst e ->
+        let prec = Token pipeFirstToken in
+          SpecificInfixPrecedence
+            ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode (self#formatPipeFirst x))
+      | ({pexp_desc = Pexp_ident {txt = Ldot (Lident ("Array"),"get")}}, [(_,e1);(_,e2)]) ->
+        begin match e1.pexp_desc with
+          | Pexp_ident ({txt = Lident "_"}) ->
+            let k = atom "Array.get" in
+            let v = makeList ~postSpace:true ~sep:(Layout.Sep ",") ~wrap:("(", ")")
+                [atom "_"; self#unparseExpr e2]
+            in
+            Simple (label k v)
+          | _ ->
+            let prec = Custom "prec_lbracket" in
+            let lhs = self#unparseResolvedRule (
+              self#ensureExpression ~reducesOnToken:prec e1
+            ) in
+            let rhs = self#unparseExpr e2 in
+            SpecificInfixPrecedence
+              ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode (self#access "[" "]" lhs rhs))
+        end
+      | ({pexp_desc = Pexp_ident {txt = Ldot (Lident ("String"),"get")}}, [(_,e1);(_,e2)]) ->
+        if Reason_heuristics.isUnderscoreIdent e1 then
+          let k = atom "String.get" in
+          let v = makeList ~postSpace:true ~sep:(Layout.Sep ",") ~wrap:("(", ")")
+              [atom "_"; self#unparseExpr e2]
+          in
+          Simple (label k v)
+        else
+          let prec = Custom "prec_lbracket" in
+            let lhs = self#unparseResolvedRule (
+              self#ensureExpression ~reducesOnToken:prec e1
+            ) in
+            let rhs = self#unparseExpr e2 in
+          SpecificInfixPrecedence
+            ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode (self#access ".[" "]" lhs rhs))
+      | (
+        {pexp_desc= Pexp_ident {txt=Ldot (Ldot (Lident "Bigarray", "Genarray" ), "get")}},
+        [(_,e1); (_,({pexp_desc=Pexp_array ls} as e2))]
+      ) ->
+        if (Reason_heuristics.isUnderscoreIdent e1) then
+          let k = atom "Bigarray.Genarray.get" in
+          let v = makeList ~postSpace:true ~sep:(Layout.Sep ",") ~wrap:("(", ")")
+              [atom "_"; self#unparseExpr e2]
+          in
+          Simple (label k v)
+        else
+          let formattedList = List.map self#unparseExpr ls in
+          let lhs = makeList [(self#simple_enough_to_be_lhs_dot_send e1); atom "."] in
+          let rhs = makeList ~break:IfNeed ~postSpace:true ~sep:commaSep ~wrap:("{", "}") formattedList in
+          let prec = Custom "prec_lbracket" in
+          SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode (label lhs rhs))
+      | (
+        {pexp_desc= Pexp_ident {txt=
+                                  Ldot (Ldot (Lident "Bigarray", (("Array1"|"Array2"|"Array3") as arrayIdent)), "get")}
+        },
+        (_,e1)::rest
+      ) ->
+        if Reason_heuristics.isUnderscoreIdent e1 then
+          let k = atom("Bigarray." ^ arrayIdent ^ ".get") in
+          let v = makeList ~postSpace:true ~sep:(Layout.Sep ",") ~wrap:("(", ")")
+              ((atom "_")::(List.map (fun (_, e) -> self#unparseExpr e) rest))
+          in
+          Simple (label k v)
+        else
+          let formattedList = List.map self#unparseExpr (List.map snd rest) in
+          let lhs = makeList [(self#simple_enough_to_be_lhs_dot_send e1); atom "."] in
+          let rhs = makeList ~break:IfNeed ~postSpace:true ~sep:commaSep ~wrap:("{", "}") formattedList in
+          let prec = Custom "prec_lbracket" in
+          SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode (label lhs rhs))
+      | _ -> (
+
+          match (self#sugar_set_expr_parts x) with
+      (* Returns None if there's attributes - would render as regular function *)
+      (* Format as if it were an infix function application with identifier "=" *)
+      | Some (simplyFormatedLeftItm, rightExpr) -> (
+        let tokenPrec = Token updateToken in
+        let rightItm = self#ensureContainingRule ~withPrecedence:tokenPrec ~reducesAfterRight:rightExpr () in
+        let leftWithOp = makeList ~postSpace:true [simplyFormatedLeftItm; atom updateToken] in
+        let expr = label ~space:true leftWithOp (self#unparseResolvedRule rightItm) in
+        SpecificInfixPrecedence ({reducePrecedence=tokenPrec; shiftPrecedence=tokenPrec}, LayoutNode expr)
+      )
+      | None -> (
+        match (printedStringAndFixityExpr e, ls) with
+       (* We must take care not to print two subsequent prefix operators without
+         spaces between them (`! !` could become `!!` which is totally
+         different).  *)
+        | (AlmostSimplePrefix prefixStr, [(Nolabel, rightExpr)]) ->
+        let forceSpace = match rightExpr.pexp_desc with
+          | Pexp_apply (ee, _) ->
+            (match printedStringAndFixityExpr ee with | AlmostSimplePrefix _ -> true | _ -> false)
+          | _ -> false
+        in
+        let prec = Token prefixStr in
+        let rightItm = self#unparseResolvedRule (
+          self#ensureContainingRule ~withPrecedence:prec ~reducesAfterRight:rightExpr ()
+        ) in
+        SpecificInfixPrecedence
+          ({reducePrecedence=prec; shiftPrecedence = prec}, LayoutNode (label ~space:forceSpace (atom prefixStr) rightItm))
+        | (UnaryPostfix postfixStr, [(Nolabel, leftExpr)]) ->
+          let forceSpace = match leftExpr.pexp_desc with
+            | Pexp_apply (ee, _) ->
+              (match printedStringAndFixityExpr ee with
+               | UnaryPostfix "^" | AlmostSimplePrefix _ -> true
+               | _ -> false)
+            | _ -> false
+          in
+          let leftItm = (match leftExpr.pexp_desc with
+            | Pexp_apply (e,_) ->
+              (match printedStringAndFixityExpr e with
+               | Infix printedIdent
+                 when requireNoSpaceFor printedIdent ||
+                      Reason_heuristics.isPipeFirst e ->
+                 self#unparseExpr leftExpr
+               | _ -> self#simplifyUnparseExpr leftExpr)
+            | Pexp_field _ -> self#unparseExpr leftExpr
+            | _ -> self#simplifyUnparseExpr leftExpr
+          )
+          in
+          Simple (label ~space:forceSpace leftItm (atom postfixStr))
+        | (Infix printedIdent, [(Nolabel, leftExpr); (Nolabel, rightExpr)]) ->
+          let infixToken = Token printedIdent in
+          let rightItm = self#ensureContainingRule ~withPrecedence:infixToken ~reducesAfterRight:rightExpr () in
+          let leftItm = self#ensureExpression ~reducesOnToken:infixToken leftExpr in
+          (* Left exprs of infix tokens which we don't print spaces for (e.g. `##`)
+             need to be wrapped in parens in the case of postfix `^`. Otherwise,
+             printing will be ambiguous as `^` is also a valid start of an infix
+             operator. *)
+          let formattedLeftItm = (match leftItm with
+            | LayoutNode x -> begin match leftExpr.pexp_desc with
+                | Pexp_apply (e,_) ->
+                  (match printedStringAndFixityExpr e with
+                   | UnaryPostfix "^" when requireNoSpaceFor printedIdent ->
+                     LayoutNode (formatPrecedence ~loc:leftExpr.pexp_loc x)
+                   | _ -> leftItm)
+                | _ -> leftItm
+              end
+            | InfixTree _ -> leftItm
+          ) in
+          let infixTree = InfixTree (printedIdent, formattedLeftItm, rightItm) in
+          SpecificInfixPrecedence ({reducePrecedence=infixToken; shiftPrecedence=infixToken}, infixTree)
+        (* Will be rendered as `(+) a b c` which is parsed with higher precedence than all
+           the other forms unparsed here.*)
+        | (UnaryPlusPrefix printedIdent, [(Nolabel, rightExpr)]) ->
+          let prec = Custom "prec_unary" in
+          let rightItm = self#unparseResolvedRule (
+            self#ensureContainingRule ~withPrecedence:prec ~reducesAfterRight:rightExpr ()
+          ) in
+          let expr = label ~space:true (atom printedIdent) rightItm in
+          SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=Token printedIdent}, LayoutNode expr)
+        | (UnaryMinusPrefix printedIdent as x, [(Nolabel, rightExpr)])
+        | (UnaryNotPrefix printedIdent as x, [(Nolabel, rightExpr)]) ->
+          let forceSpace = (match x with
+              | UnaryMinusPrefix _ -> true
+              | _ -> begin match rightExpr.pexp_desc with
+                  | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident s}}, _) ->
+                    isSimplePrefixToken s
+                  | _ -> false
+                end) in
+          let prec = Custom "prec_unary" in
+          let rightItm = self#unparseResolvedRule (
+            self#ensureContainingRule ~withPrecedence:prec ~reducesAfterRight:rightExpr ()
+          ) in
+          let expr = label ~space:forceSpace (atom printedIdent) rightItm in
+          SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=Token printedIdent}, LayoutNode expr)
+        (* Will need to be rendered in self#expression as (~-) x y z. *)
+        | (_, _) ->
+        (* This case will happen when there is something like
+
+             Bar.createElement a::1 b::2 [] [@bla] [@JSX]
+
+           At this point the bla will be stripped (because it's a visible
+           attribute) but the JSX will still be there.
+         *)
+
+        (* this case also happens when we have something like:
+         * List.map((a) => a + 1, numbers);
+         * We got two "List.map" as Pexp_ident & a list of arguments:
+         * [`(a) => a + 1`; `numbers`]
+         *
+         * Another possible case is:
+         * describe("App", () =>
+         *   test("math", () =>
+         *     Expect.expect(1 + 2) |> toBe(3)));
+         *)
+        let uncurried = try Hashtbl.find uncurriedTable x.pexp_loc with | Not_found -> false in
+        FunctionApplication (
+          self#formatFunAppl
+            ~uncurried
+            ~jsxAttrs
+            ~args:ls
+            ~applicationExpr:x
+            ~funExpr:e
+            ()
+          )
+        )
+      )
+    )
+    | Pexp_field (e, li) ->
+        let prec = Token "." in
+        let leftItm = self#unparseResolvedRule (
+          self#ensureExpression ~reducesOnToken:prec e
+        ) in
+        let {stdAttrs} = partitionAttributes e.pexp_attributes in
+        let formattedLeftItm = if stdAttrs == [] then
+            leftItm
+          else
+            formatPrecedence ~loc:e.pexp_loc leftItm
+        in
+        let layout = label (makeList [formattedLeftItm; atom "."]) (self#longident_loc li) in
+        SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode layout)
+    | Pexp_construct (li, Some eo) when not (is_simple_construct (view_expr x)) -> (
+        match view_expr x with
+        (* TODO: Explicit arity *)
+        | `normal ->
+            let arityIsClear = isArityClear arityAttrs in
+            FunctionApplication [self#constructor_expression ~arityIsClear stdAttrs (self#longident_loc li) eo]
+        | _ -> assert false
+      )
+    | Pexp_variant (l, Some eo) ->
+        if arityAttrs != [] then
+          raise (NotPossible "Should never see embedded attributes on poly variant")
+        else
+          FunctionApplication [self#constructor_expression ~polyVariant:true ~arityIsClear:true stdAttrs (atom ("`" ^ l)) eo]
+    (* TODO: Should protect this identifier *)
+    | Pexp_setinstvar (s, rightExpr) ->
+      let rightItm = self#unparseResolvedRule (
+        self#ensureContainingRule ~withPrecedence:(Token updateToken) ~reducesAfterRight:rightExpr ()
+      ) in
+      let expr = label ~space:true (makeList ~postSpace:true [(protectIdentifier s.txt); atom updateToken]) rightItm in
+      SpecificInfixPrecedence ({reducePrecedence=(Token updateToken); shiftPrecedence=(Token updateToken)}, LayoutNode expr)
+    | Pexp_setfield (leftExpr, li, rightExpr) ->
+      let rightItm = self#unparseResolvedRule (
+        self#ensureContainingRule ~withPrecedence:(Token updateToken) ~reducesAfterRight:rightExpr ()
+      ) in
+      let leftItm = self#unparseResolvedRule (
+        self#ensureExpression ~reducesOnToken:(Token ".") leftExpr
+      ) in
+      let leftLbl =
+        label
+          (makeList [leftItm; atom "."])
+          (self#longident_loc li) in
+      let expr = label ~space:true (makeList ~postSpace:true [leftLbl; atom updateToken]) rightItm in
+      SpecificInfixPrecedence ({reducePrecedence=(Token updateToken); shiftPrecedence=(Token updateToken)}, LayoutNode expr)
+    | Pexp_match (e, l) when detectTernary l != None -> (
+      match detectTernary l with
+      | None -> raise (Invalid_argument "Impossible")
+      | Some (tt, ff) ->
+        let ifTrue = self#unparseExpr tt in
+        let testItem = self#unparseResolvedRule (
+          self#ensureExpression e ~reducesOnToken:(Token "?")
+        ) in
+        let ifFalse = self#unparseResolvedRule (
+          self#ensureContainingRule ~withPrecedence:(Token ":") ~reducesAfterRight:ff ()
+        ) in
+        let trueBranch = label ~space:true ~break:`Never (atom "?") ifTrue
+        in
+        let falseBranch = label ~space:true ~break:`Never (atom ":") ifFalse
+        in
+        let expr = label ~space:true testItem (makeList ~break:IfNeed ~sep:(Sep " ") ~inline:(true, true) [trueBranch; falseBranch])
+        in
+        SpecificInfixPrecedence ({reducePrecedence=Token ":"; shiftPrecedence=Token "?"}, LayoutNode expr)
+      )
+    | _ -> (
+      match self#expression_requiring_parens_in_infix x with
+      | Some e -> e
+      | None -> raise (Invalid_argument "No match for unparsing expression")
+    )
+
+  method formatNonSequencyExpression e =
+    (*
+     * Instead of printing:
+     *   let result =  { open Fmt; strf(foo);}
+     *
+     * We format as:
+     *   let result = Fmt.(strf(foo))
+     *
+     * (Also see https://github.com/facebook/Reason/issues/114)
+     *)
+    match e.pexp_attributes, e.pexp_desc with
+    | [], Pexp_record _ (* syntax sugar for M.{x:1} *)
+    | [], Pexp_tuple _ (* syntax sugar for M.(a, b) *)
+    | [], Pexp_object {pcstr_fields = []} (* syntax sugar for M.{} *)
+    | [], Pexp_construct ( {txt= Lident"::"},Some _)
+    | [], Pexp_construct ( {txt= Lident"[]"},_)
+    | [], Pexp_extension ( {txt = "bs.obj"}, _ ) ->
+      self#simplifyUnparseExpr e (* syntax sugar for M.[x,y] *)
+    (* syntax sugar for the rest, wrap with parens to avoid ambiguity.
+     * E.g., avoid M.(M2.v) being printed as M.M2.v
+     * Or ReasonReact.(<> {string("Test")} </>);
+     *)
+    | _ -> makeList ~wrap:("(",")") ~break:IfNeed [self#unparseExpr e]
+
+  (*
+     It's not enough to only check if precedence of an infix left/right is
+     greater than the infix itself. We also should likely pay attention to
+     left/right associativity. So how do we render the minimum number of
+     parenthesis?
+
+     The intuition is that sequential right associative operators will
+     naturally build up deep trees on the right side (left builds up left-deep
+     trees). So by default, we add parens to model the tree structure that
+     we're rendering except when the parser will *naturally* parse the tree
+     structure that the parens assert.
+
+     Sequential identical infix operators:
+     ------------------------------------
+     So if we see a nested infix operator of precedence Y, as one side of
+     another infix operator that has the same precedence (Y), that is S
+     associative on the S side of the function application, we don't need to
+     wrap in parens. In more detail:
+
+     -Add parens around infix binary function application
+       Exception 1: Unless we are a left-assoc operator of precedence X in the left branch of an operator w/ precedence X.
+       Exception 2: Unless we are a right-assoc operator of precedence X in the right branch of an operator w/ precedence X.
+       Exception 3: Unless we are a _any_-assoc X operator in the _any_ branch of an Y operator where X has greater precedence than Y.
+
+     Note that the exceptions do not specify any special cases for mixing
+     left/right associativity. Precedence is what determines necessity of
+     parens for operators with non-identical precedences. Associativity
+     only determines necessity of parens for identically precedented operators.
+
+     PLUS is left assoc:
+     - So this one *shouldn't* expand into two consecutive infix +:
+
+
+            [Pexp_apply]
+              /      \
+         first +   [Pexp_apply]
+                      /   \
+                  second + third
+
+
+     - This one *should*:
+
+                    [Pexp_apply]
+                      /      \
+           [  Pexp_apply  ] + third
+              /     \
+           first +  second
+
+
+
+     COLONCOLON is right assoc, so
+     - This one *should* expand into two consecutive infix ::  :
+
+            [Pexp_apply]
+              /      \
+         first ::   [Pexp_apply]
+                      /   \
+                  second :: third
+
+
+     - This one *shouldn't*:
+
+                    [Pexp_apply]
+                      /      \
+           [  Pexp_apply  ] :: third
+              /     \
+           first ::  second
+
+
+
+
+     Sequential differing infix operators:
+     ------------------------------------
+
+     Neither of the following require paren grouping because of rule 3.
+
+
+            [Pexp_apply]
+              /      \
+         first  +  [Pexp_apply]
+                      /   \
+                  second * third
+
+
+                    [Pexp_apply]
+                      /      \
+            [Pexp_apply  +  third
+              /     \
+           first *  second
+
+      The previous has nothing to do with the fact that + and * have the same
+      associativity. Exception 3 applies to the following where :: is right assoc
+      and + is left. + has higher precedence than ::
+
+      - so parens aren't required to group + when it is in a branch of a
+        lower precedence ::
+
+            [Pexp_apply]
+              /      \
+         first ::   [Pexp_apply]
+                      /   \
+                  second + third
+
+
+      - Whereas there is no Exception that applies in this case (Exception 3
+        doesn't apply) so parens are required around the :: in this case.
+
+                    [Pexp_apply]
+                      /      \
+           [  Pexp_apply  ] + third
+              /     \
+           first ::  second
+
+  *)
+
+  method classExpressionToFormattedApplicationItems = function
+    | { pcl_desc = Pcl_apply (ce, l) } ->
+      [label (self#simple_class_expr ce) (self#label_x_expression_params l)]
+    | x -> [self#class_expr x]
+
+
+  (**
+        How JSX is formatted/wrapped. We want the attributes to wrap independently
+        of children.
+
+        <xxx
+          attr1=blah
+          attr2=foo>
+          child
+          child
+          child
+        </x>
+
+      +-------------------------------+
+      |  left   right (list of attrs) |
+      |   / \   /   \                 |
+      |   <tag                        |
+      |     attr1=blah                |
+      |     attr2=foo                 |
+      +-------------------------------+
+       |
+       |
+       |
+       |      left       right  list of children with
+       |   /       \    /  \     open,close = > </tag>
+       |  +---------+
+       +--|         |    >
+          +---------+
+
+          </tag>           *)
+  method formatJSXComponent componentName ?closeComponentName args =
+    let rec processArguments arguments processedAttrs children =
+      match arguments with
+      | (Labelled "children", {pexp_desc = Pexp_construct (_, None)}) :: tail ->
+        processArguments tail processedAttrs None
+      | (Labelled "children", {pexp_desc = Pexp_construct ({txt = Lident"::"}, Some {pexp_desc = Pexp_tuple components} )}) :: tail ->
+        processArguments tail processedAttrs (self#formatChildren components [])
+      | (Labelled "children", expr) :: tail ->
+          let dotdotdotChild = match expr with
+            | {pexp_desc = Pexp_apply (funExpr, args)}
+              when printedStringAndFixityExpr funExpr == Normal &&
+                   Reason_attributes.without_stylistic_attrs expr.pexp_attributes == [] ->
+              begin match (self#formatFunAppl ~prefix:(atom "...") ~wrap:("{", "}") ~jsxAttrs:[] ~args ~funExpr ~applicationExpr:expr ()) with
+              | [x] -> x
+              | xs -> makeList xs
+              end
+            | {pexp_desc = Pexp_fun _ } ->
+                self#formatPexpFun ~prefix:(atom "...") ~wrap:("{", "}") expr
+            | _ ->
+              let childLayout = self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{", "}") expr in
+              makeList ~break:Never [atom "..."; childLayout]
+          in
+          processArguments tail processedAttrs (Some [dotdotdotChild])
+      | (Optional lbl, expression) :: tail ->
+        let nextAttr =
+          match expression.pexp_desc with
+          | Pexp_ident ident when isPunnedJsxArg lbl ident ->
+              makeList ~break:Layout.Never [atom "?"; atom lbl]
+          | _ ->
+              label
+                (makeList ~break:Layout.Never [atom lbl; atom "=?"])
+                (self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{","}") expression) in
+        processArguments tail (nextAttr :: processedAttrs) children
+
+      | (Labelled lbl, expression) :: tail ->
+         let nextAttr =
+           match expression.pexp_desc with
+           | Pexp_ident ident when isPunnedJsxArg lbl ident -> atom lbl
+           | _ when isJSXComponent expression  ->
+               label (atom (lbl ^ "="))
+                     (makeList ~break:IfNeed ~wrap:("{", "}")
+                       [self#dont_preserve_braces#simplifyUnparseExpr expression])
+           | Pexp_open (_, lid, e)
+             when self#isSeriesOfOpensFollowedByNonSequencyExpression expression ->
+             label (makeList [atom lbl;
+                              atom "=";
+                              (label (self#longident_loc lid) (atom "."))])
+                   (self#formatNonSequencyExpression e)
+           | Pexp_apply ({pexp_desc = Pexp_ident _} as funExpr, args)
+                when printedStringAndFixityExpr funExpr == Normal &&
+                     Reason_attributes.without_stylistic_attrs expression.pexp_attributes == [] ->
+             let lhs = makeList [atom lbl; atom "="] in
+             begin match (
+               self#formatFunAppl
+                ~prefix:lhs
+                ~wrap:("{", "}")
+                ~jsxAttrs:[]
+                ~args
+                ~funExpr
+                ~applicationExpr:expression
+                ())
+             with
+             | [x] -> x
+             | xs -> makeList xs
+             end
+           | Pexp_apply (eFun, _) ->
+             let lhs = makeList [atom lbl; atom "="] in
+             let rhs = (match printedStringAndFixityExpr eFun with
+                 | Infix str when requireNoSpaceFor str -> self#unparseExpr expression
+                 | _ -> self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{","}") expression)
+             in label lhs rhs
+           | Pexp_record _
+           | Pexp_construct _
+           | Pexp_array _
+           | Pexp_tuple _
+           | Pexp_match _
+           | Pexp_extension _
+           | Pexp_function _ ->
+               label
+                (makeList [atom lbl; atom "="])
+                (self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{","}") expression)
+           | Pexp_fun _ ->
+               let propName = makeList [atom lbl; atom "="] in
+               self#formatPexpFun ~wrap:("{", "}") ~prefix:propName expression
+           | _ -> makeList [
+                    atom lbl;
+                    atom "=";
+                    self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{","}") expression
+                  ]
+         in
+         processArguments tail (nextAttr :: processedAttrs) children
+      | [] -> (processedAttrs, children)
+      | _ :: tail -> processArguments tail processedAttrs children
+    in
+    let (reversedAttributes, children) = processArguments args [] None in
+    match children with
+    | None ->
+      makeList
+        ~break:IfNeed
+        ~wrap:("<" ^ componentName, "/>")
+        ~pad:(true, true)
+        ~inline:(false, false)
+        ~postSpace:true
+        (List.rev reversedAttributes)
+    | Some renderedChildren ->
+      let openTagAndAttrs =
+        match reversedAttributes with
+        | [] -> (atom ("<" ^ componentName ^ ">"))
+        | revAttrHd::revAttrTl ->
+          let finalAttrList = (List.rev (makeList ~break:Layout.Never [revAttrHd; atom ">"] :: revAttrTl)) in
+          let renderedAttrList = (makeList ~inline:(true, true) ~break:IfNeed ~pad:(false, false) ~preSpace:true finalAttrList) in
+          label
+            ~space:true
+            (atom ("<" ^ componentName))
+            renderedAttrList
+      in
+      label
+        openTagAndAttrs
+        (makeList
+          ~wrap:("", "</" ^ (match closeComponentName with None -> componentName | Some close -> close) ^ ">")
+          ~inline:(true, false)
+          ~break:IfNeed
+          ~pad:(true, true)
+          ~postSpace:true
+          renderedChildren)
+
+  (*
+   * Format Pexp_fun expression: (a, b) => a + b;
+   * Example: the `onClick` prop with Pexp_fun in
+   *  <div
+   *    onClick={(event) => {
+   *      Js.log(event);
+   *      handleChange(event);
+   *    }}
+   *  />;
+   *
+   *  The arguments of the callback (Pexp_fun) should be inlined as much as
+   *  possible on the same line as `onClick={`.
+   *  Also notice the brace-hugging `}}` at the end.
+   *
+   *  ~prefix -> prefixes the Pexp_fun layout, example `onClick=`
+   *  ~wrap -> wraps the `Pexp_fun` in the tuple passed to wrap, e.g. `{` and
+   *  `}` for jsx
+   *)
+  method formatPexpFun ?(prefix=(atom "")) ?(wrap=("","")) expression =
+    let (lwrap, rwrap) = wrap in
+    let {stdAttrs; uncurried} = partitionAttributes expression.pexp_attributes in
+    if uncurried then Hashtbl.add uncurriedTable expression.pexp_loc true;
+
+    let (args, ret) =
+      (* omit attributes here, we're formatting them manually *)
+      self#curriedPatternsAndReturnVal {expression with pexp_attributes = [] }
+    in
+    (* Format `onClick={` *)
+    let propName = makeList ~wrap:("", lwrap) [prefix] in
+    let argsList =
+      let args = match args with
+      | [argsList] -> argsList
+      | args -> makeList args
+      in
+      match stdAttrs with
+      | [] -> args
+      | attrs ->
+          (* attach attributes to the args of the Pexp_fun: `[@attr] (event)` *)
+          let attrList =
+            makeList ~inline:(true, true) ~break:IfNeed ~postSpace:true
+              (List.map self#attribute attrs)
+          in
+          let all = [attrList; args] in
+          makeList ~break:IfNeed ~inline:(true, true) ~postSpace:true all
+    in
+    (* Format `onClick={(event)` *)
+    let propNameWithArgs = label propName argsList in
+    (* Pick constraints: (a, b) :string => ...
+     * :string is the constraint here *)
+    let (return, optConstr) = match ret.pexp_desc with
+      | Pexp_constraint (e, ct) -> (e, Some (self#non_arrowed_core_type ct))
+      | _ -> (ret, None)
+    in
+    let returnExpr = match (self#letList return) with
+    | [x] ->
+      (* Format `handleChange(event)}` or
+       *  handleChange(event)
+       * }
+       *
+       * If the closing rwrap is empty, we need it to be inline, otherwise
+       * we get a empty newline when the layout breaks:
+       * ```
+       *  handleChange(event)
+       *
+       * ```
+       * (Notice to nonsense newline)
+       *)
+       let inlineClosing = rwrap = "" in
+       makeList ~break:IfNeed ~inline:(true, inlineClosing) ~wrap:("", rwrap) [x]
+    | xs ->
+      (* Format `Js.log(event)` and `handleChange(event)` as
+       * {
+       *   Js.log(event);
+       *   handleChange(event);
+       * }}
+       *)
+        makeList
+          ~break:Always_rec ~sep:(SepFinal (";", ";")) ~wrap:("{", "}" ^ rwrap)
+          xs
+    in
+    match optConstr with
+    | Some typeConstraint ->
+      let upToConstraint =
+        label ~space:true
+          (makeList ~wrap:("", ":") [propNameWithArgs])
+          typeConstraint
+      in
+      label ~space:true
+        (makeList ~wrap:("", " =>") [upToConstraint])
+        returnExpr
+    | None ->
+      label ~space:true
+        (makeList ~wrap:("", " =>") [propNameWithArgs])
+        returnExpr
+
+  (* Creates a list of simple module expressions corresponding to module
+     expression or functor application. *)
+  method moduleExpressionToFormattedApplicationItems ?(prefix="") x =
+    match x with
+    (* are we formatting a functor application with a module structure as arg?
+     * YourLib.Make({
+     *   type t = int;
+     *   type s = string;
+     * });
+     *
+     * We should "hug" the parens here: ({ & }) should stick together.
+     *)
+    | { pmod_desc = Pmod_apply (
+            ({pmod_desc = Pmod_ident _} as m1),
+            ({pmod_desc = Pmod_structure _} as m2)
+         )
+      } ->
+        let modIdent = source_map ~loc:m1.pmod_loc (self#simple_module_expr m1) in
+        let name = if prefix <> "" then
+          makeList ~postSpace:true[atom prefix; modIdent]
+          else modIdent
+        in
+        let arg = source_map ~loc:m2.pmod_loc (self#simple_module_expr ~hug:true m2) in
+        label name arg
+    | _ ->
+      let rec extract_apps args = function
+        | { pmod_desc = Pmod_apply (me1, me2) } ->
+          let arg = source_map ~loc:me2.pmod_loc (self#simple_module_expr me2) in
+          extract_apps (arg :: args) me1
+        | me ->
+          let head = source_map ~loc:me.pmod_loc (self#module_expr me) in
+          if args == [] then head else label head (makeTup args)
+      in
+      let functor_application = extract_apps [] x in
+      if prefix <> "" then
+        makeList ~postSpace:true [atom prefix; functor_application]
+      else
+        functor_application
+
+  (*
+
+     Watch out, if you see something like below (sixteenTuple getting put on a
+     newline), yet a paren-wrapped list wouldn't have had an extra newlin, you
+     might need to wrap the single token (sixteenTuple) in [ensureSingleTokenSticksToLabel].
+     let (
+        axx,
+        oxx,
+        pxx
+      ):
+        sixteenTuple = echoTuple (
+        0,
+        0,
+        0
+      );
+  *)
+
+  method formatSimplePatternBinding labelOpener layoutPattern typeConstraint appTerms =
+    let letPattern = label ~break:`Never ~space:true (atom labelOpener) layoutPattern in
+    let upUntilEqual =
+      match typeConstraint with
+        | None -> letPattern
+        | Some tc -> formatTypeConstraint letPattern tc
+    in
+    let includingEqual = makeList ~postSpace:true [upUntilEqual; atom "="] in
+    formatAttachmentApplication applicationFinalWrapping (Some (true, includingEqual)) appTerms
+
+  (*
+     The [bindingLabel] is either the function name (if let binding) or first
+     arg (if lambda).
+
+     For defining layout of the following form:
+
+         lbl one
+             two
+             constraint => {
+           ...
+         }
+
+     If using "=" as the arrow, can also be used for:
+
+         met private
+             myMethod
+             constraint = fun ...
+
+   *)
+  method wrapCurriedFunctionBinding
+         ?attachTo
+         ~arrow
+         ?(sweet=false)
+         ?(spaceBeforeArrow=true)
+         prefixText
+         bindingLabel
+         patternList
+         returnedAppTerms =
+    let allPatterns = bindingLabel::patternList in
+    let partitioning = curriedFunctionFinalWrapping allPatterns in
+    let everythingButReturnVal =
+      (*
+         Because align_closing is set to false, you get:
+
+         (Brackets[] inserted to show boundaries between open/close of pattern list)
+         let[firstThing
+             secondThing
+             thirdThing]
+
+         It only wraps to indent four by coincidence: If the "opening" token was
+         longer, you'd get:
+
+         letReallyLong[firstThing
+                       secondThing
+                       thirdThing]
+
+         For curried let bindings, we stick the arrow in the *last* pattern:
+         let[firstThing
+             secondThing
+             thirdThing =>]
+
+         But it could have just as easily been the "closing" token corresponding to
+         "let". This works because we have [align_closing = false]. The benefit of
+         shoving it in the last pattern, is that we can turn [align_closing = true]
+         and still have the arrow stuck to the last pattern (which is usually what we
+         want) (See modeTwo below).
+      *)
+      match partitioning with
+        | None when sweet ->
+          makeList
+            ~pad:(false, spaceBeforeArrow)
+            ~wrap:("", arrow)
+            ~indent:(settings.space * settings.indentWrappedPatternArgs)
+            ~postSpace:true
+            ~inline:(true, true)
+            ~break:IfNeed
+            allPatterns
+        | None ->
+            (* We want the binding label to break *with* the arguments. Again,
+               there's no apparent way to add additional indenting for the
+               args with this setting. *)
+
+            (*
+               Formats lambdas by treating the first pattern as the
+               "bindingLabel" which is kind of strange in some cases (when
+               you only have one arg that wraps)...
+
+                  echoTheEchoer (
+                    fun (
+                          a,
+                          p
+                        ) => (
+                      a,
+                      b
+                    )
+
+               But it makes sense in others (where you have multiple args):
+
+                  echoTheEchoer (
+                    fun (
+                          a,
+                          p
+                        )
+                        mySecondArg
+                        myThirdArg => (
+                      a,
+                      b
+                    )
+
+               Try any other convention for wrapping that first arg and it
+               won't look as balanced when adding multiple args.
+
+            *)
+          makeList
+            ~pad:(true, spaceBeforeArrow)
+            ~wrap:(prefixText, arrow)
+            ~indent:(settings.space * settings.indentWrappedPatternArgs)
+            ~postSpace:true
+            ~inline:(true, true)
+            ~break:IfNeed
+            allPatterns
+        | Some (attachedList, wrappedListy) ->
+            (* To get *only* the final argument to "break", while not
+               necessarily breaking the prior arguments, we dock everything
+               but the last item to a created label *)
+          label
+            ~space:true
+            (
+              makeList
+                ~pad:(true, spaceBeforeArrow)
+                ~wrap:(prefixText, arrow)
+                ~indent:(settings.space * settings.indentWrappedPatternArgs)
+                ~postSpace:true
+                ~inline:(true, true)
+                ~break:IfNeed
+                attachedList
+            )
+            wrappedListy
+    in
+
+    let everythingButAppTerms = match attachTo with
+      | None -> everythingButReturnVal
+      | Some toThis -> label ~space:true toThis everythingButReturnVal
+    in
+    formatAttachmentApplication
+      applicationFinalWrapping
+      (Some (true, everythingButAppTerms))
+      returnedAppTerms
+
+  method leadingCurriedAbstractTypes x =
+    let rec argsAndReturn xx =
+      match xx.pexp_desc with
+        | Pexp_newtype (str,e) ->
+            let (nextArgs, return) = argsAndReturn e in
+            (str::nextArgs, return)
+        | _ -> ([], xx.pexp_desc)
+    in argsAndReturn x
+
+  method curriedConstructorPatternsAndReturnVal cl =
+    let rec argsAndReturn args = function
+      | { pcl_desc = Pcl_fun (label, eo, p, e); pcl_attributes = [] } ->
+        let arg = source_map ~loc:p.ppat_loc (self#label_exp label eo p) in
+        argsAndReturn (arg :: args) e
+      | xx ->
+        if args == [] then (None, xx) else (Some (makeTup (List.rev args)), xx)
+    in
+    argsAndReturn [] cl
+
+
+
+  (*
+    Returns the arguments list (if any, that occur before the =>), and the
+    final expression (that is either returned from the function (after =>) or
+    that is bound to the value (if there are no arguments, and this is just a
+    let pattern binding)).
+  *)
+  method curriedPatternsAndReturnVal x =
+    let uncurried = try Hashtbl.find uncurriedTable x.pexp_loc with | Not_found -> false in
+    let rec extract_args xx =
+      let {stdAttrs} = partitionAttributes ~allowUncurry:false xx.pexp_attributes in
+      if stdAttrs != [] then
+        ([], xx)
+      else match xx.pexp_desc with
+        (* label * expression option * pattern * expression *)
+        | Pexp_fun (l, eo, p, e) ->
+          let args, ret = extract_args e in
+          (`Value (l,eo,p) :: args, ret)
+        | Pexp_newtype (newtype,e) ->
+          let args, ret = extract_args e in
+          (`Type newtype :: args, ret)
+        | Pexp_constraint _ -> ([], xx)
+        | _ -> ([], xx)
+    in
+    let prepare_arg = function
+      | `Value (l,eo,p) -> source_map ~loc:p.ppat_loc (self#label_exp l eo p)
+      | `Type nt -> atom ("type " ^ nt)
+    in
+    let single_argument_no_parens p ret =
+      if uncurried then false
+      else
+        let isUnitPat = is_unit_pattern p in
+        let isAnyPat = is_any_pattern p in
+        begin match ret.pexp_desc with
+        (* (event) :ReasonReact.event => {...}
+         * The above Pexp_fun with constraint ReasonReact.event requires parens
+         * surrounding the single argument `event`.*)
+        | Pexp_constraint _ when not isUnitPat && not isAnyPat -> false
+        | _ -> isUnitPat || isAnyPat || is_ident_pattern p
+      end
+    in
+    match extract_args x with
+    | ([], ret) -> ([], ret)
+    | ([`Value (Nolabel, None, p) ], ret) when is_unit_pattern p && uncurried ->
+        ( [atom "(.)"], ret)
+    | ([`Value (Nolabel, None, p) as arg], ret) when single_argument_no_parens p ret ->
+      ([prepare_arg arg], ret)
+    | (args, ret) ->
+        ([makeTup ~uncurried (List.map prepare_arg args)], ret)
+
+  (* Returns the (curriedModule, returnStructure) for a functor *)
+  method curriedFunctorPatternsAndReturnStruct = function
+    (* string loc * module_type option * module_expr *)
+    | { pmod_desc = Pmod_functor(s, mt, me2) } ->
+        let firstOne =
+          match mt with
+            | None -> atom "()"
+            | Some mt' -> self#module_type (makeList [atom s.txt; atom ":"]) mt'
+        in
+        let (functorArgsRecurse, returnStructure) = (self#curriedFunctorPatternsAndReturnStruct me2) in
+        (firstOne::functorArgsRecurse, returnStructure)
+    | me -> ([], me)
+
+  method isRenderableAsPolymorphicAbstractTypes
+         typeVars
+         polyType
+         leadingAbstractVars
+         nonVarifiedType =
+      same_ast_modulo_varification_and_extensions polyType nonVarifiedType &&
+      for_all2' string_equal typeVars leadingAbstractVars
+
+  (* Reinterpret this as a pattern constraint since we don't currently have a
+     way to disambiguate. There is currently a way to disambiguate a parsing
+     from Ppat_constraint vs.  Pexp_constraint. Currently (and consistent with
+     OCaml standard parser):
+
+       let (x: typ) = blah;
+         Becomes Ppat_constraint
+       let x:poly . type = blah;
+         Becomes Ppat_constraint
+       let x:typ = blah;
+         Becomes Pexp_constraint(ghost)
+       let x = (blah:typ);
+         Becomes Pexp_constraint(ghost)
+
+     How are double constraints represented?
+     let (x:typ) = (blah:typ);
+     If currently both constraints are parsed into a single Pexp_constraint,
+     then something must be lost, and how could you fail type checking on:
+     let x:int = (10:string) ?? Answer: It probably parses into a nested
+     Pexp_constraint.
+
+     Proposal:
+
+       let (x: typ) = blah;
+         Becomes Ppat_constraint   (still)
+       let x:poly . type = blah;
+         Becomes Ppat_constraint   (still)
+       let x:typ = blah;
+         Becomes Ppat_constraint
+       let x = blah:typ;
+         Becomes Pexp_constraint
+
+
+     Reasoning: Allows parsing of any of the currently valid ML forms, but
+     combines the two most similar into one form. The only lossyness is the
+     unnecessary parens, which there is already precedence for dropping in
+     expressions. In the existing approach, preserving a paren-constrained
+     expression is *impossible* because it becomes pretty printed as
+     let x:t =.... In the proposal, it is not impossible - it is only
+     impossible to preserve unnecessary parenthesis around the let binding.
+
+     The one downside is that integrating with existing code that uses [let x =
+     (blah:typ)] in standard OCaml will be parsed as a Pexp_constraint. There
+     might be some lossiness (beyond parens) that occurs in the original OCaml
+     parser.
+  *)
+
+  method locallyAbstractPolymorphicFunctionBinding prefixText layoutPattern funWithNewTypes absVars bodyType =
+    let appTerms = self#unparseExprApplicationItems funWithNewTypes in
+    let locallyAbstractTypes = (List.map atom absVars) in
+    let typeLayout =
+      source_map ~loc:bodyType.ptyp_loc (self#core_type bodyType)
+    in
+    let polyType =
+      label
+        ~space:true
+        (* TODO: This isn't a correct use of sep! It ruins how
+         * comments are interleaved. *)
+        (makeList [makeList ~sep:(Sep " ") (atom "type"::locallyAbstractTypes); atom "."])
+        typeLayout
+      in
+    self#formatSimplePatternBinding
+      prefixText
+      layoutPattern
+      (Some polyType)
+      appTerms
+
+  (**
+      Intelligently switches between:
+      Curried function binding w/ constraint on return expr:
+         lbl patt
+             pattAux
+             arg
+             :constraint => {
+           ...
+         }
+
+      Constrained:
+         lbl patt
+             pattAux...
+             :constraint = {
+           ...
+         }
+   *)
+  method wrappedBinding prefixText ~arrow pattern patternAux expr =
+    let expr = self#process_underscore_application expr in
+    let (argsList, return) = self#curriedPatternsAndReturnVal expr in
+    let patternList = match patternAux with
+      | [] -> pattern
+      | _::_ -> makeList ~postSpace:true ~inline:(true, true) ~break:IfNeed (pattern::patternAux)
+    in
+    match (argsList, return.pexp_desc) with
+      | ([], Pexp_constraint (e, ct)) ->
+          let typeLayout =
+            source_map ~loc:ct.ptyp_loc
+              begin match ct.ptyp_desc with
+              | Ptyp_package (li, cstrs) ->
+                self#typ_package li cstrs
+              | _ ->
+                self#core_type ct
+              end
+          in
+          let appTerms = self#unparseExprApplicationItems e in
+          self#formatSimplePatternBinding prefixText patternList (Some typeLayout) appTerms
+      | ([], _) ->
+          (* simple let binding, e.g. `let number = 5` *)
+          (* let f = (. a, b) => a + b; *)
+          let appTerms = self#unparseExprApplicationItems expr in
+          self#formatSimplePatternBinding prefixText patternList None appTerms
+      | (_::_, _) ->
+          let (argsWithConstraint, actualReturn) = self#normalizeFunctionArgsConstraint argsList return in
+          let fauxArgs =
+            List.concat [patternAux; argsWithConstraint] in
+          let returnedAppTerms = self#unparseExprApplicationItems actualReturn in
+           (* Attaches the `=` to `f` to recreate javascript function syntax in
+            * let f = (a, b) => a + b; *)
+          let lbl = makeList ~sep:(Sep " ") ~break:Layout.Never [pattern; atom "="] in
+          self#wrapCurriedFunctionBinding prefixText ~arrow lbl fauxArgs returnedAppTerms
+
+  (* Similar to the above method. *)
+  method wrappedClassBinding prefixText pattern patternAux expr =
+    let (args, return) = self#curriedConstructorPatternsAndReturnVal expr in
+    let patternList =
+      match patternAux with
+        | [] -> pattern
+        | _::_ -> makeList ~postSpace:true ~inline:(true, true) ~break:IfNeed (pattern::patternAux)
+    in
+    match (args, return.pcl_desc) with
+      | (None, Pcl_constraint (e, ct)) ->
+          let typeLayout = source_map ~loc:ct.pcty_loc (self#class_constructor_type ct) in
+          self#formatSimplePatternBinding prefixText patternList (Some typeLayout)
+            (self#classExpressionToFormattedApplicationItems e, None)
+      | (None, _) ->
+          self#formatSimplePatternBinding prefixText patternList None
+            (self#classExpressionToFormattedApplicationItems expr, None)
+      | (Some args, _) ->
+          let (argsWithConstraint, actualReturn) =
+            self#normalizeConstructorArgsConstraint [args] return in
+          let fauxArgs =
+            List.concat [patternAux; argsWithConstraint] in
+          self#wrapCurriedFunctionBinding prefixText ~arrow:"=" pattern fauxArgs
+            (self#classExpressionToFormattedApplicationItems actualReturn, None)
+
+  (* Attaches doc comments to a layout, with whitespace preserved
+   * Example:
+   * /** Doc comment */
+   *
+   * /* another random comment */
+   * let a = 1;
+   *)
+  method attachDocAttrsToLayout
+    (* all std attributes attached on the ast node backing the layout *)
+    ~stdAttrs:(stdAttrs : Ast_404.Parsetree.attributes)
+    (* all doc comments attached on the ast node backing the layout *)
+    ~docAttrs:(docAttrs : Ast_404.Parsetree.attributes)
+    (* location of the layout *)
+    ~loc
+    (* layout to attach the doc comments to *)
+    ~layout () =
+    (*
+     * compute the correct location of layout
+     * Example:
+     * 1| /** doc-comment */
+     * 2|
+     * 3| [@attribute]
+     * 4| let a = 1;
+     *
+     * The location might indicate a start of line 4 for the ast-node
+     * representing `let a = 1`. The reality is that `[@attribute]` should be
+     * included (start of line 3), to represent the correct start location
+     * of the whole layout.
+     *)
+    let loc = match stdAttrs with
+    | (astLoc, _)::_ -> astLoc.loc
+    | [] -> loc
+    in
+    let rec aux prevLoc layout = function
+      | ((x, _) as attr : Ast_404.Parsetree.attribute)::xs ->
+        let newLayout =
+          let range = Range.makeRangeBetween x.loc prevLoc in
+          let layout =
+            if Range.containsWhitespace ~range ~comments:self#comments () then
+              let region = WhitespaceRegion.make ~range ~newlines:1 () in
+              Layout.Whitespace(region, layout)
+            else layout
+          in
+          makeList ~inline:(true, true) ~break:Always [
+            self#attribute attr;
+            layout
+          ]
+        in aux x.loc newLayout xs
+      | [] -> layout
+    in
+    aux loc layout (List.rev docAttrs)
+
+  method binding prefixText x = (* TODO: print attributes *)
+    let body = match x.pvb_pat.ppat_desc with
+      | (Ppat_var _) ->
+        self#wrappedBinding prefixText ~arrow:"=>"
+          (source_map ~loc:x.pvb_pat.ppat_loc (self#simple_pattern x.pvb_pat))
+          [] x.pvb_expr
+      (*
+         Ppat_constraint is used in bindings of the form
+
+            let (inParenVar:typ) = ...
+
+         And in the case of let bindings for explicitly polymorphic type
+         annotations (see parser for more details).
+
+         See reason_parser.mly for explanation of how we encode the two primary
+         forms of explicit polymorphic annotations in the parse tree, and how
+         we must recover them here.
+       *)
+      | (Ppat_constraint(p, ty)) -> (
+          (* Locally abstract forall types are *seriously* mangled by the parsing
+             stage, and we have to be very smart about how to recover it.
+
+              let df_locallyAbstractFuncAnnotated:
+                type a b.
+                  a =>
+                  b =>
+                  (inputEchoRecord a, inputEchoRecord b) =
+                fun (input: a) (input2: b) => (
+                  {inputIs: input},
+                  {inputIs: input2}
+                );
+
+             becomes:
+
+               let df_locallyAbstractFuncAnnotatedTwo:
+                 'a 'b .
+                 'a => 'b => (inputEchoRecord 'a, inputEchoRecord 'b)
+                =
+                 fun (type a) (type b) => (
+                   fun (input: a) (input2: b) => ({inputIs: input}, {inputIs:input2}):
+                     a => b => (inputEchoRecord a, inputEchoRecord b)
+                 );
+          *)
+          let layoutPattern =
+            source_map ~loc:x.pvb_pat.ppat_loc (self#simple_pattern p)
+          in
+          let leadingAbsTypesAndExpr = self#leadingCurriedAbstractTypes x.pvb_expr in
+          match (p.ppat_desc, ty.ptyp_desc, leadingAbsTypesAndExpr) with
+            | (Ppat_var _,
+               Ptyp_poly (typeVars, varifiedPolyType),
+               (_::_ as absVars, Pexp_constraint(funWithNewTypes, nonVarifiedExprType)))
+              when self#isRenderableAsPolymorphicAbstractTypes
+                  typeVars
+                  (* If even artificially varified - don't know until returns*)
+                  varifiedPolyType
+                  absVars
+                  nonVarifiedExprType ->
+              (*
+                 We assume was the case whenever we see this pattern in the
+                 AST, it was because the parser parsed the polymorphic locally
+                 abstract type sugar.
+
+                 Ppat_var..Ptyp_poly...Pexp_constraint:
+
+                    let x: 'a 'b . 'a => 'b => 'b =
+                      fun (type a) (type b) =>
+                         (fun aVal bVal => bVal : a => b => b);
+
+                 We need to be careful not to accidentally detect similar
+                 forms, that cannot be printed as sugar.
+
+                    let x: 'a 'b . 'a => 'b => 'b =
+                      fun (type a) (type b) =>
+                         (fun aVal bVal => bVal : int => int => int);
+
+                 Should *NOT* be formatted as:
+
+                    let x: type a b. int => int => int = fun aVal bVal => bVal;
+
+                 The helper function
+                 [same_ast_modulo_varification_and_extensions] was created to
+                 help compare the varified constraint pattern body, and the
+                 non-varified expression constraint type.
+
+                 The second requirement that we check before assuming that the
+                 sugar form is correct, is to make sure the list of type vars
+                 corresponds to a leading prefix of the Pexp_newtype variables.
+              *)
+              self#locallyAbstractPolymorphicFunctionBinding
+                prefixText
+                layoutPattern
+                funWithNewTypes
+                absVars
+                nonVarifiedExprType
+            | _ ->
+              let typeLayout = source_map ~loc:ty.ptyp_loc (self#core_type ty) in
+              let appTerms = self#unparseExprApplicationItems x.pvb_expr in
+              self#formatSimplePatternBinding
+                prefixText
+                layoutPattern
+                (Some typeLayout)
+                appTerms
+        )
+      | _ ->
+        let layoutPattern =
+          source_map ~loc:x.pvb_pat.ppat_loc (self#pattern x.pvb_pat)
+        in
+        let appTerms = self#unparseExprApplicationItems x.pvb_expr in
+        self#formatSimplePatternBinding prefixText layoutPattern None appTerms
+    in
+    let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true x.pvb_attributes in
+
+    let body = makeList ~inline:(true, true) [body] in
+    let layout = self#attach_std_item_attrs stdAttrs (source_map ~loc:x.pvb_loc body) in
+    self#attachDocAttrsToLayout
+      ~stdAttrs
+      ~docAttrs
+      ~loc:x.pvb_pat.ppat_loc
+      ~layout
+      ()
+
+  (* Ensures that the constraint is formatted properly for sake of function
+     binding (formatted without arrows)
+     let x y z : no_unguarded_arrows_allowed_here => ret;
+   *)
+  method normalizeFunctionArgsConstraint argsList return =
+    match return.pexp_desc with
+      | Pexp_constraint (e, ct) ->
+        let typeLayout =
+          source_map ~loc:ct.ptyp_loc
+            (self#non_arrowed_non_simple_core_type ct)
+        in
+        ([makeList
+           ~break:IfNeed
+           ~inline:(true, true)
+           (argsList@[formatJustTheTypeConstraint typeLayout])], e)
+      | _ -> (argsList, return)
+
+  method normalizeConstructorArgsConstraint argsList return =
+    match return.pcl_desc with
+      | Pcl_constraint (e, ct) when return.pcl_attributes == [] ->
+        let typeLayout =
+          source_map ~loc:ct.pcty_loc
+            (self#non_arrowed_class_constructor_type ct)
+        in
+        (argsList@[formatJustTheTypeConstraint typeLayout], e)
+      | _ -> (argsList, return)
+
+  method bindingsLocationRange ?extension l =
+    let len = List.length l in
+    let fstLoc = match extension with
+    | Some ({pexp_loc = {loc_ghost = false}} as ext) -> ext.pexp_loc
+    | _ -> (List.nth l 0).pvb_loc
+    in
+    let lstLoc = (List.nth l (len - 1)).pvb_loc in
+    {
+      loc_start = fstLoc.loc_start;
+      loc_end = lstLoc.loc_end;
+      loc_ghost = false
+    }
+
+  method bindings ?extension (rf, l) =
+    let label = add_extension_sugar "let" extension in
+    let label = match rf with
+      | Nonrecursive -> label
+      | Recursive -> label ^ " rec"
+    in
+    match l with
+    | [x] -> self#binding label x
+    | l ->
+      let items = List.mapi (fun i x ->
+        let loc = extractLocValBinding x in
+        let layout = self#binding (if i == 0 then label else "and") x in
+        (loc, layout)
+      ) l
+      in
+      let itemsLayout = groupAndPrint
+        ~xf:(fun (_, layout) -> layout)
+        ~getLoc:(fun (loc, _) -> loc)
+        ~comments:self#comments
+        items
+      in
+      makeList
+        ~postSpace:true
+        ~break:Always
+        ~indent:0
+        ~inline:(true, true)
+        itemsLayout
+
+  method letList expr =
+    (* Recursively transform a nested ast of "let-items", into a flat
+     * list containing the location indicating start/end of the "let-item" and
+     * its layout. *)
+    let rec processLetList acc expr =
+      let {stdAttrs; arityAttrs; jsxAttrs} = partitionAttributes ~allowUncurry:false expr.pexp_attributes in
+      match (stdAttrs, expr.pexp_desc) with
+        | ([], Pexp_let (rf, l, e)) ->
+          (* For "letList" bindings, the start/end isn't as simple as with
+           * module value bindings. For "let lists", the sequences were formed
+           * within braces {}. The parser relocates the first let binding to the
+           * first brace. *)
+           let bindingsLayout = self#bindings (rf, l) in
+           let bindingsLoc = self#bindingsLocationRange l in
+           let layout = source_map ~loc:bindingsLoc bindingsLayout in
+           processLetList ((bindingsLoc, layout)::acc) e
+        | (attrs, Pexp_open (ovf, lid, e))
+            (* Add this when check to make sure these are handled as regular "simple expressions" *)
+            when not (self#isSeriesOfOpensFollowedByNonSequencyExpression {expr with pexp_attributes = []}) ->
+          let overrideStr = match ovf with | Override -> "!" | Fresh -> "" in
+          let openLayout = label ~space:true
+            (atom ("open" ^ overrideStr))
+            (self#longident_loc lid)
+          in
+          let attrsOnOpen =
+            makeList ~inline:(true, true) ~postSpace:true ~break:Always
+            ((self#attributes attrs)@[openLayout])
+          in
+          (* Just like the bindings, have to synthesize a location since the
+           * Pexp location is parsed (potentially) beginning with the open
+           * brace {} in the let sequence. *)
+          let layout = source_map ~loc:lid.loc attrsOnOpen in
+          let loc = {
+            lid.loc with
+            loc_start = {
+              lid.loc.loc_start with
+              pos_lnum = expr.pexp_loc.loc_start.pos_lnum
+            }
+          } in
+          processLetList ((loc, layout)::acc) e
+        | ([], Pexp_letmodule (s, me, e)) ->
+            let prefixText = "contract" in
+            let bindingName = atom ~loc:s.loc s.txt in
+            let moduleExpr = me in
+            let letModuleLayout =
+              (self#let_module_binding prefixText bindingName moduleExpr) in
+            let letModuleLoc = {
+              loc_start = s.loc.loc_start;
+              loc_end = me.pmod_loc.loc_end;
+              loc_ghost = false
+            } in
+            (* Just like the bindings, have to synthesize a location since the
+             * Pexp location is parsed (potentially) beginning with the open
+             * brace {} in the let sequence. *)
+          let layout = source_map ~loc:letModuleLoc letModuleLayout in
+        let (_, return) = self#curriedFunctorPatternsAndReturnStruct moduleExpr in
+          let loc = {
+            letModuleLoc with
+            loc_end = return.pmod_loc.loc_end
+          } in
+           processLetList ((loc, layout)::acc) e
+        | ([], Pexp_letexception (extensionConstructor, expr)) ->
+            let exc = self#exception_declaration extensionConstructor in
+            let layout = source_map ~loc:extensionConstructor.pext_loc exc in
+            processLetList ((extensionConstructor.pext_loc, layout)::acc) expr
+        | ([], Pexp_sequence (({pexp_desc=Pexp_sequence _ }) as e1, e2))
+        | ([], Pexp_sequence (({pexp_desc=Pexp_let _      }) as e1, e2))
+        | ([], Pexp_sequence (({pexp_desc=Pexp_open _     }) as e1, e2))
+        | ([], Pexp_sequence (({pexp_desc=Pexp_letmodule _}) as e1, e2))
+        | ([], Pexp_sequence (e1, e2)) ->
+            let e1Layout = match expression_not_immediate_extension_sugar e1 with
+              | Some (extension, e) ->
+                    self#attach_std_item_attrs ~extension []
+                      (self#unparseExpr e)
+              | None ->
+                  self#unparseExpr e1
+            in
+            let loc = e1.pexp_loc in
+            let layout = source_map ~loc e1Layout in
+            processLetList ((loc, layout)::acc) e2
+        | _ ->
+          let expr = { expr with pexp_attributes = (arityAttrs @ stdAttrs @ jsxAttrs) }
+          in
+          match expression_not_immediate_extension_sugar expr with
+          | Some (extension, {pexp_attributes = []; pexp_desc = Pexp_let (rf, l, e)}) ->
+            let bindingsLayout = self#bindings ~extension (rf, l) in
+            let bindingsLoc = self#bindingsLocationRange ~extension:expr l in
+            let layout = source_map ~loc:bindingsLoc bindingsLayout in
+            processLetList ((extractLocationFromValBindList expr l, layout)::acc) e
+          | Some (extension, e) ->
+            let layout = self#attach_std_item_attrs ~extension [] (self#unparseExpr e) in
+            (expr.pexp_loc, layout)::acc
+          | None ->
+            (* Should really do something to prevent infinite loops here. Never
+               allowing a top level call into letList to recurse back to
+               self#unparseExpr- top level calls into letList *must* be one of the
+               special forms above whereas lower level recursive calls may be of
+               any form. *)
+            let layout = source_map ~loc:expr.pexp_loc (self#unparseExpr expr) in
+            (expr.pexp_loc, layout)::acc
+    in
+    let es = processLetList [] expr in
+    (* Interleave whitespace between the "let-items" when appropriate *)
+    groupAndPrint
+      ~xf:(fun (_, layout) -> layout)
+      ~getLoc:(fun (loc, _) -> loc)
+      ~comments:self#comments
+      (List.rev es)
+
+  method constructor_expression ?(polyVariant=false) ~arityIsClear stdAttrs ctor eo =
+    let (implicit_arity, arguments) =
+      match eo.pexp_desc with
+      | Pexp_construct ( {txt= Lident "()"},_) ->
+        (* `foo() is a polymorphic variant that contains a single unit construct as expression
+         * This requires special formatting: `foo(()) -> `foo() *)
+        (false, atom "()")
+      (* special printing: MyConstructor(()) -> MyConstructor() *)
+      | Pexp_tuple l when is_single_unit_construct l ->
+          (false, atom "()")
+      | Pexp_tuple l when polyVariant == true ->
+          (false, self#unparseSequence ~wrap:("(", ")") ~construct:`Tuple l)
+      | Pexp_tuple l ->
+        (* There is no ambiguity when the number of tuple components is 1.
+             We don't need put implicit_arity in that case *)
+        (match l with
+        | exprList when isSingleArgParenApplication exprList ->
+            (false, self#singleArgParenApplication exprList)
+        | _ ->
+            (not arityIsClear, makeTup (List.map self#unparseProtectedExpr l)))
+      | _ when isSingleArgParenApplication [eo] ->
+          (false, self#singleArgParenApplication [eo])
+      | _ ->
+          (false, makeTup [self#unparseProtectedExpr eo])
+    in
+    let arguments = source_map ~loc:eo.pexp_loc arguments in
+    let construction =
+      label ctor (if isSequencey arguments
+                  then arguments
+                  else (ensureSingleTokenSticksToLabel arguments))
+    in
+    let attrs =
+      if implicit_arity && (not polyVariant) then
+        ({txt="implicit_arity"; loc=eo.pexp_loc}, PStr []) :: stdAttrs
+      else
+        stdAttrs
+    in
+    match attrs with
+      | [] -> construction
+      | _::_ -> formatAttributed construction (self#attributes attrs)
+
+  (* TODOATTRIBUTES: Handle stdAttrs here (merge with implicit_arity) *)
+  method constructor_pattern ?(polyVariant=false) ~arityIsClear ctor po =
+    let (implicit_arity, arguments) =
+      match po.ppat_desc with
+      (* There is no ambiguity when the number of tuple components is 1.
+           We don't need put implicit_arity in that case *)
+      | Ppat_tuple (([] | _::[]) as l) ->
+        (false, l)
+      | Ppat_tuple l ->
+        (not arityIsClear, l)
+
+      | _ -> (false, [po])
+    in
+    let space, arguments = match arguments with
+      | [x] when is_direct_pattern x -> (true, self#simple_pattern x)
+      | xs when isSingleArgParenPattern xs -> (false, self#singleArgParenPattern xs)
+      (* Optimize the case when it's a variant holding a shot variable - avoid trailing*)
+      | [{ppat_desc=Ppat_constant (Pconst_string (s, None))} as x]
+      | [{ppat_desc=Ppat_construct (({txt=Lident s}), None)} as x]
+      | [{ppat_desc=Ppat_var ({txt = s})} as x]
+        when Reason_heuristics.singleTokenPatternOmmitTrail s ->
+        let layout = makeTup ~trailComma:false [self#pattern x] in
+        (false, source_map ~loc:po.ppat_loc layout)
+      | [{ppat_desc=Ppat_any} as x]
+      | [{ppat_desc=Ppat_constant (Pconst_char _)} as x]
+      | [{ppat_desc=Ppat_constant (Pconst_integer _)} as x] ->
+        let layout = makeTup ~trailComma:false [self#pattern x] in
+        (false, source_map ~loc:po.ppat_loc layout)
+      | xs ->
+        let layout = makeTup (List.map self#pattern xs) in
+        (false, source_map ~loc:po.ppat_loc layout)
+    in
+    let construction = label ~space ctor arguments in
+    if implicit_arity && (not polyVariant) then
+      formatAttributed construction
+        (self#attributes [({txt="implicit_arity"; loc=po.ppat_loc}, PStr [])])
+    else
+      construction
+
+  (*
+   * Provides special printing for constructor arguments:
+   * iff there's one argument & they have some kind of wrapping,
+   * they're wrapping need to 'hug' the surrounding parens.
+   * Example:
+   *  switch x {
+   *  | Some({
+   *      a,
+   *      b,
+   *    }) => ()
+   *  }
+   *
+   *  Notice how ({ and }) hug.
+   *  This applies for records, arrays, tuples & lists.
+   *  Also see `isSingleArgParenPattern` to determine if this kind of wrapping applies.
+   *)
+  method singleArgParenPattern = function
+    | [{ppat_desc = Ppat_record (l, closed); ppat_loc = loc}] ->
+      source_map ~loc (self#patternRecord ~wrap:("(", ")") l closed)
+    | [{ppat_desc = Ppat_array l; ppat_loc = loc}] ->
+      source_map ~loc (self#patternArray ~wrap:("(", ")") l)
+    | [{ppat_desc = Ppat_tuple l; ppat_loc = loc}] ->
+      source_map ~loc (self#patternTuple ~wrap:("(", ")") l)
+    | [{ppat_desc = Ppat_construct (({txt=Lident "::"}), _); ppat_loc} as listPattern]  ->
+      source_map ~loc:ppat_loc (self#patternList ~wrap:("(", ")")  listPattern)
+    | _ -> assert false
+
+  method patternArray ?(wrap=("","")) l =
+    let (left, right) = wrap in
+    let wrap = (left ^ "[|", "|]" ^ right) in
+    makeList ~wrap ~break:IfNeed ~postSpace:true ~sep:commaTrail (List.map self#pattern l)
+
+  method patternTuple ?(wrap=("","")) l =
+    let (left, right) = wrap in
+    let wrap = (left ^ "(", ")" ^ right) in
+    makeList ~wrap ~sep:commaTrail ~postSpace:true ~break:IfNeed (List.map self#constrained_pattern l)
+
+  method patternRecord ?(wrap=("","")) l closed =
+    let longident_x_pattern (li, p) =
+      match (li, p.ppat_desc) with
+        | ({txt = ident}, Ppat_var {txt}) when Longident.last ident = txt ->
+          (* record field punning when destructuring. {x: x, y: y} becomes {x, y} *)
+          (* works with module prefix too: {MyModule.x: x, y: y} becomes {MyModule.x, y} *)
+            self#longident_loc li
+        | ({txt = ident},
+           Ppat_alias ({ppat_desc = (Ppat_var {txt = ident2}) }, {txt = aliasIdent}))
+           when Longident.last ident = ident2 ->
+          (* record field punning when destructuring with renaming. {state: state as prevState} becomes {state as prevState *)
+          (* works with module prefix too: {ReasonReact.state: state as prevState} becomes {ReasonReact.state as prevState *)
+            makeList ~sep:(Sep " ") [self#longident_loc li; atom "as"; atom aliasIdent]
+        | _ ->
+            label ~space:true (makeList [self#longident_loc li; atom ":"]) (self#pattern p)
+    in
+    let rows = (List.map longident_x_pattern l)@(
+      match closed with
+        | Closed -> []
+        | _ -> [atom "_"]
+    ) in
+    let (left, right) = wrap in
+    let wrap = (left ^ "{", "}" ^ right) in
+    makeList
+      ~wrap
+      ~break:IfNeed
+      ~sep:commaTrail
+      ~postSpace:true
+      rows
+
+  method patternFunction ?extension loc l =
+    let estimatedFunLocation = {
+        loc_start = loc.loc_start;
+        loc_end = {loc.loc_start with pos_cnum = loc.loc_start.Lexing.pos_cnum + 3};
+        loc_ghost = false;
+    } in
+    makeList
+      ~postSpace:true
+      ~break:IfNeed
+      ~inline:(true, true)
+      ~pad:(false, false)
+      ((atom ~loc:estimatedFunLocation (add_extension_sugar funToken extension)) :: (self#case_list l))
+
+  method parenthesized_expr ?break expr =
+    let result = self#unparseExpr expr in
+    match expr.pexp_attributes, expr.pexp_desc with
+    | [], (Pexp_tuple _ | Pexp_construct ({txt=Lident "()"}, None)) -> result
+    | _ -> makeList ~wrap:("(",")") ?break [self#unparseExpr expr]
+
+  (* Expressions requiring parens, in most contexts such as separated by infix *)
+  method expression_requiring_parens_in_infix x =
+    let {stdAttrs} = partitionAttributes x.pexp_attributes in
+    assert (stdAttrs == []);
+    (* keep the incoming expression around, an expr with
+     * immediate extension sugar might contain less than perfect location
+     * info in its children (used for comment interleaving), the expression passed to
+     * 'expression_requiring_parens_in_infix' contains the correct location *)
+    let originalExpr = x in
+    let extension, x = expression_immediate_extension_sugar x in
+    match x.pexp_desc with
+      (* The only reason Pexp_fun must also be wrapped in parens when under
+         pipe, is that its => token will be confused with the match token.
+         Simple expression will also invoke `#reset`. *)
+      | Pexp_function _ when pipe || semi -> None (* Would be rendered as simplest_expression  *)
+      (* Pexp_function, on the other hand, doesn't need wrapping in parens in
+         most cases anymore, since `fun` is not ambiguous anymore (we print Pexp_fun
+         as ES6 functions). *)
+      | Pexp_function l ->
+        let prec = Custom funToken in
+        let expr = self#patternFunction ?extension x.pexp_loc l in
+        Some (SpecificInfixPrecedence
+                ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode expr))
+      | _ ->
+        (* The Pexp_function cases above don't use location because comment printing
+          breaks for them. *)
+        let itm = match x.pexp_desc with
+          | Pexp_fun _
+          | Pexp_newtype _ ->
+            (* let uncurried =  *)
+            let (args, ret) = self#curriedPatternsAndReturnVal x in
+            (match args with
+              | [] -> raise (NotPossible ("no arrow args in unparse "))
+              | firstArg::tl ->
+                (* Suboptimal printing of parens:
+
+                      something >>= fun x => x + 1;
+
+                   Will be printed as:
+
+                      something >>= (fun x => x + 1);
+
+                   Because the arrow has lower precedence than >>=, but it wasn't
+                   needed because
+
+                      (something >>= fun x) => x + 1;
+
+                   Is not a valid parse. Parens around the `=>` weren't needed to
+                   prevent reducing instead of shifting. To optimize this part, we need
+                   a much deeper encoding of the parse rules to print parens only when
+                   needed, testing which rules will be reduced. It really should be
+                   integrated deeply with Menhir.
+
+                   One question is, if it's this difficult to describe when parens are
+                   needed, should we even print them with the minimum amount?  We can
+                   instead model everything as "infix" with ranked precedences.  *)
+                let retValUnparsed = self#unparseExprApplicationItems ret in
+                Some (self#wrapCurriedFunctionBinding
+                        ~sweet:(extension = None)
+                        (add_extension_sugar funToken extension)
+                        ~arrow:"=>" firstArg tl retValUnparsed)
+            )
+          | Pexp_try (e, l) ->
+            let estimatedBracePoint = {
+              loc_start = e.pexp_loc.loc_end;
+              loc_end = x.pexp_loc.loc_end;
+              loc_ghost = false;
+            }
+            in
+            let cases = (self#case_list ~allowUnguardedSequenceBodies:true l) in
+            let switchWith = label ~space:true
+                (atom (add_extension_sugar "try" extension))
+                (self#parenthesized_expr ~break:IfNeed e)
+            in
+            Some (
+              label
+                ~space:true
+                switchWith
+                (source_map ~loc:estimatedBracePoint
+                   (makeList ~indent:settings.trySwitchIndent ~wrap:("{", "}")
+                      ~break:Always_rec ~postSpace:true cases))
+            )
+          (* These should have already been handled and we should never havgotten this far. *)
+          | Pexp_setinstvar _ -> raise (Invalid_argument "Cannot handle setinstvar here - call unparseExpr")
+          | Pexp_setfield (_, _, _) -> raise (Invalid_argument "Cannot handle setfield here - call unparseExpr")
+          | Pexp_apply _ -> raise (Invalid_argument "Cannot handle apply here - call unparseExpr")
+          | Pexp_match (e, l) ->
+             let estimatedBracePoint = {
+               loc_start = e.pexp_loc.loc_end;
+               (* See originalExpr binding, for more info.
+                * It contains the correct location under immediate extension sugar *)
+               loc_end = originalExpr.pexp_loc.loc_end;
+               loc_ghost = false;
+             }
+             in
+             let cases = (self#case_list ~allowUnguardedSequenceBodies:true l) in
+             let switchWith =
+               label ~space:true (atom (add_extension_sugar "switch" extension))
+                 (self#parenthesized_expr ~break:IfNeed e)
+             in
+             let lbl =
+               label
+                 ~space:true
+                 switchWith
+                 (source_map ~loc:estimatedBracePoint
+                    (makeList ~indent:settings.trySwitchIndent ~wrap:("{", "}")
+                       ~break:Always_rec ~postSpace:true cases))
+             in
+             Some lbl
+          | Pexp_ifthenelse (e1, e2, eo) ->
+            let (blocks, finalExpression) = sequentialIfBlocks eo in
+            let rec singleExpression exp =
+              match exp.pexp_desc with
+              | Pexp_ident _ -> true
+              | Pexp_constant _ -> true
+              | Pexp_construct (_, arg) ->
+                (match arg with
+                | None -> true
+                | Some x -> singleExpression x)
+              | _ -> false
+            in
+            let singleLineIf =
+              (singleExpression e1) &&
+              (singleExpression e2) &&
+              (match eo with
+               | Some expr -> singleExpression expr
+               | None -> true
+              )
+            in
+            let makeLetSequence =
+              if singleLineIf then
+                makeLetSequenceSingleLine
+              else
+                makeLetSequence
+            in
+            let rec sequence soFar remaining = (
+              match (remaining, finalExpression) with
+                | ([], None) -> soFar
+                | ([], Some e) ->
+                  let soFarWithElseAppended = makeList ~postSpace:true [soFar; atom "else"] in
+                  label ~space:true soFarWithElseAppended
+                    (source_map ~loc:e.pexp_loc (makeLetSequence (self#letList e)))
+                | (hd::tl, _) ->
+                  let (e1, e2) = hd in
+                  let soFarWithElseIfAppended =
+                    label
+                      ~space:true
+                      (makeList ~postSpace:true [soFar; atom "else if"])
+                      (makeList ~wrap:("(",")") [self#unparseExpr e1])
+                  in
+                  let nextSoFar =
+                    label ~space:true soFarWithElseIfAppended
+                      (source_map ~loc:e2.pexp_loc (makeLetSequence (self#letList e2)))
+                  in
+                  sequence nextSoFar tl
+            ) in
+            let init =
+              let if_ = atom (add_extension_sugar "if" extension) in
+              let cond = self#parenthesized_expr e1 in
+              label ~space:true
+                (source_map ~loc:e1.pexp_loc (label ~space:true if_ cond))
+                (source_map ~loc:e2.pexp_loc (makeLetSequence (self#letList e2)))
+            in
+            Some (sequence init blocks)
+          | Pexp_while (e1, e2) ->
+            let lbl =
+              let while_ = atom (add_extension_sugar "while" extension) in
+              let cond = self#parenthesized_expr e1 in
+              label ~space:true
+                (label ~space:true while_ cond)
+                (source_map ~loc:e2.pexp_loc (makeLetSequence (self#letList e2)))
+            in
+            Some lbl
+          | Pexp_for (s, e1, e2, df, e3) ->
+            (*
+             *  for longIdentifier in
+             *      (longInit expr) to
+             *      (longEnd expr) {
+             *    print_int longIdentifier;
+             *  };
+             *)
+            let identifierIn = (makeList ~postSpace:true [self#pattern s; atom "in";]) in
+            let dockedToFor = makeList
+                ~break:IfNeed
+                ~postSpace:true
+                ~inline:(true, true)
+                ~wrap:("(",")")
+                [
+                  identifierIn;
+                  makeList ~postSpace:true [self#unparseExpr e1; self#direction_flag df];
+                  (self#unparseExpr e2);
+                ]
+            in
+            let upToBody = makeList ~inline:(true, true) ~postSpace:true
+                [atom (add_extension_sugar "for" extension); dockedToFor]
+            in
+            Some (label ~space:true upToBody
+                    (source_map ~loc:e3.pexp_loc (makeLetSequence (self#letList e3))))
+          | Pexp_new li ->
+            Some (label ~space:true (atom "new") (self#longident_class_or_type_loc li))
+          | Pexp_assert e ->
+            Some (
+              label
+                (atom "assert")
+                (makeTup [(self#unparseExpr e)]);
+            )
+          | Pexp_lazy e ->
+              Some (label ~space:true (atom "lazy") (self#simplifyUnparseExpr e))
+          | Pexp_poly _ ->
+            failwith (
+              "This version of the pretty printer assumes it is impossible to " ^
+              "construct a Pexp_poly outside of a method definition - yet it sees one."
+            )
+          | _ -> None
+        in
+        match itm with
+          | None -> None
+          | Some i -> Some (PotentiallyLowPrecedence (source_map ~loc:x.pexp_loc i))
+
+  method potentiallyConstrainedExpr x =
+    match x.pexp_desc with
+      | Pexp_constraint (e, ct) ->
+          formatTypeConstraint (self#unparseExpr e) (self#core_type ct)
+      | _ -> self#unparseExpr x
+
+
+  (*
+   * Because the rule BANG simple_expr was given %prec below_DOT_AND_SHARP,
+   * !x.y.z will parse as !(x.y.z) and not (!x).y.z.
+   *
+   *     !x.y.z == !((x.y).z)
+   *     !x#y#z == !((x#y)#z)
+   *
+   * So the intuition is: In general, any simple expression can exist to the
+   * left of a `.`, except `BANG simple_expr`, which has special precedence,
+   * and must be guarded in this one case.
+   *
+   * TODO: Instead of special casing this here, we should continue to extend
+   * unparseExpr to also unparse simple expressions, (by encoding the
+   * rules precedence below_DOT_AND_SHARP).
+   *
+   * TODO:
+   *  Some would even have the prefix application be parsed with lower
+   *  precedence function *application*. In the case of !, where ! means not,
+   *  it makes a lot of sense because (!identifier)(arg) would be meaningless.
+   *
+   *  !callTheFunction(1, 2, 3)(andEvenCurriedArgs)
+   *
+   * Only problem is that it could then not appear anywhere simple expressions
+   * would appear.
+   *
+   * We could make a special case for ! followed by one simple expression, and
+   * consider the result simple.
+   *
+   * Alternatively, we can figure out a way to not require simple expressions
+   * in the most common locations such as if/while tests. This is really hard
+   * (impossible w/ grammars Menhir supports?)
+   *
+   * if ! myFunc argOne argTwo {
+   *
+   * } else {
+   *
+   * };
+   *
+   *)
+  method simple_enough_to_be_lhs_dot_send x =
+    match x.pexp_desc with
+    | (Pexp_apply (eFun, _)) -> (
+        match printedStringAndFixityExpr eFun with
+        | AlmostSimplePrefix _
+        | UnaryPlusPrefix _
+        | UnaryMinusPrefix _
+        | UnaryNotPrefix _
+        | UnaryPostfix _
+        | Infix _ -> self#simplifyUnparseExpr x
+        | Normal ->
+          if x.pexp_attributes == [] then
+            (* `let a = foo().bar` instead of `let a = (foo()).bar *)
+            (* same for foo()##bar, foo()#=bar, etc. *)
+            self#unparseExpr x
+          else
+            self#simplifyUnparseExpr x
+      )
+    | _ -> self#simplifyUnparseExpr x
+
+  method unparseRecord
+    ?wrap:((lwrap, rwrap)=("", ""))
+    ?withStringKeys:(withStringKeys=false)
+    ?allowPunning:(allowPunning=true)
+    ?forceBreak:(forceBreak=false)
+    l eo =
+    (* forceBreak is a ref which can be set to always break the record rows.
+     * Example, when we have a row which contains a nested record,
+     * this ref can be set to true from inside the printing of that row,
+     * which forces breaks for the outer record structure. *)
+    let forceBreak = ref forceBreak in
+    let quote = (atom "\"") in
+    let maybeQuoteFirstElem fst rest =
+        if withStringKeys then (match fst.txt with
+          | Lident s -> quote::(atom s)::quote::rest
+          | Ldot _  | Lapply _ -> assert false
+          )
+        else
+          (self#longident_loc fst)::rest
+    in
+    let makeRow (li, e) shouldPun =
+      let totalRowLoc = {
+        loc_start = li.Asttypes.loc.loc_start;
+        loc_end = e.pexp_loc.loc_end;
+        loc_ghost = false;
+      } in
+      let theRow = match (e.pexp_desc, shouldPun, allowPunning) with
+        (* record value punning. Turns {foo: foo, bar: 1} into {foo, bar: 1} *)
+        (* also turns {Foo.bar: bar, baz: 1} into {Foo.bar, baz: 1} *)
+        (* don't turn {bar: Foo.bar, baz: 1} into {bar, baz: 1}, naturally *)
+        | (Pexp_ident {txt = Lident value}, true, true) when Longident.last li.txt = value ->
+          makeList (maybeQuoteFirstElem li [])
+
+          (* Force breaks for nested records or bs obj sugar
+           * Example:
+           *  let person = {name: {first: "Bob", last: "Zhmith"}, age: 32};
+           * is a lot less readable than
+           *  let person = {
+           *   "name": {
+           *     "first": "Bob",
+           *     "last": "Zhmith"
+           *   },
+           *  "age": 32
+           *  };
+           *)
+        | (Pexp_record (recordRows, optionalGadt), _, _) ->
+            forceBreak := true;
+            let keyWithColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
+            let value = self#unparseRecord ~forceBreak: true recordRows optionalGadt in
+            label ~space:true keyWithColon value
+        | (Pexp_extension (s, p), _, _) when s.txt = "bs.obj" ->
+            forceBreak := true;
+            let keyWithColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
+            let value = self#formatBsObjExtensionSugar ~forceBreak:true p in
+            label ~space:true keyWithColon value
+        | (Pexp_object classStructure, _, _) ->
+            forceBreak := true;
+            let keyWithColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
+            let value = self#classStructure ~forceBreak:true classStructure in
+            label ~space:true keyWithColon value
+        | _ ->
+          let (argsList, return) = self#curriedPatternsAndReturnVal e in
+          match argsList with
+          | [] ->
+            let appTerms = self#unparseExprApplicationItems e in
+            let upToColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
+            formatAttachmentApplication applicationFinalWrapping (Some (true, upToColon)) appTerms
+          | firstArg :: tl ->
+            let upToColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
+            let returnedAppTerms = self#unparseExprApplicationItems return in
+            self#wrapCurriedFunctionBinding
+              ~sweet:true ~attachTo:upToColon funToken ~arrow:"=>"
+              firstArg tl returnedAppTerms
+      in (source_map ~loc:totalRowLoc theRow, totalRowLoc)
+    in
+    let rec getRows l =
+      match l with
+        | [] -> []
+        | hd::[] -> [makeRow hd true]
+        | hd::hd2::tl -> (makeRow hd true)::(getRows (hd2::tl))
+    in
+
+    let allRows = match eo with
+      | None -> (
+        match l with
+          (* No punning (or comma) for records with only a single field. It's ambiguous with an expression in a scope *)
+          (* See comment in parser.mly for lbl_expr_list_with_at_least_one_non_punned_field *)
+          | [hd] -> [makeRow hd false]
+          | _ -> getRows l
+        )
+      (* This case represents a "spread" being present -> {...x, a: 1, b: 2} *)
+      | Some withRecord ->
+        let firstRow =
+          let row = (
+            (* Unclear why "sugar_expr" was special cased hre. *)
+            let appTerms = self#unparseExprApplicationItems withRecord in
+            formatAttachmentApplication applicationFinalWrapping (Some (false, (atom "..."))) appTerms
+          )
+          in (
+            source_map ~loc:withRecord.pexp_loc row,
+            withRecord.pexp_loc
+          )
+        in
+        firstRow::(getRows l)
+    in
+    makeList
+      ~wrap:(lwrap ^ "{" ,"}" ^ rwrap)
+      ~break:(if !forceBreak then Layout.Always else Layout.IfNeed)
+      ~sep:commaTrail
+      ~postSpace:true
+      (groupAndPrint ~xf:fst ~getLoc:snd ~comments:self#comments allRows)
+
+  method isSeriesOfOpensFollowedByNonSequencyExpression expr =
+    match (expr.pexp_attributes, expr.pexp_desc) with
+        | ([], Pexp_let _) -> false
+        | ([], Pexp_sequence _) -> false
+        | ([], Pexp_letmodule _) -> false
+        | ([], Pexp_open (ovf, _, e)) ->
+          ovf == Fresh && self#isSeriesOfOpensFollowedByNonSequencyExpression e
+        | ([], Pexp_letexception _) -> false
+        | ([], Pexp_extension ({txt}, _)) -> txt = "bs.obj"
+        | _ -> true
+
+  method unparseObject ?wrap:((lwrap,rwrap)=("", "")) ?(withStringKeys=false) l o =
+    let core_field_type (s, attrs, ct) =
+      let l = extractStdAttrs attrs in
+      let row =
+         let rowKey = if withStringKeys then
+            (makeList ~wrap:("\"", "\"") [atom s])
+          else (atom s)
+          in
+          label ~space:true
+                (makeList ~break:Layout.Never [rowKey; (atom ":")])
+                (self#core_type ct)
+      in
+      (match l with
+       | [] -> row
+       | _::_ ->
+         makeList
+           ~postSpace:true
+           ~break:IfNeed
+           ~inline:(true, true)
+           (List.concat [self#attributes attrs; [row]]))
+    in
+    let rows = List.map core_field_type l in
+    let openness = match o with
+      | Closed -> atom "."
+      | Open -> atom ".."
+    in
+    (* if an object has more than 2 rows, always break for readability *)
+    let rows_layout = makeList
+        ~inline:(true, true) ~postSpace:true ~sep:commaTrail rows
+        ~break:(if List.length rows >= 2
+                then Layout.Always_rec
+                else Layout.IfNeed)
+    in
+    makeList
+      ~break:Layout.IfNeed
+      ~preSpace:(rows != [])
+      ~wrap:(lwrap ^ "{", "}" ^ rwrap)
+      (openness::[rows_layout])
+
+  method unparseSequence ?wrap:(wrap=("", "")) ~construct l =
+    match construct with
+    | `ES6List ->
+      let seq, ext = (match List.rev l with
+        | ext :: seq_rev -> (List.rev seq_rev, ext)
+        | [] -> assert false) in
+      makeES6List ~wrap (List.map self#unparseExpr seq) (self#unparseExpr ext)
+    | _ ->
+      let (left, right) = wrap in
+      let (xf, (leftDelim, rightDelim)) = (match construct with
+        | `List -> (self#unparseExpr, ("[", "]"))
+        | `Array -> (self#unparseExpr, ("[|", "|]"))
+        | `Tuple -> (self#potentiallyConstrainedExpr, ("(", ")"))
+        | `ES6List -> assert false)
+      in
+      let wrap = (left ^ leftDelim, rightDelim ^ right) in
+      makeList
+        ~wrap
+        ~sep:commaTrail
+        ~break:IfNeed
+        ~postSpace:true
+        (List.map xf l)
+
+
+  method formatBsObjExtensionSugar ?wrap:(wrap=("", "")) ?(forceBreak=false) payload =
+    match payload with
+    | PStr [itm] -> (
+      match itm with
+      | {pstr_desc = Pstr_eval ({ pexp_desc = Pexp_record (l, eo) }, []) } ->
+        self#unparseRecord ~forceBreak ~wrap ~withStringKeys:true ~allowPunning:false l eo
+      | {pstr_desc = Pstr_eval ({ pexp_desc = Pexp_extension ({txt = "bs.obj"}, payload) }, []) } ->
+        (* some folks write `[%bs.obj [%bs.obj {foo: bar}]]`. This looks improbable but
+          it happens often if you use the sugared version: `[%bs.obj {"foo": bar}]`.
+          We're gonna be lenient here and treat it as if they wanted to just write
+          `{"foo": bar}`. BuckleScript does the same relaxation when parsing bs.obj
+        *)
+        self#formatBsObjExtensionSugar ~wrap ~forceBreak payload
+      | _ -> raise (Invalid_argument "bs.obj only accepts a record. You've passed something else"))
+    | _ -> assert false
+
+  method should_preserve_requested_braces expr =
+    let {stylisticAttrs} = partitionAttributes expr.pexp_attributes in
+    match expr.pexp_desc with
+    | Pexp_ifthenelse _
+    | Pexp_try _ -> false
+    | _ ->
+        preserve_braces &&
+        Reason_attributes.has_preserve_braces_attrs stylisticAttrs
+
+  method simplest_expression x =
+    let {stdAttrs; jsxAttrs} = partitionAttributes x.pexp_attributes in
+    if stdAttrs != [] then
+      None
+    else if self#should_preserve_requested_braces x then
+      let layout =
+        makeList
+          ~break:(if inline_braces then Always else Always_rec)
+          ~inline:(true, inline_braces)
+          ~wrap:("{", "}")
+          ~postSpace:true
+          ~sep:(if inline_braces then NoSep else (SepFinal (";", ";")))
+          (self#letList x)
+      in
+      Some layout
+    else
+      let item =
+        match x.pexp_desc with
+        (* The only reason Pexp_fun must also be wrapped in parens is that its =>
+           token will be confused with the match token. *)
+        | Pexp_fun _ when pipe || semi -> Some (self#reset#simplifyUnparseExpr x)
+        | Pexp_function l when pipe || semi -> Some (formatPrecedence ~loc:x.pexp_loc (self#reset#patternFunction x.pexp_loc l))
+        | Pexp_apply _ -> (
+          match self#simple_get_application x with
+          (* If it's the simple form of application. *)
+          | Some simpleGet -> Some simpleGet
+          | None -> None
+        )
+        | Pexp_object cs -> Some (self#classStructure cs)
+        | Pexp_override l -> (* FIXME *)
+          let string_x_expression (s, e) =
+            label ~space:true (atom (s.txt ^ ":")) (self#unparseExpr e)
+          in
+          Some (
+            makeList
+              ~postSpace:true
+              ~wrap:("{<", ">}")
+              ~sep:(Sep ",")
+              (List.map string_x_expression l)
+          )
+        | Pexp_construct _  when is_simple_construct (view_expr x) ->
+            let hasJsxAttribute = jsxAttrs != [] in
+            Some (
+              match view_expr x with
+              | `nil -> if hasJsxAttribute then atom "<> </>" else atom "[]"
+              | `tuple -> atom "()"
+              | `list xs -> (* LIST EXPRESSION *)
+                if hasJsxAttribute then
+                  let actualChildren =
+                    match self#formatChildren xs [] with
+                    | None -> []
+                    | Some ch -> ch
+                  in
+                    makeList
+                      ~break:IfNeed
+                      ~inline:(false, false)
+                      ~postSpace:true
+                      ~wrap:("<>", "</>")
+                      ~pad:(true, true)
+                      actualChildren
+                else
+                  self#unparseSequence ~construct:`List xs
+              | `cons xs ->
+                  self#unparseSequence ~construct:`ES6List xs
+              | `simple x -> self#longident x
+              | _ -> assert false
+            )
+        | Pexp_ident li ->
+            (* Lone identifiers shouldn't break when to the right of a label *)
+            Some (ensureSingleTokenSticksToLabel (self#longident_loc li))
+        | Pexp_constant c ->
+            (* Constants shouldn't break when to the right of a label *)
+          let raw_literal, _ = extract_raw_literal x.pexp_attributes in
+            Some (ensureSingleTokenSticksToLabel
+                    (self#constant ?raw_literal c))
+        | Pexp_pack me ->
+          Some (
+            makeList
+              ~break:IfNeed
+              ~postSpace:true
+              ~wrap:("(", ")")
+              ~inline:(true, true)
+              [atom "contract"; self#module_expr me;]
+          )
+        | Pexp_tuple l ->
+            (* TODO: These may be simple, non-simple, or type constrained
+               non-simple expressions *)
+          Some (self#unparseSequence ~construct:`Tuple l)
+        | Pexp_constraint (e, ct) ->
+          Some (
+            makeList
+              ~break:IfNeed
+              ~wrap:("(", ")")
+              [formatTypeConstraint (self#unparseExpr e) (self#core_type ct)]
+          )
+        | Pexp_coerce (e, cto1, ct) ->
+            let optFormattedType = match cto1 with
+              | None -> None
+              | Some typ -> Some (self#core_type typ) in
+            Some (
+              makeList
+                ~break:IfNeed
+                ~wrap:("(", ")")
+                [formatCoerce (self#unparseExpr e) optFormattedType (self#core_type ct)]
+            )
+        | Pexp_variant (l, None) ->
+            Some (ensureSingleTokenSticksToLabel (atom ("`" ^ l)))
+        | Pexp_record (l, eo) -> Some (self#unparseRecord l eo)
+        | Pexp_array l ->
+          Some (self#unparseSequence ~construct:`Array l)
+        | Pexp_let _ | Pexp_sequence _
+        | Pexp_letmodule _ | Pexp_letexception _ ->
+          Some (makeLetSequence (self#letList x))
+        | Pexp_extension e ->
+          begin match expression_immediate_extension_sugar x with
+            | (Some _, _) -> None
+            | (None, _) ->
+              match expression_extension_sugar x with
+              | None -> Some (self#extension e)
+              | Some (_, x') ->
+                match x'.pexp_desc with
+                | Pexp_let _ ->
+                  Some (makeLetSequence (self#letList x))
+                | _ -> Some (self#extension e)
+          end
+        | Pexp_open (_, lid, e) ->
+            if self#isSeriesOfOpensFollowedByNonSequencyExpression x then
+              Some (label (label (self#longident_loc lid) (atom (".")))
+                          (self#formatNonSequencyExpression e))
+          else
+            Some (makeLetSequence (self#letList x))
+        | Pexp_send (e, s) ->
+          let needparens = match e.pexp_desc with
+            | Pexp_apply (ee, _) ->
+              (match printedStringAndFixityExpr ee with
+               | UnaryPostfix "^" -> true
+               | _ -> false)
+            | _ -> false
+          in
+          let lhs = self#simple_enough_to_be_lhs_dot_send e in
+          let lhs = if needparens then makeList ~wrap:("(",")") [lhs] else lhs in
+          Some (label (makeList [lhs; atom "#";]) (atom s))
+        | _ -> None
+      in
+      match item with
+      | None -> None
+      | Some i -> Some (source_map ~loc:x.pexp_loc i)
+
+  method formatChildren children processedRev =
+    match children with
+    | {pexp_desc = Pexp_constant constant} as x :: remaining ->
+      let raw_literal, _ = extract_raw_literal x.pexp_attributes in
+      self#formatChildren remaining (self#constant ?raw_literal constant :: processedRev)
+    | {pexp_desc = Pexp_construct ({txt = Lident "::"}, Some {pexp_desc = Pexp_tuple children} )} as x :: remaining ->
+      let {jsxAttrs} = partitionAttributes x.pexp_attributes in
+      if jsxAttrs != [] then
+        match self#simplest_expression x with
+        | Some r -> self#formatChildren remaining (r :: processedRev)
+        | None -> self#formatChildren (remaining @ children) processedRev
+      else
+        self#formatChildren (remaining @ children) processedRev
+    | ({pexp_desc = Pexp_apply _} as e) :: remaining ->
+        let child =
+        (* Pipe first behaves differently according to the expression on the
+         * right. In example (1) below, it's a `SpecificInfixPrecedence`; in
+         * (2), however, it's `Simple` and doesn't need to be wrapped in parens.
+         *
+         * (1). <div> {items->Belt.Array.map(ReasonReact.string)->ReasonReact.array} </div>;
+         * (2). <Foo> (title === "" ? [1, 2, 3] : blocks)->Foo.toString </Foo>; *)
+        if Reason_heuristics.isPipeFirst e &&
+           not (Reason_heuristics.isPipeFirstWithNonSimpleJSXChild e)
+        then
+          self#formatPipeFirst e
+        else
+          self#inline_braces#simplifyUnparseExpr ~inline:true ~wrap:("{", "}") e
+        in
+        self#formatChildren remaining (child::processedRev)
+    | {pexp_desc = Pexp_ident li} :: remaining ->
+      self#formatChildren remaining (self#longident_loc li :: processedRev)
+    | {pexp_desc = Pexp_construct ({txt = Lident "[]"}, None)} :: remaining -> self#formatChildren remaining processedRev
+    | {pexp_desc = Pexp_match _ } as head :: remaining ->
+        self#formatChildren
+          remaining
+          (self#inline_braces#simplifyUnparseExpr ~inline:true ~wrap:("{", "}") head :: processedRev)
+    | head :: remaining ->
+        self#formatChildren
+          remaining
+          (self
+            #dont_preserve_braces (* the brace logic is handled here *)
+            #simplifyUnparseExpr ~inline:true ~wrap:("{", "}")
+            head
+           :: processedRev)
+    | [] -> match processedRev with
+        | [] -> None
+        | _::_ -> Some (List.rev processedRev)
+
+  method direction_flag = function
+    | Upto -> atom "to"
+    | Downto -> atom "downto"
+
+  method payload ppxToken ppxId e =
+    let wrap = ("[" ^ ppxToken ^ ppxId.txt, "]") in
+    let wrap_prefix str (x,y) = (x^str, y) in
+    let break = Layout.IfNeed in
+    let pad = (true, false) in
+    let postSpace = true in
+    match e with
+    | PStr [] -> atom ("[" ^ ppxToken  ^ ppxId.txt  ^ "]")
+    | PStr [itm] -> makeList ~break ~wrap ~pad [self#structure_item itm]
+    | PStr (_::_ as items) ->
+      let rows = List.map self#structure_item items in
+      makeList ~wrap ~break ~pad ~postSpace ~sep:(Layout.Sep ";") rows
+    | PTyp x ->
+      let wrap = wrap_prefix ":" wrap in
+      makeList ~wrap ~break ~pad [self#core_type x]
+    (* Signatures in attributes were added recently *)
+    | PSig [] -> atom ("[" ^ ppxToken ^ ppxId.txt ^":]")
+    | PSig [x] ->
+      let wrap = wrap_prefix ":" wrap in
+      makeList ~break ~wrap ~pad [self#signature_item x]
+    | PSig items ->
+      let wrap = wrap_prefix ":" wrap in
+      let rows = List.map self#signature_item items in
+      makeList ~wrap ~break ~pad ~postSpace ~sep:(Layout.Sep ";") rows
+    | PPat (x, None) ->
+      let wrap = wrap_prefix "?" wrap in
+      makeList ~wrap ~break ~pad [self#pattern x]
+    | PPat (x, Some e) ->
+      let wrap = wrap_prefix "?" wrap in
+      makeList ~wrap ~break ~pad ~postSpace [
+        self#pattern x;
+        label ~space:true (atom "when") (self#unparseExpr e)
+      ]
+
+  method extension (s, p) =
+    match s.txt with
+    (* We special case "bs.obj" for now to allow for a nicer interop with
+     * BuckleScript. We might be able to generalize to any kind of record
+     * looking thing with struct keys. *)
+    | "bs.obj" -> self#formatBsObjExtensionSugar p
+    | _ -> (self#payload "%" s p)
+
+  method item_extension (s, e) = (self#payload "%%" s e)
+
+
+  (* [@ ...] Simple attributes *)
+  method attribute = function
+    | { Location. txt = ("ocaml.doc" | "ocaml.text") },
+      PStr [{ pstr_desc = Pstr_eval ({ pexp_desc = Pexp_constant (Pconst_string(text, None)) } , _);
+              pstr_loc }] ->
+      let text = if text = "" then "/**/" else "/**" ^ text ^ "*/" in
+      makeList ~inline:(true, true) ~postSpace:true ~preSpace:true ~indent:0 ~break:IfNeed [atom ~loc:pstr_loc text]
+    | (s, e) -> self#payload "@" s e
+
+  (* [@@ ... ] Attributes that occur after a major item in a structure/class *)
+  method item_attribute = self#attribute
+
+  (* [@@ ...] Attributes that occur not *after* an item in some structure/class/sig, but
+     rather as their own standalone item. Note that syntactic distinction
+     between item_attribute and floating_attribute is no longer necessary with
+     Reason. Thank you semicolons. *)
+  method floating_attribute = self#item_attribute
+
+  method attributes l = List.map self#attribute l
+
+  method attach_std_attrs l toThis =
+    let l = extractStdAttrs l in
+    match l with
+      | [] -> toThis
+      | _::_ -> makeList ~postSpace:true (List.concat [self#attributes l; [toThis]])
+
+  method attach_std_item_attrs ?(allowUncurry=true) ?extension l toThis =
+    let l = (partitionAttributes ~allowUncurry l).stdAttrs in
+    match extension, l with
+    | None, [] -> toThis
+    | _, _ ->
+      let extension = match extension with
+        | None -> []
+        | Some id -> [atom ("%" ^ id.txt)]
+      in
+      makeList
+        ~postSpace:true ~indent:0 ~break:Layout.Always_rec ~inline:(true, true)
+        (extension @ List.map self#item_attribute l @ [toThis])
+
+  method exception_declaration ed =
+    let pcd_name = ed.pext_name in
+    let pcd_loc = ed.pext_loc in
+    let pcd_attributes = [] in
+    let exn_arg = match ed.pext_kind with
+      | Pext_decl (args, type_opt) ->
+          let pcd_args, pcd_res = args, type_opt in
+          [self#type_variant_leaf_nobar {pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes}]
+      | Pext_rebind id ->
+          [atom pcd_name.txt; atom "="; (self#longident_loc id)] in
+    let {stdAttrs; docAttrs} =
+      partitionAttributes ~partDoc:true ed.pext_attributes
+    in
+    let layout =
+      self#attach_std_item_attrs
+        stdAttrs
+        (label ~space:true
+          (atom "exception")
+          (makeList ~postSpace:true ~inline:(true, true) exn_arg))
+    in
+    self#attachDocAttrsToLayout
+      ~stdAttrs
+      ~docAttrs
+      ~loc:ed.pext_loc
+      ~layout
+      ()
+
+  (*
+    Note: that override doesn't appear in class_sig_field, but does occur in
+    class/object expressions.
+    TODO: TODOATTRIBUTES
+   *)
+  method method_sig_flags_for s = function
+    | Virtual -> [atom "virtual"; atom s]
+    | Concrete ->  [atom s]
+
+  method value_type_flags_for s = function
+    | (Virtual, Mutable) -> [atom "virtual"; atom "mutable"; atom s]
+    | (Virtual, Immutable) -> [atom "virtual"; atom s]
+    | (Concrete, Mutable) -> [atom "mutable"; atom s]
+    | (Concrete, Immutable) -> [atom s]
+
+  method class_sig_field x =
+    match x.pctf_desc with
+    | Pctf_inherit ct ->
+      label ~space:true (atom "inherit") (self#class_constructor_type ct)
+    | Pctf_val (s, mf, vf, ct) ->
+      let valueFlags = self#value_type_flags_for (s ^ ":") (vf, mf) in
+      label
+        ~space:true
+        (
+          label ~space:true
+            (atom "val")
+            (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed valueFlags)
+        )
+        (self#core_type ct)
+    | Pctf_method (s, pf, vf, ct) ->
+      let methodFlags = self#method_sig_flags_for (s ^ ":") vf
+      in
+      let pubOrPrivate =
+        match pf with
+        | Private -> "pri"
+        | Public -> "pub"
+      in
+      let m = label
+        ~space:true
+        (label ~space:true
+            (atom pubOrPrivate)
+            (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed methodFlags)
+        )
+        (self#core_type ct)
+      in
+      (self#attach_std_item_attrs x.pctf_attributes m)
+    | Pctf_constraint (ct1, ct2) ->
+      label
+        ~space:true
+        (atom "constraint")
+        (label ~space:true
+            (makeList ~postSpace:true [self#core_type ct1; atom "="])
+            (self#core_type ct2)
+        )
+    | Pctf_attribute a -> self#floating_attribute a
+    | Pctf_extension e -> self#item_extension e
+
+  (*
+    /** doc comment */                                    (* formattedDocs *)
+    [@bs.val] [@bs.module "react-dom"]                    (* formattedAttrs *)
+    external render : reactElement => element => unit =   (* frstHalf *)
+      "render";                                           (* sndHalf *)
+
+    To improve the formatting with breaking & indentation:
+      * consider the part before the '=' as a label
+      * combine that label with '=' in a list
+      * consider the part after the '=' as a list
+      * combine both parts as a label
+      * format the doc comment with a ~postSpace:true (inline, not inline) list
+      * format the attributes with a ~postSpace:true (inline, inline) list
+      * format everything together in a ~postSpace:true (inline, inline) list
+        for nicer breaking
+  *)
+  method primitive_declaration vd =
+    let lblBefore =
+      label
+        ~space:true
+        (makeList
+           [(makeList ~postSpace:true [atom "external"; protectIdentifier vd.pval_name.txt]); (atom ":")])
+        (self#core_type vd.pval_type)
+    in
+    let frstHalf = makeList ~postSpace:true [lblBefore; atom "="] in
+    let sndHalf = makeSpacedBreakableInlineList (List.map self#constant_string vd.pval_prim) in
+    let primDecl = label ~space:true frstHalf sndHalf in
+    match vd.pval_attributes with
+    | [] -> primDecl
+    | attrs ->
+        let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true attrs in
+        let docs = List.map self#item_attribute docAttrs in
+        let formattedDocs = makeList ~postSpace:true docs in
+        let attrs = List.map self#item_attribute stdAttrs in
+        let formattedAttrs = makeSpacedBreakableInlineList attrs in
+        let layouts = match (docAttrs, stdAttrs) with
+        | ([], _) -> [formattedAttrs; primDecl]
+        | (_, []) -> [formattedDocs; primDecl]
+        | _ -> [formattedDocs; formattedAttrs; primDecl] in
+        makeSpacedBreakableInlineList layouts
+
+  method class_instance_type x =
+    match x.pcty_desc with
+    | Pcty_signature cs ->
+      let {pcsig_self = ct; pcsig_fields = l} = cs in
+      let instTypeFields = List.map self#class_sig_field l in
+      let allItems = match ct.ptyp_desc with
+        | Ptyp_any -> instTypeFields
+        | _ ->
+          label ~space:true (atom "as") (self#core_type ct) ::
+          instTypeFields
+      in
+      self#attach_std_item_attrs ~allowUncurry:false x.pcty_attributes (
+        makeList
+          ~wrap:("{", "}")
+          ~postSpace:true
+          ~break:Layout.Always_rec
+          (List.map semiTerminated allItems)
+      )
+    | Pcty_constr (li, l) ->
+      self#attach_std_attrs x.pcty_attributes (
+        match l with
+        | [] -> self#longident_loc li
+        | _::_ ->
+          label
+            (self#longident_loc li)
+            (makeList ~wrap:("(", ")") ~sep:commaTrail (List.map self#core_type l))
+      )
+    | Pcty_extension e ->
+      self#attach_std_item_attrs x.pcty_attributes (self#extension e)
+    | Pcty_arrow _ -> failwith "class_instance_type should not be printed with Pcty_arrow"
+
+  method class_declaration_list l =
+    let class_declaration ?(class_keyword=false)
+        ({pci_params=ls; pci_name={txt}; pci_virt; pci_loc} as x) =
+      let (firstToken, pattern, patternAux) = self#class_opening class_keyword txt pci_virt ls in
+      let classBinding = self#wrappedClassBinding firstToken pattern patternAux x.pci_expr in
+      source_map ~loc:pci_loc
+        (self#attach_std_item_attrs x.pci_attributes classBinding)
+    in
+    (match l with
+      | [] -> raise (NotPossible "Class definitions will have at least one item.")
+      | x::rest ->
+        makeNonIndentedBreakingList (
+          class_declaration ~class_keyword:true x ::
+          List.map class_declaration rest
+        )
+    )
+  (* For use with [class type a = class_instance_type]. Class type
+     declarations/definitions declare the types of instances generated by class
+     constructors.
+     We have to call self#class_instance_type because self#class_constructor_type
+     would add a "new" before the type.
+     TODO: TODOATTRIBUTES:
+  *)
+  method class_type_declaration_list l =
+    let class_type_declaration kwd ({pci_params=ls;pci_name;pci_attributes} as x) =
+      let opener = match x.pci_virt with
+        | Virtual -> kwd ^ " " ^ "virtual"
+        | Concrete -> kwd
+      in
+
+      let upToName =
+        if ls == [] then
+          label ~space:true (atom opener) (atom pci_name.txt)
+        else
+          label
+            ~space:true
+            (label ~space:true (atom opener) (atom pci_name.txt))
+            (self#class_params_def ls)
+      in
+      let includingEqual = makeList ~postSpace:true [upToName; atom "="] in
+      let {stdAttrs; docAttrs} =
+        partitionAttributes ~partDoc:true pci_attributes
+      in
+      let layout =
+        self#attach_std_item_attrs stdAttrs @@
+        label ~space:true includingEqual (self#class_instance_type x.pci_expr)
+      in
+      self#attachDocAttrsToLayout
+        ~stdAttrs
+        ~docAttrs
+        ~loc:pci_name.loc
+        ~layout
+        ()
+    in
+    match l with
+    | [] -> failwith "Should not call class_type_declaration with no classes"
+    | [x] -> class_type_declaration "class type" x
+    | x :: xs ->
+      makeList
+        ~break:Always_rec
+        ~indent:0
+        ~inline:(true, true)
+        (
+          (class_type_declaration "class type" x)::
+          List.map (class_type_declaration "and") xs
+        )
+
+  (*
+     Formerly the [class_type]
+     Notice how class_constructor_type doesn't have any type attributes -
+     class_instance_type does.
+     TODO: Divide into class_constructor_types that allow arrows and ones
+     that don't.
+   *)
+  method class_constructor_type x =
+    match x.pcty_desc with
+    | Pcty_arrow _ ->
+      let rec allArrowSegments acc = function
+        | { pcty_desc = Pcty_arrow (l, ct1, ct2); } ->
+            allArrowSegments (self#type_with_label (l, ct1, false) :: acc) ct2
+        (* This "new" is unfortunate. See reason_parser.mly for details. *)
+        | xx -> (List.rev acc, self#class_constructor_type xx)
+      in
+      let (params, return) = allArrowSegments [] x in
+      let normalized =
+        makeList ~break:IfNeed
+          ~sep:(Sep "=>")
+          ~preSpace:true ~postSpace:true ~inline:(true, true)
+        [makeCommaBreakableListSurround "(" ")" params; return]
+      in
+      source_map ~loc:x.pcty_loc normalized
+    | _ ->
+      (* Unfortunately, we have to have final components of a class_constructor_type
+         be prefixed with the `new` keyword.  Hopefully this is temporary. *)
+      self#class_instance_type x
+
+  method non_arrowed_class_constructor_type x =
+    match x.pcty_desc with
+    | Pcty_arrow _ ->
+      source_map ~loc:x.pcty_loc
+        (formatPrecedence (self#class_constructor_type x))
+    | _ -> self#class_instance_type x
+
+  method class_field x =
+    let itm =
+      match x.pcf_desc with
+      | Pcf_inherit (ovf, ce, so) ->
+        let inheritText = ("inherit" ^ override ovf) in
+        let inheritExp = self#class_expr ce in
+        label
+          ~space:true
+          (atom inheritText)
+          (
+            match so with
+            | None -> inheritExp;
+            | Some s -> label ~space:true inheritExp (atom ("as " ^ s))
+          )
+      | Pcf_val (s, mf, Cfk_concrete (ovf, e)) ->
+        let opening = match mf with
+          | Mutable ->
+            let mutableName = [atom "mutable"; atom s.txt] in
+            label
+              ~space:true
+              (atom ("val" ^ override ovf))
+              (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed mutableName)
+          | Immutable -> label ~space:true (atom ("val" ^ override ovf)) (atom s.txt)
+        in
+        let valExprAndConstraint = match e.pexp_desc with
+          | Pexp_constraint (ex, ct) ->
+            let openingWithTypeConstraint = formatTypeConstraint opening (self#core_type ct) in
+            label
+              ~space:true
+              (makeList ~postSpace:true [openingWithTypeConstraint; atom "="])
+              (self#unparseExpr ex)
+          | _ ->
+            label ~space:true (makeList ~postSpace:true [opening; atom "="]) (self#unparseExpr e)
+        in
+        valExprAndConstraint
+      | Pcf_val (s, mf, Cfk_virtual ct) ->
+        let opening = match mf with
+          | Mutable ->
+            let mutableVirtualName = [atom "mutable"; atom "virtual"; atom s.txt] in
+            let openingTokens =
+              (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed mutableVirtualName) in
+            label ~space:true (atom "val") openingTokens
+          | Immutable ->
+            let virtualName = [atom "virtual"; atom s.txt] in
+            let openingTokens =
+              (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed virtualName) in
+            label ~space:true (atom "val") openingTokens
+        in
+        formatTypeConstraint opening (self#core_type ct)
+      | Pcf_method (s, pf, Cfk_virtual ct) ->
+        let opening = match pf with
+          | Private ->
+            let privateVirtualName = [atom "virtual"; atom s.txt] in
+            let openingTokens =
+              (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed privateVirtualName) in
+            label ~space:true (atom "pri") openingTokens
+          | Public ->
+            let virtualName = [atom "virtual"; atom s.txt] in
+            let openingTokens =
+              (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed virtualName) in
+            label ~space:true (atom "pub") openingTokens
+        in
+        formatTypeConstraint opening (self#core_type ct)
+      | Pcf_method (s, pf, Cfk_concrete (ovf, e)) ->
+        let methodText =
+           let postFix = if ovf == Override then "!" else "" in
+           (
+           match pf with
+           | Private -> "pri" ^ postFix
+           | Public -> "pub" ^ postFix
+           ) in
+        (* Should refactor the binding logic so faking out the AST isn't needed,
+           currently, it includes a ton of nuanced logic around recovering explicitly
+           polymorphic type definitions, and that furthermore, that representation...
+           Actually, let's do it.
+
+           For some reason, concrete methods are only ever parsed as Pexp_poly.
+           If there *is* no polymorphic function for the method, then the return
+           value of the function is wrapped in a ghost Pexp_poly with [None] for
+           the type vars.*)
+        (match e.pexp_desc with
+          | (Pexp_poly
+              ({pexp_desc=Pexp_constraint (methodFunWithNewtypes, nonVarifiedExprType)},
+                Some ({ptyp_desc=Ptyp_poly (typeVars, varifiedPolyType)})
+              )
+            ) when (
+              let (leadingAbstractVars, _) =
+                self#leadingCurriedAbstractTypes methodFunWithNewtypes in
+              self#isRenderableAsPolymorphicAbstractTypes
+                typeVars
+                (* If even artificially varified. Don't know until this returns*)
+                varifiedPolyType
+                leadingAbstractVars
+                nonVarifiedExprType
+          ) ->
+            let (leadingAbstractVars, _) =
+              self#leadingCurriedAbstractTypes methodFunWithNewtypes in
+            self#locallyAbstractPolymorphicFunctionBinding
+              methodText
+              (atom s.txt)
+              methodFunWithNewtypes
+              leadingAbstractVars
+              nonVarifiedExprType
+          | Pexp_poly (e, Some ct) ->
+            self#formatSimplePatternBinding methodText (atom s.txt)
+              (Some (source_map ~loc:ct.ptyp_loc (self#core_type ct)))
+              (self#unparseExprApplicationItems e)
+          (* This form means that there is no type constraint - it's a strange node name.*)
+          | Pexp_poly (e, None) ->
+            self#wrappedBinding methodText ~arrow:"=>" (atom s.txt) [] e
+          | _ -> failwith "Concrete methods should only ever have Pexp_poly."
+        )
+      | Pcf_constraint (ct1, ct2) ->
+        label
+          ~space:true
+          (atom "constraint")
+          (
+            makeList ~postSpace:true ~inline:(true, false) [
+              makeList ~postSpace:true [self#core_type ct1; atom "="];
+              self#core_type ct2
+            ]
+          )
+      | Pcf_initializer e ->
+        label
+          ~space:true
+          (atom "initializer")
+          (self#simplifyUnparseExpr e)
+      | Pcf_attribute a -> self#floating_attribute a
+      | Pcf_extension e ->
+        (* And don't forget, we still need to print post_item_attributes even for
+           this case *)
+        self#item_extension e
+    in
+    source_map ~loc:x.pcf_loc itm
+
+  method class_self_pattern_and_structure {pcstr_self = p; pcstr_fields = l} =
+    let fields = List.map self#class_field l in
+    (* Recall that by default self is bound to "this" at parse time. You'd
+       have to go out of your way to bind it to "_". *)
+    match (p.ppat_attributes, p.ppat_desc) with
+      | ([], Ppat_var ({txt = "this"})) -> fields
+      | _ ->
+        let field = label ~space:true (atom "as") (self#pattern p) in
+        source_map ~loc:p.ppat_loc field :: fields
+
+  method simple_class_expr x =
+    let {stdAttrs} = partitionAttributes x.pcl_attributes in
+    if stdAttrs != [] then
+      formatSimpleAttributed
+        (self#simple_class_expr {x with pcl_attributes=[]})
+        (self#attributes stdAttrs)
+    else
+      let itm =
+        match x.pcl_desc with
+        | Pcl_constraint (ce, ct) ->
+          formatTypeConstraint (self#class_expr ce) (self#class_constructor_type ct)
+        (* In OCaml,
+          - In the most recent version of OCaml, when in the top level of a
+            module, let _ = ... is a PStr_eval.
+          - When in a function, it is a Pexp_let PPat_any
+          - When in class pre-member let bindings it is a Pcl_let PPat_any
+
+           Reason normalizes all of these to be simple imperative expressions
+           with trailing semicolons, *except* in the case of classes because it
+           will likely introduce a conflict with some proposed syntaxes for
+           objects.
+        *)
+        | Pcl_let _
+        | Pcl_structure _ ->
+          let rows = (self#classExprLetsAndRest x) in
+          makeList ~wrap:("{", "}") ~inline:(true, false) ~postSpace:true ~break:Always_rec (List.map semiTerminated rows)
+        | Pcl_extension e -> self#extension e
+        | _ -> formatPrecedence (self#class_expr x)
+     in source_map ~loc:x.pcl_loc itm
+
+  method classExprLetsAndRest x =
+    match x.pcl_desc with
+      | Pcl_structure cs -> self#class_self_pattern_and_structure cs
+      | Pcl_let (rf, l, ce) ->
+        (* For "letList" bindings, the start/end isn't as simple as with
+         * module value bindings. For "let lists", the sequences were formed
+         * within braces {}. The parser relocates the first let binding to the
+         * first brace. *)
+        let binding =
+          source_map ~loc:(self#bindingsLocationRange l)
+            (self#bindings (rf, l))
+        in
+        (binding :: self#classExprLetsAndRest ce)
+      | _ -> [self#class_expr x]
+
+  method class_expr x =
+    let {stdAttrs} = partitionAttributes x.pcl_attributes in
+    (* We cannot handle the attributes here. Must handle them in each item *)
+    if stdAttrs != [] then
+      (* Do not need a "simple" attributes precedence wrapper. *)
+      formatAttributed
+        (self#simple_class_expr {x with pcl_attributes=[]})
+        (self#attributes stdAttrs)
+    else
+      match x.pcl_desc with
+      | Pcl_fun _ ->
+        (match self#curriedConstructorPatternsAndReturnVal x with
+         | None, _ ->
+           (* x just matched Pcl_fun, there is at least one parameter *)
+           assert false
+         | Some args, e ->
+           label ~space:true
+             (makeList ~postSpace:true
+                [label ~space:true (atom funToken) args; atom "=>"])
+             (self#class_expr e))
+      | Pcl_apply _ ->
+        formatAttachmentApplication applicationFinalWrapping None
+         (self#classExpressionToFormattedApplicationItems x, None)
+      | Pcl_constr (li, []) ->
+        label ~space:true (atom "class") (self#longident_loc li)
+      | Pcl_constr (li, l) ->
+        label
+          (makeList ~postSpace:true [atom "class"; self#longident_loc li])
+          (makeTup (List.map self#non_arrowed_non_simple_core_type l))
+      | Pcl_constraint _
+      | Pcl_extension _
+      | Pcl_let _
+      | Pcl_structure _ -> self#simple_class_expr x;
+
+  method classStructure ?(forceBreak=false) ?(wrap=("", "")) cs =
+    let (left, right) = wrap in
+    makeList
+      ~sep:(Layout.Sep ";")
+      ~wrap:(left ^ "{", "}" ^ right)
+      ~break:(if forceBreak then Layout.Always else Layout.IfNeed)
+      ~postSpace:true
+      ~inline:(true, false)
+      (self#class_self_pattern_and_structure cs)
+
+  method signature signatureItems =
+    match signatureItems with
+    | [] -> atom ""
+    | first::_ as signatureItems ->
+      let last = match (List.rev signatureItems) with | last::_ -> last | [] -> assert false in
+      let loc_start = first.psig_loc.loc_start in
+      let loc_end = last.psig_loc.loc_end in
+      let items =
+        groupAndPrint
+          ~xf:self#signature_item
+          ~getLoc:(fun x -> x.psig_loc)
+          ~comments:self#comments
+          signatureItems
+      in
+      source_map ~loc:{loc_start; loc_end; loc_ghost=false}
+        (makeList
+           ~postSpace:true
+           ~break:Layout.Always_rec
+           ~indent:0
+           ~inline:(true, false)
+           ~sep:(SepFinal (";", ";"))
+           items)
+
+  method signature_item x : Layout.t =
+    let item: Layout.t =
+      match x.psig_desc with
+        | Psig_type (rf, l) ->
+            self#type_def_list (rf, l)
+        | Psig_value vd ->
+            if vd.pval_prim != [] then
+              self#primitive_declaration vd
+            else
+              let intro = atom "let" in
+              let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true vd.pval_attributes in
+              let layout = self#attach_std_item_attrs stdAttrs
+                (formatTypeConstraint
+                   (label ~space:true intro
+                      (source_map ~loc:vd.pval_name.loc
+                         (protectIdentifier vd.pval_name.txt)))
+                  (self#core_type vd.pval_type))
+              in
+              self#attachDocAttrsToLayout
+                ~stdAttrs
+                ~docAttrs
+                ~loc:vd.pval_loc
+                ~layout
+                ()
+
+        | Psig_typext te ->
+            self#type_extension te
+        | Psig_exception ed ->
+            self#exception_declaration ed
+        | Psig_class l ->
+            let class_description
+                ?(class_keyword=false)
+                ({pci_params=ls; pci_name={txt}; pci_loc} as x) =
+              let (firstToken, pattern, patternAux) = self#class_opening class_keyword txt x.pci_virt ls in
+              let withColon = self#wrapCurriedFunctionBinding
+                ~arrow:":"
+                ~spaceBeforeArrow:false
+                firstToken
+                pattern
+                patternAux
+                ([(self#class_constructor_type x.pci_expr)], None)
+              in
+              let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true x.pci_attributes in
+              let layout = self#attach_std_item_attrs stdAttrs withColon in
+              source_map ~loc:pci_loc
+                (self#attachDocAttrsToLayout
+                  ~stdAttrs
+                  ~docAttrs
+                  ~loc:x.pci_name.loc
+                  ~layout
+                  ())
+            in
+            makeNonIndentedBreakingList (
+              match l with
+              | [] -> raise (NotPossible "No recursive class bindings")
+              | [x] -> [class_description ~class_keyword:true x]
+              | x :: xs ->
+                 (class_description ~class_keyword:true x)::
+                 (List.map class_description xs)
+            )
+        | Psig_module {pmd_name; pmd_type={pmty_desc=Pmty_alias alias}; pmd_attributes} ->
+            let {stdAttrs; docAttrs} =
+              partitionAttributes ~partDoc:true pmd_attributes
+            in
+            let layout =
+              self#attach_std_item_attrs stdAttrs @@
+              label ~space:true
+                (makeList ~postSpace:true [
+                   atom "contract";
+                   atom pmd_name.txt;
+                   atom "="
+                 ])
+                (self#longident_loc alias)
+            in
+            self#attachDocAttrsToLayout
+              ~stdAttrs
+              ~docAttrs
+              ~loc:pmd_name.loc
+              ~layout
+              ()
+        | Psig_module pmd ->
+            let {stdAttrs; docAttrs} =
+              partitionAttributes ~partDoc:true pmd.pmd_attributes
+            in
+            let letPattern =
+              makeList
+                [makeList ~postSpace:true [atom "contract"; (atom pmd.pmd_name.txt)];
+                 atom ":"]
+            in
+            let layout =
+              self#attach_std_item_attrs stdAttrs @@
+              (self#module_type letPattern pmd.pmd_type)
+            in
+            self#attachDocAttrsToLayout
+              ~stdAttrs
+              ~docAttrs
+              ~loc:pmd.pmd_name.loc
+              ~layout
+              ()
+        | Psig_open od ->
+          let {stdAttrs; docAttrs} =
+            partitionAttributes ~partDoc:true od.popen_attributes
+          in
+          let layout =
+            self#attach_std_item_attrs stdAttrs @@
+            label ~space:true
+              (atom ("open" ^ (override od.popen_override)))
+              (self#longident_loc od.popen_lid)
+          in
+          self#attachDocAttrsToLayout
+            ~stdAttrs
+            ~docAttrs
+            ~loc:od.popen_lid.loc
+            ~layout
+            ()
+        | Psig_include incl ->
+          let {stdAttrs; docAttrs} =
+            partitionAttributes ~partDoc:true incl.pincl_attributes
+          in
+          let layout =
+            self#attach_std_item_attrs stdAttrs @@
+            (self#module_type (atom "include") incl.pincl_mod)
+          in
+          self#attachDocAttrsToLayout
+            ~stdAttrs
+            ~docAttrs
+            ~loc:incl.pincl_mod.pmty_loc
+            ~layout
+            ()
+        | Psig_modtype x ->
+          let name = atom x.pmtd_name.txt in
+          let letPattern = makeList ~postSpace:true [atom "contract type"; name; atom "="] in
+          let main = match x.pmtd_type with
+            | None -> makeList ~postSpace:true [atom "contract type"; name]
+            | Some mt -> self#module_type letPattern mt
+          in
+          let {stdAttrs; docAttrs} =
+            partitionAttributes ~partDoc:true x.pmtd_attributes
+          in
+          let layout =
+            self#attach_std_item_attrs stdAttrs main
+          in
+          self#attachDocAttrsToLayout
+            ~stdAttrs
+            ~docAttrs
+            ~loc:x.pmtd_name.loc
+            ~layout
+            ()
+        | Psig_class_type l -> self#class_type_declaration_list l
+        | Psig_recmodule decls ->
+            let items = List.mapi (fun i xx ->
+              let {stdAttrs; docAttrs} =
+                partitionAttributes ~partDoc:true xx.pmd_attributes
+              in
+              let letPattern =
+                makeList [
+                  makeList ~postSpace:true [
+                    atom (if i == 0 then "contract rec" else "and");
+                    atom xx.pmd_name.txt
+                  ];
+                 atom ":"
+                ]
+              in
+              let layout =
+                self#attach_std_item_attrs stdAttrs
+                  (self#module_type ~space:true letPattern xx.pmd_type)
+              in
+              let layoutWithDocAttrs =
+                self#attachDocAttrsToLayout
+                 ~stdAttrs
+                 ~docAttrs
+                 ~loc:xx.pmd_name.loc
+                 ~layout
+                 ()
+              in
+              (extractLocModDecl xx, layoutWithDocAttrs)
+            ) decls
+            in
+            makeNonIndentedBreakingList
+              (groupAndPrint
+                ~xf:(fun (_, layout) -> layout)
+                ~getLoc:(fun (loc, _) -> loc)
+                ~comments:self#comments
+                items)
+
+        | Psig_attribute a -> self#floating_attribute a
+        | Psig_extension (({loc}, _) as ext, attrs) ->
+          let {stdAttrs; docAttrs} =
+            partitionAttributes ~partDoc:true attrs
+          in
+          let layout =
+            self#attach_std_item_attrs stdAttrs (self#item_extension ext)
+          in
+          self#attachDocAttrsToLayout
+            ~stdAttrs
+            ~docAttrs
+            ~loc
+            ~layout
+            ()
+    in
+    source_map ~loc:x.psig_loc item
+
+  method non_arrowed_module_type ?(space=true) letPattern x =
+    match x.pmty_desc with
+      | Pmty_alias li ->
+        label ~space
+          letPattern
+          (formatPrecedence (label ~space:true (atom "contract") (self#longident_loc li)))
+      | Pmty_typeof me ->
+        let labelWithoutFinalWrap =
+          label ~space:true
+            (label ~space:true
+               letPattern
+               (makeList
+                  ~inline:(false, false)
+                  ~wrap:("(","")
+                  ~postSpace:true
+                  [atom "contract type of"]))
+            (self#module_expr me)
+        in
+        makeList ~wrap:("",")") [labelWithoutFinalWrap]
+      | _ -> self#simple_module_type ~space letPattern x
+
+  method simple_module_type ?(space=true) letPattern x =
+    match x.pmty_desc with
+      | Pmty_ident li -> label ~space letPattern (self#longident_loc li)
+      | Pmty_signature s ->
+        let items =
+          groupAndPrint
+          ~xf:self#signature_item
+          ~getLoc:(fun x -> x.psig_loc)
+          ~comments:self#comments
+          s
+        in
+        let shouldBreakLabel = if List.length s > 1 then `Always else `Auto in
+        label
+          ~indent:0
+          ~break:shouldBreakLabel
+          (makeList
+            [label
+               ~break:shouldBreakLabel
+                (makeList
+                  ~postSpace:true
+                  [letPattern; (atom "{")])
+              (source_map
+                 ~loc:x.pmty_loc
+                 (makeList
+                    ~break:(if List.length s > 1 then Always else IfNeed)
+                    ~inline:(true, true)
+                    ~postSpace:true
+                    ~sep:(SepFinal (";", ";"))
+                    items))])
+          (atom "}")
+      | Pmty_extension (s, e) -> label ~space letPattern (self#payload "%" s e)
+      | _ ->
+        makeList ~break:IfNeed ~wrap:("", ")")
+          [self#module_type ~space:false (makeList ~pad:(false,true) ~wrap:("","(") [letPattern]) x]
+
+  method module_type ?(space=true) letPattern x =
+    let pmty = match x.pmty_desc with
+      | Pmty_functor _ ->
+        (* The segments that should be separated by arrows. *)
+        let rec extract_args args xx = match xx.pmty_desc with
+          | Pmty_functor (_, None, mt2) -> extract_args (`Unit :: args) mt2
+          | Pmty_functor (s, Some mt1, mt2) ->
+            let arg =
+              if s.txt = "_"
+              then self#module_type ~space:false (atom "") mt1
+              else self#module_type ~space (makeList [(atom s.txt); atom ":"]) mt1
+            in
+            extract_args (`Arg arg :: args) mt2
+          | _ ->
+            let prepare_arg = function
+              | `Unit -> atom "()"
+              | `Arg x -> x
+            in
+            let args = match args with
+              | [`Unit] -> []
+              | _ -> List.rev_map prepare_arg args
+            in
+            (args, self#module_type (atom "") xx)
+        in
+        let args, ret = extract_args [] x in
+        label ~space letPattern
+          (makeList
+             ~break:IfNeed
+             ~sep:(Sep "=>")
+             ~preSpace:true
+             ~inline:(true, true)
+             [makeTup args; ret])
+
+      (* See comments in sugar_parser.mly about why WITH constraints aren't "non
+       * arrowed" *)
+      | Pmty_with (mt, l) ->
+          let modSub atm li2 token = makeList ~postSpace:true [
+            atom "contract";
+            atm;
+            atom token;
+            self#longident_loc li2
+          ] in
+          let typeAtom = atom "type" in
+          let eqAtom = atom "=" in
+          let destrAtom = atom ":=" in
+          let with_constraint = function
+            | Pwith_type (li, td) ->
+                self#formatOneTypeDef
+                  typeAtom
+                  (makeList ~preSpace:true [(self#longident_loc li)])
+                  eqAtom
+                  td
+            | Pwith_module (li, li2) ->
+                modSub (self#longident_loc li) li2 "="
+            | Pwith_typesubst td ->
+                self#formatOneTypeDef
+                  typeAtom
+                  (atom ~loc:td.ptype_name.loc td.ptype_name.txt)
+                  destrAtom
+                  td
+            | Pwith_modsubst (s, li2) -> modSub (atom s.txt) li2 ":="
+          in
+          (match l with
+            | [] -> self#module_type ~space letPattern mt
+            | _ ->
+              label ~space letPattern
+                (label ~space:true
+                  (makeList ~preSpace:true [self#module_type ~space:false (atom "") mt; atom "with"])
+                  (makeList
+                     ~break:IfNeed
+                     ~inline:(true, true)
+                     ~sep:(Sep "and")
+                     ~postSpace:true
+                     ~preSpace:true
+                     (List.map with_constraint l)))
+          )
+        (* Seems like an infinite loop just waiting to happen. *)
+        | _ -> self#non_arrowed_module_type ~space letPattern x
+    in
+    source_map ~loc:x.pmty_loc pmty
+
+  method simple_module_expr ?(hug=false) x = match x.pmod_desc with
+    | Pmod_unpack e ->
+        let exprLayout = match e.pexp_desc with
+        | Pexp_constraint (e, {ptyp_desc = Ptyp_package(lid, cstrs)}) ->
+          formatTypeConstraint
+            (makeList ~postSpace:true [atom "val"; (self#unparseExpr e)])
+            (self#typ_package ~mod_prefix:false lid cstrs)
+        | _ -> makeList ~postSpace:true [atom "val"; (self#unparseExpr e)]
+        in formatPrecedence exprLayout
+    | Pmod_ident li ->
+        ensureSingleTokenSticksToLabel (self#longident_loc li)
+    | Pmod_constraint (unconstrainedRet, mt) ->
+        let letPattern = makeList [(self#module_expr unconstrainedRet); atom ":"]
+        in
+        formatPrecedence (self#module_type letPattern mt)
+    | Pmod_structure s ->
+        let wrap = if hug then ("({", "})") else ("{", "}") in
+        let items =
+          groupAndPrint
+            ~xf:self#structure_item
+            ~getLoc:(fun x -> x.pstr_loc)
+            ~comments:self#comments
+            s
+        in
+        makeList
+          ~break:Always_rec
+          ~inline:(true, false)
+          ~wrap
+          ~postSpace:true
+          ~sep:(SepFinal (";", ";"))
+          items
+    | _ ->
+        (* For example, functor application will be wrapped. *)
+        formatPrecedence (self#module_expr x)
+
+  method module_expr x =
+    match x.pmod_desc with
+    | Pmod_functor _ ->
+      let (argsList, return) = self#curriedFunctorPatternsAndReturnStruct x in
+      (* See #19/20 in syntax.mls - cannot annotate return type at
+               the moment. *)
+      self#wrapCurriedFunctionBinding funToken ~sweet:true ~arrow:"=>" (makeTup argsList) []
+        ([self#moduleExpressionToFormattedApplicationItems return], None)
+    | Pmod_apply _ ->
+      self#moduleExpressionToFormattedApplicationItems x
+    | Pmod_extension (s, e) -> self#payload "%" s e
+    | Pmod_unpack _
+    | Pmod_ident _
+    | Pmod_constraint _
+    | Pmod_structure _ -> self#simple_module_expr x
+
+
+  method structure structureItems =
+    match structureItems with
+    | [] -> atom ""
+    | first::_ as structureItems ->
+      let last = match (List.rev structureItems) with | last::_ -> last | [] -> assert false in
+      let loc_start = first.pstr_loc.loc_start in
+      let loc_end = last.pstr_loc.loc_end in
+      let items =
+        groupAndPrint
+          ~xf:self#structure_item
+          ~getLoc:(fun x -> x.pstr_loc)
+          ~comments:self#comments
+          structureItems
+      in
+      source_map ~loc:{loc_start; loc_end; loc_ghost = false}
+        (makeList
+           ~postSpace:true
+           ~break:Always_rec
+           ~indent:0
+           ~inline:(true, false)
+           ~sep:(SepFinal (";", ";"))
+           items)
+
+  (*
+     How do modules become parsed?
+     let module (X: sig) = blah;
+       Will not parse! (Should just make it parse to let [X:sig =]).
+     let module X: sig = blah;
+       Becomes Pmod_constraint
+     let module X: sig = (blah:sig);
+       Becomes Pmod_constraint .. Pmod_constraint
+     let module X = blah:typ;
+       Becomes Pmod_constraint
+     let module X (Y:y) (Z:z):r => Q
+       Becomes Pmod_functor...=> Pmod_constraint
+
+     let module X (Y:y) (Z:z):r => (Q:r2)
+       Probably becomes Pmod_functor...=> (Pmod_constraint..
+       Pmod_constraint)
+
+    let (module X) =
+      Is a *completely* different thing (unpacking/packing first class modules).
+      We should make sure this is very well distinguished.
+      - Just replace all "let module" with a new three letter keyword (mod)?
+      - Reserve let (module X) for unpacking first class modules.
+
+    See the notes about how Ppat_constraint become parsed and attempt to unify
+    those as well.
+  *)
+
+  method let_module_binding prefixText bindingName moduleExpr =
+    let (argsList, return) = self#curriedFunctorPatternsAndReturnStruct moduleExpr in (
+      match (argsList, return.pmod_desc) with
+        (* Simple module with type constraint, no functor args. *)
+        | ([], Pmod_constraint (unconstrainedRetTerm, ct)) ->
+            let letPattern =
+              makeList
+                [makeList ~postSpace:true [atom prefixText; bindingName];
+                 atom ":"]
+            in
+            let typeConstraint = self#module_type letPattern ct in
+            let includingEqual = makeList ~postSpace:true [typeConstraint; atom "="]
+            in
+            formatAttachmentApplication applicationFinalWrapping (Some (true, includingEqual))
+              ([self#moduleExpressionToFormattedApplicationItems unconstrainedRetTerm], None)
+
+        (* Simple module with type no constraint, no functor args. *)
+        | ([], _) ->
+          self#formatSimplePatternBinding prefixText bindingName None
+            ([self#moduleExpressionToFormattedApplicationItems return], None)
+        | (_, _) ->
+            (* A functor *)
+            let (argsWithConstraint, actualReturn) = (
+              match return.pmod_desc with
+                (* A functor with constrained return type:
+                 *
+                 * let module X = (A) (B) : Ret => ...
+                 * *)
+                | Pmod_constraint (me, ct) ->
+                  ([makeTup argsList;
+                    self#non_arrowed_module_type (atom ":") ct], me)
+                | _ -> ([makeTup argsList], return)
+            ) in
+            self#wrapCurriedFunctionBinding prefixText ~arrow:"=>"
+              (makeList [bindingName; atom " ="]) argsWithConstraint
+              ([self#moduleExpressionToFormattedApplicationItems actualReturn], None)
+    )
+
+    method class_opening class_keyword name pci_virt ls =
+      let firstToken = if class_keyword then "class" else "and" in
+      match (pci_virt, ls) with
+        (* When no class params, it's a very simple formatting for the
+           opener - no breaking. *)
+        | (Virtual, []) ->
+          (firstToken, atom "virtual", [atom name])
+        | (Concrete, []) ->
+          (firstToken, atom name, [])
+        | (Virtual, _::_) ->
+          (firstToken, atom "virtual", [atom name; self#class_params_def ls])
+        | (Concrete, _::_) ->
+          (firstToken, atom name, [self#class_params_def ls])
+
+
+  (* TODO: TODOATTRIBUTES: Structure items don't have attributes, but each
+     pstr_desc *)
+  method structure_item term =
+    let item = (
+      match term.pstr_desc with
+        | Pstr_eval (e, attrs) ->
+            let {stdAttrs; jsxAttrs; uncurried} = partitionAttributes attrs in
+            if uncurried then Hashtbl.add uncurriedTable e.pexp_loc true;
+            let layout = self#attach_std_item_attrs stdAttrs (self#unparseUnattributedExpr e) in
+            (* If there was a JSX attribute BUT JSX component wasn't detected,
+               that JSX attribute needs to be pretty printed so it doesn't get
+               lost *)
+            (match jsxAttrs with
+            | [] -> layout
+            | _::_ ->
+              let jsxAttrNodes = List.map self#attribute jsxAttrs in
+              makeList ~sep:(Sep " ") (jsxAttrNodes @ [layout]))
+        | Pstr_type (_, []) -> assert false
+        | Pstr_type (rf, l)  -> (self#type_def_list (rf, l))
+        | Pstr_value (rf, l) -> (self#bindings (rf, l))
+        | Pstr_typext te -> (self#type_extension te)
+        | Pstr_exception ed -> (self#exception_declaration ed)
+        | Pstr_module x ->
+            let bindingName = atom ~loc:x.pmb_name.loc x.pmb_name.txt in
+            self#attach_std_item_attrs x.pmb_attributes @@
+            self#let_module_binding "contract" bindingName x.pmb_expr
+        | Pstr_open od ->
+            self#attach_std_item_attrs od.popen_attributes @@
+            makeList ~postSpace:true [
+              atom ("open" ^ (override od.popen_override));
+              self#longident_loc od.popen_lid;
+            ]
+        | Pstr_modtype x ->
+            let name = atom x.pmtd_name.txt in
+            let letPattern = makeList ~postSpace:true [atom "contract type"; name; atom "="] in
+            let main = match x.pmtd_type with
+              | None -> makeList ~postSpace:true [atom "contract type"; name]
+              | Some mt -> self#module_type letPattern mt
+            in
+            self#attach_std_item_attrs x.pmtd_attributes main
+        | Pstr_class l -> self#class_declaration_list l
+        | Pstr_class_type l -> self#class_type_declaration_list l
+        | Pstr_primitive vd -> self#primitive_declaration vd
+        | Pstr_include incl ->
+            self#attach_std_item_attrs incl.pincl_attributes @@
+            (* Kind of a hack *)
+            let moduleExpr = incl.pincl_mod in
+            self#moduleExpressionToFormattedApplicationItems
+              ~prefix:"include"
+              moduleExpr
+
+        | Pstr_recmodule decls -> (* 3.07 *)
+            let items = List.mapi (fun i xx ->
+              let {stdAttrs; docAttrs} =
+                partitionAttributes ~partDoc:true xx.pmb_attributes
+              in
+              let layout =
+                self#attach_std_item_attrs stdAttrs @@
+                self#let_module_binding
+                  (if i == 0 then "contract rec" else "and")
+                  (atom xx.pmb_name.txt)
+                  xx.pmb_expr
+              in
+              let layoutWithDocAttrs =
+                self#attachDocAttrsToLayout
+                 ~stdAttrs
+                 ~docAttrs
+                 ~loc:xx.pmb_name.loc
+                 ~layout
+                 ()
+              in
+              (extractLocModuleBinding xx, layoutWithDocAttrs)
+            ) decls
+            in
+            makeNonIndentedBreakingList
+              (groupAndPrint
+                ~xf:(fun (_, layout) -> layout)
+                ~getLoc:(fun (loc, _) -> loc)
+                ~comments:self#comments
+                items)
+        | Pstr_attribute a -> self#floating_attribute a
+        | Pstr_extension ((extension, PStr [item]), a) ->
+          begin match item.pstr_desc with
+            | Pstr_value (rf, l) -> self#bindings ~extension (rf, l)
+            | _ ->
+                let {stdAttrs; docAttrs} =
+                  partitionAttributes ~partDoc:true a
+                in
+                let layout =
+                  self#attach_std_item_attrs ~extension stdAttrs
+                     (self#structure_item item)
+                in
+                makeList ~inline:(true, true) ~break:Always
+                  ((List.map self#attribute docAttrs)@[layout])
+          end
+        | Pstr_extension (e, a) ->
+          (* Notice how extensions have attributes - but not every structure
+             item does. *)
+          self#attach_std_item_attrs a (self#item_extension e)
+    ) in
+    source_map ~loc:term.pstr_loc item
+
+  method type_extension te =
+    let formatOneTypeExtStandard prepend ({ptyext_path} as te) =
+      let name = self#longident_loc ptyext_path in
+      let item = self#formatOneTypeExt prepend name (atom "+=") te in
+      let {stdAttrs; docAttrs} =
+        partitionAttributes ~partDoc:true te.ptyext_attributes
+      in
+      let layout = self#attach_std_item_attrs stdAttrs item in
+      self#attachDocAttrsToLayout
+        ~stdAttrs
+        ~docAttrs
+        ~loc:ptyext_path.loc
+        ~layout
+        ()
+    in
+    formatOneTypeExtStandard (atom "type") te
+
+  (* [allowUnguardedSequenceBodies] allows sequence expressions {} to the right of `=>` to not
+     be guarded in `{}` braces. *)
+  method case_list ?(allowUnguardedSequenceBodies=false) l =
+    let rec appendLabelToLast items rhs =
+      match items with
+        | hd::[] -> (label ~indent:0 ~space:true hd rhs)::[]
+        | hd::tl -> hd::(appendLabelToLast tl rhs)
+        | [] -> raise (NotPossible "Cannot append to last of nothing")
+    in
+
+    let case_row {pc_lhs; pc_guard; pc_rhs} =
+      let theOrs = orList pc_lhs in
+
+      (* match x with *)
+      (* | AnotherReallyLongVariantName (_, _, _)   *)
+      (* | AnotherReallyLongVariantName2 (_, _, _)
+           when true => {                           *)
+
+      (*   }                                        *)
+
+      (*<sbi><X>match x with</X>   *)
+      (*     <Y>everythingElse</Y> *)
+      (*</sbi>                     *)
+
+
+
+      (*     ............................................................
+             :    each or segment has a spaced list <> that ties its    :
+             : bar "|" to its pattern                                   :
+             ...:..........................................................:.....
+             :  :  each or-patterned match is grouped in SpacedBreakableInline  :
+             :  :                                                          :    :
+             v  v                                                          v    v
+             <sbi><>|<lb><A><>     FirstThingStandalone t =></A></><B>t</B></lb></></sbi>
+             <sbi><>|<C>           AnotherReallyLongVariantName (_, _, _)</C></>
+             ^    <>|<lb><><lb><D>AnotherReallyLongVariantNam2 (_, _, _)</D>             (label the last in or ptn for or and label it again for arrow)
+             :        ^  ^   ^     <E>when true<E></lb> =></><F>{
+             :        :  :   :    </F>}</lb></sbi> ^       ^
+             :        :  :   :            ^     ^   :      :
+             :        :  :   :            :     :   :      :
+             :        :  :   :If there is :a WHERE  :      :
+             :        :  :   :an extra    :label is :      :
+             :        :  :   :inserted bef:ore the  :      :
+             :        :  :   :arrow.      :     :   :      :
+             :        :  :   :............:.....:...:      :
+             :        :  :                :     :          :
+             :        :  :                :     :          :
+             :        :  :                :     :          :
+             :        :  :The left side of:this final label:
+             :        :  :uses a list to  :append the arrow:
+             :        :  :................:.....:..........:
+             :        :                   :     :
+             :        :                   :     :
+             :        :                   :     :
+             :        :Final or segment is:     :
+             :        :wrapped in lbl that:     :
+             :        :partitions pattern :     :
+             :        :and arrow from     :     :
+             :        :expression.        :     :
+             :        :                   :     :
+             :        :...................:     :
+             :     [orsWithWhereAndArrowOnLast] :
+             :                                  :
+             :..................................:
+                         [row]
+
+      *)
+      let bar xx = makeList ~postSpace:true [atom "|"; xx] in
+      let appendWhereAndArrow p = match pc_guard with
+        | None -> makeList ~postSpace:true [p; atom "=>"]
+        | Some g ->
+          (* when x should break as a whole - extra list added around it to make it break as one *)
+          let withWhen = label ~space:true p
+              (makeList ~break:Layout.Never ~inline:(true, true) ~postSpace:true
+                 [label ~space:true (atom "when") (self#unparseExpr g)])
+          in
+          makeList ~inline:(true, true) ~postSpace:true [withWhen; atom "=>"]
+      in
+      let rec appendWhereAndArrowToLastOr = function
+        | [] -> []
+        | hd::tl ->
+          let formattedHd = self#pattern hd in
+          let formattedHd =
+            if tl == [] then appendWhereAndArrow formattedHd else formattedHd
+          in
+          (formattedHd :: appendWhereAndArrowToLastOr tl)
+      in
+      let orsWithWhereAndArrowOnLast = appendWhereAndArrowToLastOr theOrs in
+      let rhs =
+        if allowUnguardedSequenceBodies then
+          match (self#under_pipe#letList pc_rhs) with
+          (* TODO: Still render a list with located information here so that
+               comments (eol) are interleaved *)
+          | [hd] -> hd
+          (* In this case, we don't need any additional indentation, because there aren't
+             wrapping {} which would cause zero indentation to look strange. *)
+          | lst -> makeUnguardedLetSequence lst
+        else self#under_pipe#unparseExpr pc_rhs
+      in
+      source_map
+        (* Fake shift the location to accommodate for the bar, to make sure
+           * the wrong comments don't make their way past the next bar. *)
+        ~loc:(expandLocation ~expand:(0, 0) {
+            loc_start = pc_lhs.ppat_loc.loc_start;
+            loc_end = pc_rhs.pexp_loc.loc_end;
+            loc_ghost = false;
+          })
+        (makeList ~break:Always_rec ~inline:(true, true)
+           (List.map bar (appendLabelToLast orsWithWhereAndArrowOnLast rhs)))
+    in
+    groupAndPrint
+      ~xf:case_row
+      ~getLoc:(fun {pc_lhs; pc_rhs} -> {pc_lhs.ppat_loc with loc_end = pc_rhs.pexp_loc.loc_end})
+      ~comments:self#comments
+      l
+
+  (* Formats a list of a single expr param in such a way that the parens of the function or
+   * (poly)-variant application and the wrapping of the param stick together when the layout breaks.
+   *  Example: `foo({a: 1, b: 2})` needs to be formatted as
+   *  foo({
+   *    a: 1,
+   *    b: 2
+   *  })
+   *  when the line length dictates breaking. Notice how `({` and `})` 'hug'.
+   *  Also see "isSingleArgParenApplication" which determines if
+   *  this kind of formatting should happen. *)
+  method singleArgParenApplication ?(wrap=("", "")) ?(uncurried=false) es =
+    let (lwrap, rwrap) = wrap in
+    let lparen = lwrap ^ (if uncurried then  "(. " else "(") in
+    let rparen = ")" ^ rwrap in
+    match es with
+    | [{pexp_attributes = []; pexp_desc = Pexp_record (l, eo)}] ->
+      self#unparseRecord ~wrap:(lparen, rparen) l eo
+    | [{pexp_attributes = []; pexp_desc = Pexp_tuple l}] ->
+      self#unparseSequence ~wrap:(lparen, rparen) ~construct:`Tuple l
+    | [{pexp_attributes = []; pexp_desc = Pexp_array l}] ->
+      self#unparseSequence ~wrap:(lparen, rparen) ~construct:`Array l
+    | [{pexp_attributes = []; pexp_desc = Pexp_object cs}] ->
+      self#classStructure ~wrap:(lparen, rparen) cs
+    | [{pexp_attributes = []; pexp_desc = Pexp_extension (s, p)}] when s.txt = "bs.obj" ->
+      self#formatBsObjExtensionSugar ~wrap:(lparen, rparen) p
+    | [({pexp_attributes = []} as exp)] when (is_simple_list_expr exp) ->
+          (match view_expr exp with
+          | `list xs ->
+              self#unparseSequence ~construct:`List ~wrap:(lparen, rparen) xs
+          | `cons xs ->
+              self#unparseSequence ~construct:`ES6List ~wrap:(lparen, rparen) xs
+          | _ -> assert false)
+    | _ -> assert false
+
+
+  method label_x_expression_param (l, e) =
+    let term = self#unparseProtectedExpr e in
+    let param = match (l, e) with
+      | (Nolabel, _) -> term
+      | (Labelled lbl, _) when is_punned_labelled_expression e lbl ->
+        makeList [atom namedArgSym; term]
+      | (Optional lbl, _) when is_punned_labelled_expression e lbl ->
+        makeList [atom namedArgSym; label term (atom "?")]
+      | (Labelled lbl, _) ->
+        label (atom (namedArgSym ^ lbl ^ "=")) term
+      | (Optional lbl, _) ->
+        label (atom (namedArgSym ^ lbl ^ "=?")) term
+    in
+    source_map ~loc:e.pexp_loc param
+
+  method label_x_expression_params ?wrap ?(uncurried=false) xs =
+    match xs with
+      (* function applications with unit as only argument should be printed differently
+       * e.g. print_newline(()) should be printed as print_newline() *)
+      | [(Nolabel, {pexp_attributes = []; pexp_desc = Pexp_construct ( {txt= Lident "()"}, None)})]
+          -> makeList
+              ~break:Never
+              ?wrap
+              [if uncurried then atom "(.)" else atom "()"]
+
+      (* The following cases provide special formatting when there's only one expr_param that is a tuple/array/list/record etc.
+       *  e.g. foo({a: 1, b: 2})
+       *  becomes ->
+       *  foo({
+       *    a: 1,
+       *    b: 2,
+       *  })
+       *  when the line-length indicates breaking.
+       *)
+      | [(Nolabel, exp)] when isSingleArgParenApplication [exp] ->
+          self#singleArgParenApplication ?wrap ~uncurried [exp]
+      | params ->
+          makeTup ?wrap ~uncurried (List.map self#label_x_expression_param params)
+
+  (*
+   * Prefix represents an optional layout. When passed it will be "prefixed" to
+   * the funExpr. Example, given `bar(x, y)` with prefix `foo`, we get
+   * foobar(x,y). When the arguments break, the closing `)` is nicely aligned
+   * on the height of the prefix:
+   *  foobar(
+   *    x,
+   *    y,
+   *  )  --> notice how `)` sits on the height of `foo` instead of `bar`
+   *
+   *  ~wrap -> represents optional "wrapping", might be useful in context of jsx
+   *  where braces are required:
+   * prop={bar(   -> `{` is formatted before the funExpr
+   *   x,
+   *   y,
+   * )}      -> notice how the closing brace hugs: `)}`
+   *)
+  method formatFunAppl ?(prefix=(atom "")) ?(wrap=("", "")) ~jsxAttrs ~args ~funExpr ~applicationExpr ?(uncurried=false) () =
+    let (leftWrap, rightWrap) = wrap in
+    let uncurriedApplication = uncurried in
+    (* If there was a JSX attribute BUT JSX component wasn't detected,
+       that JSX attribute needs to be pretty printed so it doesn't get
+       lost *)
+    let maybeJSXAttr = List.map self#attribute jsxAttrs in
+    let categorizeFunApplArgs args =
+      let reverseArgs = List.rev args in
+      match reverseArgs with
+      | ((_, {pexp_desc = Pexp_fun _}) as callback)::args
+          when
+            [] == List.filter (fun (_, e) -> match e.pexp_desc with Pexp_fun _ -> true | _ -> false) args
+          (* default to normal formatting if there's more than one callback *)
+          -> `LastArgIsCallback(callback, List.rev args)
+      | _ -> `NormalFunAppl args
+    in
+    let formattedFunExpr = match funExpr.pexp_desc with
+      (* pipe first chain or sharpop chain as funExpr, no parens needed, we know how to parse *)
+      | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident s}}, _)
+        when requireNoSpaceFor s ->
+        self#unparseExpr funExpr
+      | Pexp_field _ -> self#unparseExpr funExpr
+      | _ -> self#simplifyUnparseExpr funExpr
+    in
+    let formattedFunExpr = makeList [prefix; atom leftWrap; formattedFunExpr] in
+    begin match categorizeFunApplArgs args with
+    | `LastArgIsCallback(callbackArg, args) ->
+        (* This is the following case:
+         * Thing.map(foo, bar, baz, (abc, z) =>
+         *   MyModuleBlah.toList(argument)
+         *)
+        let (argLbl, cb) = callbackArg in
+        let {stdAttrs; uncurried} = partitionAttributes cb.pexp_attributes in
+        let cbAttrs = stdAttrs in
+        if uncurried then Hashtbl.add uncurriedTable cb.pexp_loc true;
+        let (cbArgs, retCb) = self#curriedPatternsAndReturnVal {cb with pexp_attributes = []} in
+        let cbArgs = if cbAttrs != [] then
+            makeList ~break:IfNeed ~inline:(true, true) ~postSpace:true
+              (List.map self#attribute cbAttrs @ cbArgs)
+        else makeList cbArgs in
+        let theCallbackArg = match argLbl with
+          | Optional s -> makeList ([atom namedArgSym; atom s; atom "=?"]@[cbArgs])
+          | Labelled s -> makeList ([atom namedArgSym; atom s; atom "="]@[cbArgs])
+          | Nolabel -> cbArgs
+        in
+        let theFunc =
+          source_map ~loc:funExpr.pexp_loc
+            (makeList
+               ~wrap:("", (if uncurriedApplication then "(." else "("))
+               [formattedFunExpr])
+        in
+        let formattedFunAppl = begin match self#letList retCb with
+        | [x] ->
+          (* force breaks for test assertion style callbacks, e.g.
+           *  describe("App", () => test("math", () => Expect.expect(1 + 2) |> toBe(3)));
+           * should always break for readability of the tests:
+           *  describe("App", () =>
+           *    test("math", () =>
+           *      Expect.expect(1 + 2) |> toBe(3)
+           *    )
+           *  );
+           *)
+          let forceBreak = match funExpr.pexp_desc with
+          | Pexp_ident ident when
+              let lastIdent = Longident.last ident.txt in
+              List.mem lastIdent ["test"; "describe"; "it"; "expect"] -> true
+          | _ -> false
+          in
+          let returnValueCallback =
+            makeList
+              ~break:(if forceBreak then Always else IfNeed)
+              ~wrap:("=> ", ")" ^ rightWrap)
+              [x]
+          in
+          let argsWithCallbackArgs = List.concat [(List.map self#label_x_expression_param args); [theCallbackArg]] in
+          let left = label
+            theFunc
+            (makeList
+               ~pad:(uncurriedApplication, false)
+               ~wrap:("", " ") ~break:IfNeed ~inline:(true, true) ~sep:(Sep ",") ~postSpace:true
+              argsWithCallbackArgs)
+          in
+          label left returnValueCallback
+        | xs ->
+          let printWidthExceeded = Reason_heuristics.funAppCallbackExceedsWidth ~printWidth:settings.width ~args ~funExpr () in
+          if printWidthExceeded = false then
+              (*
+               * Thing.map(foo, bar, baz, (abc, z) =>
+               *   MyModuleBlah.toList(argument)
+               * )
+               *
+               * To get this kind of formatting we need to construct the following tree:
+               * <Label>
+               * <left>Thing.map(foo, bar, baz, (abc, z)</left><right>=>
+               *   MyModuleBlah.toList(argument)
+               * )</right>
+               * </Label>
+               *
+               * where left is
+               * <Label><left>Thing.map(</left></right>foo, bar, baz, (abc, z) </right></Label>
+               *
+               * The <right> part of that label could be a <List> with wrap:("", " ") break:IfNeed inline:(true, true)
+               * with items: "foo", "bar", "baz", "(abc, z)", separated by commas.
+               *
+               * this is also necessary to achieve the following formatting where }) hugs :
+               * test("my test", () => {
+               *   let x = a + b;
+               *   let y = z + c;
+               *   x + y
+               * });
+               *)
+            let right =
+              source_map ~loc:retCb.pexp_loc
+                (makeList ~break:Always_rec ~wrap:("=> {", "})" ^ rightWrap) ~sep:(SepFinal (";", ";")) xs)
+            in
+            let argsWithCallbackArgs =
+              List.map self#label_x_expression_param args @ [theCallbackArg]
+            in
+            let left = label
+                theFunc
+                (makeList ~wrap:("", " ") ~break:IfNeed ~inline:(true, true) ~sep:(Sep ",") ~postSpace:true
+                   argsWithCallbackArgs)
+            in
+            label left right
+          else
+            (* Since the heuristic says the line length is exceeded in this case,
+             * we conveniently format everything as
+             * <label><left>Thing.map(</left><right><list>
+             *   foo,
+             *   bar,
+             *   baz,
+             *   <label> <left>(abc) =></left> <right><list> {
+             *     let x = 1;
+             *     let y = 2;
+             *     x + y
+             *   }</list></right></label>
+             * )</list></right></label>
+            *)
+            let args =
+              makeList ~break:Always ~wrap:("", ")" ^ rightWrap) ~sep:commaTrail (
+                (List.map self#label_x_expression_param args) @
+                [label ~space:true (makeList ~wrap:("", " =>") [theCallbackArg])
+                   (source_map ~loc:retCb.pexp_loc (makeLetSequence xs))]
+              )
+            in
+            label theFunc args
+        end in
+        maybeJSXAttr @ [formattedFunAppl]
+    | `NormalFunAppl args ->
+      let theFunc =
+        source_map ~loc:funExpr.pexp_loc formattedFunExpr
+      in
+      (* reset here only because [function,match,try,sequence] are lower priority *)
+      (* The "expression location" might be different than the location of the actual
+       * function application because things like surrounding { } expand the
+       * parsed location (in body of while loop for example).
+       * We recover the most meaningful function application location we can.*)
+      let (syntheticApplicationLocation, syntheticArgLoc) = match args with
+        | [] -> (funExpr.pexp_loc, funExpr.pexp_loc)
+        | _::_ ->
+          {funExpr.pexp_loc with loc_end = applicationExpr.pexp_loc.loc_end},
+          {funExpr.pexp_loc with loc_start = funExpr.pexp_loc.loc_end; loc_end = applicationExpr.pexp_loc.loc_end}
+      in
+      let theArgs = self#reset#label_x_expression_params ~wrap:("", rightWrap) ~uncurried args in
+      maybeJSXAttr @ [source_map ~loc:syntheticApplicationLocation
+                        (label theFunc (source_map ~loc:syntheticArgLoc theArgs))]
+    end
+end;;
+
+let toplevel_phrase ppf x =
+  match x with
+  | Ptop_def s -> format_layout ppf (printer#structure s)
+  | Ptop_dir _ -> print_string "(* top directives not supported *)"
+
+let case_list ppf x =
+  List.iter (format_layout ppf) (printer#case_list x)
+
+(* Convert a Longident to a list of strings.
+   E.g. M.Constructor will be ["Constructor"; "M.Constructor"]
+   Also support ".Constructor" to specify access without a path.
+ *)
+let longident_for_arity lid =
+  let rec toplevel = function
+    | Lident s ->
+        [s]
+    | Ldot (lid, s) ->
+        let append_s x = x ^ "." ^ s in
+        s :: (List.map append_s (toplevel lid))
+    | Lapply (_,s) ->
+        toplevel s in
+   match lid with
+    | Lident s ->
+        ("." ^ s) :: toplevel lid
+    | _ ->
+        toplevel lid
+
+(* add expilcit_arity to a list of attributes
+ *)
+let add_explicit_arity loc attributes =
+  ({txt="explicit_arity"; loc}, PStr []) ::
+  normalized_attributes "explicit_arity" attributes
+
+(* explicit_arity_exists check if expilcit_arity exists
+ *)
+let explicit_arity_not_exists attributes =
+  not (attribute_exists "explicit_arity" attributes)
+
+(* wrap_expr_with_tuple wraps an expression
+ * with tuple as a sole argument.
+ *)
+let wrap_expr_with_tuple exp =
+  {exp with pexp_desc = Pexp_tuple [exp]}
+
+(* wrap_pat_with_tuple wraps an pattern
+ * with tuple as a sole argument.
+ *)
+let wrap_pat_with_tuple pat =
+  {pat with ppat_desc = Ppat_tuple [pat]}
+
+
+
+(* explicit_arity_constructors is a set of constructors that are known to have
+ * multiple arguments
+ *
+ *)
+
+module StringSet = Set.Make(String);;
+
+let built_in_explicit_arity_constructors = ["Some"; "Assert_failure"; "Match_failure"]
+
+let explicit_arity_constructors = StringSet.of_list(built_in_explicit_arity_constructors @ (!configuredSettings).constructorLists)
+
+let add_explicit_arity_mapper super =
+  let super_expr = super.Ast_mapper.expr in
+  let super_pat = super.Ast_mapper.pat in
+  let expr mapper expr =
+    let expr =
+      match expr with
+      | {pexp_desc=Pexp_construct(lid, Some sp);
+         pexp_loc;
+         pexp_attributes} when
+          List.exists
+            (fun c -> StringSet.mem c explicit_arity_constructors)
+            (longident_for_arity lid.txt) &&
+          explicit_arity_not_exists pexp_attributes ->
+        {pexp_desc=Pexp_construct(lid, Some (wrap_expr_with_tuple sp));
+         pexp_loc;
+         pexp_attributes=add_explicit_arity pexp_loc pexp_attributes}
+      | x -> x
+    in
+    super_expr mapper expr
+  and pat mapper pat =
+    let pat =
+      match pat with
+      | {ppat_desc=Ppat_construct(lid, Some sp);
+         ppat_loc;
+         ppat_attributes} when
+          List.exists
+            (fun c -> StringSet.mem c explicit_arity_constructors)
+            (longident_for_arity lid.txt) &&
+          explicit_arity_not_exists ppat_attributes ->
+        {ppat_desc=Ppat_construct(lid, Some (wrap_pat_with_tuple sp));
+         ppat_loc;
+         ppat_attributes=add_explicit_arity ppat_loc ppat_attributes}
+      | x -> x
+    in
+    super_pat mapper pat
+  in
+  { super with Ast_mapper. expr; pat }
+
+let preprocessing_mapper =
+  ml_to_reason_swap_operator_mapper
+    (escape_stars_slashes_mapper
+      (add_explicit_arity_mapper Ast_mapper.default_mapper))
+
+let core_type ppf x =
+  format_layout ppf
+    (printer#core_type (apply_mapper_to_type x preprocessing_mapper))
+
+let pattern ppf x =
+  format_layout ppf
+    (printer#pattern (apply_mapper_to_pattern x preprocessing_mapper))
+
+let signature (comments : Comment.t list) ppf x =
+  List.iter (fun comment -> printer#trackComment comment) comments;
+  format_layout ppf ~comments
+    (printer#signature (apply_mapper_to_signature x preprocessing_mapper))
+
+let structure (comments : Comment.t list) ppf x =
+  List.iter (fun comment -> printer#trackComment comment) comments;
+  format_layout ppf ~comments
+    (printer#structure (apply_mapper_to_structure x preprocessing_mapper))
+
+let expression ppf x =
+  format_layout ppf
+    (printer#unparseExpr (apply_mapper_to_expr x preprocessing_mapper))
+
+let case_list = case_list
+
+end
+in
+object
+  method core_type = Formatter.core_type
+  method pattern = Formatter.pattern
+  method signature = Formatter.signature
+  method structure = Formatter.structure
+  (* For merlin-destruct *)
+  method toplevel_phrase = Formatter.toplevel_phrase
+  method expression = Formatter.expression
+  method case_list = Formatter.case_list
+end

--- a/tools/liquidity/reason/reason_pprint_ast.ml-orig
+++ b/tools/liquidity/reason/reason_pprint_ast.ml-orig
@@ -1,0 +1,8018 @@
+(*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *  Forked from OCaml, which is provided under the license below:
+ *
+ *  Xavier Leroy, projet Cristal, INRIA Rocquencourt
+ *
+ *  Copyright © 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006 Inria
+ *
+ *  Permission is hereby granted, free of charge, to the Licensee obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense
+ *  under any license of the Licensee's choice, and/or sell copies of the
+ *  Software, subject to the following conditions:
+ *
+ *  1.	Redistributions of source code must retain the above copyright notice
+ *  and the following disclaimer.
+ *  2.	Redistributions in binary form must reproduce the above copyright
+ *  notice, the following disclaimer in the documentation and/or other
+ *  materials provided with the distribution.
+ *  3.	All advertising materials mentioning features or use of the Software
+ *  must display the following acknowledgement: This product includes all or
+ *  parts of the Caml system developed by Inria and its contributors.
+ *  4.	Other than specified in clause 3, neither the name of Inria nor the
+ *  names of its contributors may be used to endorse or promote products
+ *  derived from the Software without specific prior written permission.
+ *
+ *  Disclaimer
+ *
+ *  This software is provided by Inria and contributors “as is” and any express
+ *  or implied warranties, including, but not limited to, the implied
+ *  warranties of merchantability and fitness for a particular purpose are
+ *  disclaimed. in no event shall Inria or its contributors be liable for any
+ *  direct, indirect, incidental, special, exemplary, or consequential damages
+ *  (including, but not limited to, procurement of substitute goods or
+ *  services; loss of use, data, or profits; or business interruption) however
+ *  caused and on any theory of liability, whether in contract, strict
+ *  liability, or tort (including negligence or otherwise) arising in any way
+ *  out of the use of this software, even if advised of the possibility of such
+ *  damage.
+ *
+ *)
+
+(* TODO more fine-grained precedence pretty-printing *)
+
+module Easy_format = Vendored_easy_format
+
+open Ast_404
+open Asttypes
+open Location
+open Longident
+open Parsetree
+open Easy_format
+open Reason_syntax_util
+open Reason_attributes
+
+module Comment = Reason_comment
+module Layout = Reason_layout
+module WhitespaceRegion = Layout.WhitespaceRegion
+module Range = Reason_location.Range
+
+let source_map = Layout.source_map
+
+exception NotPossible of string
+
+let commaTrail = Layout.SepFinal (",", Reason_syntax_util.TrailingCommaMarker.string)
+let commaSep = Layout.Sep (",")
+
+type ruleInfoData = {
+  reducePrecedence: precedence;
+  shiftPrecedence: precedence;
+}
+
+and ruleCategory =
+  (* Printing will be parsed with very high precedence, so not much need to
+     worry about ensuring it will reduce correctly. In short, you can put
+     `FunctionApplication` content anywhere around an infix identifier without
+     wrapping in parens. For example `myFunc x y z` or `if x {y} else {z}`
+     The layout is kept in list form only to allow for elegant wrapping rules
+     to take into consideration the *number* of high precedence parsed items. *)
+  | FunctionApplication of Layout.t list
+  (* Care should be taken to ensure the rule that caused it to be parsed will
+     reduce again on the printed output - context should carefully consider
+     wrapping in parens according to the ruleInfoData. *)
+  | SpecificInfixPrecedence of ruleInfoData * resolvedRule
+  (* Not safe to include anywhere between infix operators without wrapping in
+     parens. This describes expressions like `fun x => x` which doesn't fit into
+     our simplistic algorithm for printing function applications separated by infix.
+
+     It might be possible to include these in between infix, but there are
+     tricky rules to determining when these must be guarded by parens (it
+     depends highly on context that is hard to reason about). It's so nuanced
+     that it's easier just to always wrap them in parens.  *)
+  | PotentiallyLowPrecedence of Layout.t
+  (* Simple means it is clearly one token (such as (anything) or [anything] or identifier *)
+  | Simple of Layout.t
+
+(* Represents a ruleCategory where the precedence has been resolved.
+ * The precedence of a ruleCategory gets resolved in `ensureExpression` or
+ * `ensureContainingRule`. The result is either a plain Layout.t (where
+ * parens probably have been applied) or an InfixTree containing the operator and
+ * a left & right resolvedRule. The latter indicates that the precedence has been resolved,
+ * but the actual formatting is deferred to a later stadium.
+ * Think `let x = foo |> f |> z |>`, which requires a certain formatting style when
+ * things break over multiple lines. *)
+and resolvedRule =
+  | LayoutNode of Layout.t
+  | InfixTree of string * resolvedRule * resolvedRule
+
+and associativity =
+  | Right
+  | Nonassoc
+  | Left
+
+and precedenceEntryType =
+  | TokenPrecedence
+  | CustomPrecedence
+
+and precedence =
+  | Token of string
+  | Custom of string
+
+(* Describes the "fixity" of a token, and stores its *printed* representation
+   should it be rendered as infix/prefix (This rendering may be different than
+   how it is stored in the AST). *)
+and tokenFixity =
+  (* Such as !simple_expr and ~!simple_expr. These function applications are
+     considered *almost* "simple" because they may be allowed anywhere a simple
+     expression is accepted, except for when on the left hand side of a
+     dot/send. *)
+  | AlmostSimplePrefix of string
+  | UnaryPlusPrefix of string
+  | UnaryMinusPrefix of string
+  | UnaryNotPrefix of string
+  | UnaryPostfix of string
+  | Infix of string
+  | Normal
+
+(* Type which represents a resolvedRule's InfixTree flattened *)
+type infixChain =
+  | InfixToken of string
+  | Layout of Layout.t
+
+(* Helpers for dealing with extension nodes (%expr) *)
+
+let expression_extension_sugar x =
+  if x.pexp_attributes != [] then None
+  else match x.pexp_desc with
+    | Pexp_extension (name, PStr [{pstr_desc = Pstr_eval(expr, [])}])
+      when name.txt <> "bs.obj" ->
+      Some (name, expr)
+    | _ -> None
+
+let expression_immediate_extension_sugar x =
+  match expression_extension_sugar x with
+  | None -> (None, x)
+  | Some (name, expr) ->
+    match expr.pexp_desc with
+    | Pexp_for _ | Pexp_while _ | Pexp_ifthenelse _
+    | Pexp_function _ | Pexp_newtype _
+    | Pexp_try _ | Pexp_match _ ->
+      (Some name, expr)
+    | _ -> (None, x)
+
+let expression_not_immediate_extension_sugar x =
+  match expression_immediate_extension_sugar x with
+  | (Some _, _) -> None
+  | (None, _) -> expression_extension_sugar x
+
+let add_extension_sugar keyword = function
+  | None -> keyword
+  | Some str -> keyword ^ "%" ^ str.txt
+
+let string_equal : string -> string -> bool = (=)
+
+let longident_same l1 l2 =
+  let rec equal l1 l2 =
+    match l1, l2 with
+    | Lident l1, Lident l2 -> string_equal l1 l2
+    | Ldot (path1, l1), Ldot (path2, l2) ->
+      equal path1 path2 && string_equal l1 l2
+    | Lapply (l11, l12), Lapply (l21, l22) ->
+      equal l11 l21 && equal l12 l22
+    | _ -> false
+  in
+  equal l1.txt l2.txt
+
+(* A variant of List.for_all2 that returns false instead of failing on lists
+   of different size *)
+let for_all2' pred l1 l2 =
+  List.length l1 = List.length l2 &&
+  List.for_all2 pred l1 l2
+
+(*
+   Checks to see if two types are the same modulo the process of varification
+   which turns abstract types into type variables of the same name.
+   For example, [same_ast_modulo_varification] would consider (a => b) and ('a
+   => 'b) to have the same ast. This is useful in recovering syntactic sugar
+   for explicit polymorphic types with locally abstract types.
+
+   Does not compare attributes, or extensions intentionally.
+
+   TODO: This has one more issue: We need to compare only accepting t1's type
+   variables, to be considered compatible with t2's type constructors - not the
+   other way around.
+ *)
+let same_ast_modulo_varification_and_extensions t1 t2 =
+  let rec loop t1 t2 = match (t1.ptyp_desc, t2.ptyp_desc) with
+    (* Importantly, cover the case where type constructors (of the form [a])
+       are converted to type vars of the form ['a].
+     *)
+    | (Ptyp_constr({txt=Lident s1}, []), Ptyp_var s2) -> string_equal s1 s2
+    (* Now cover the case where type variables (of the form ['a]) are
+       converted to type constructors of the form [a].
+     *)
+    | (Ptyp_var s1, Ptyp_constr({txt=Lident s2}, [])) -> string_equal s1 s2
+    (* Now cover the typical case *)
+    | (Ptyp_constr(longident1, lst1), Ptyp_constr(longident2, lst2))  ->
+      longident_same longident1 longident2 &&
+      for_all2' loop lst1 lst2
+    | (Ptyp_any, Ptyp_any) -> true
+    | (Ptyp_var x1, Ptyp_var x2) -> string_equal x1 x2
+    | (Ptyp_arrow (label1, core_type1, core_type1'), Ptyp_arrow (label2, core_type2, core_type2')) ->
+      begin
+         match label1, label2 with
+         | Nolabel, Nolabel -> true
+         | Labelled s1, Labelled s2 -> string_equal s1 s2
+         | Optional s1, Optional s2 -> string_equal s1 s2
+         | _ -> false
+      end &&
+      loop core_type1 core_type2 &&
+      loop core_type1' core_type2'
+    | (Ptyp_tuple lst1, Ptyp_tuple lst2) -> for_all2' loop lst1 lst2
+    | (Ptyp_object (lst1, o1), Ptyp_object (lst2, o2)) ->
+      let tester = fun (s1, _, t1) (s2, _, t2) ->
+        string_equal s1 s2 &&
+        loop t1 t2
+      in
+      for_all2' tester lst1 lst2 && o1 = o2
+    | (Ptyp_class (longident1, lst1), Ptyp_class (longident2, lst2)) ->
+      longident_same longident1 longident2 &&
+      for_all2' loop lst1 lst2
+    | (Ptyp_alias(core_type1, string1), Ptyp_alias(core_type2, string2)) ->
+      loop core_type1 core_type2 &&
+      string_equal string1 string2
+    | (Ptyp_variant(row_field_list1, flag1, lbl_lst_option1), Ptyp_variant(row_field_list2, flag2, lbl_lst_option2)) ->
+      for_all2' rowFieldEqual row_field_list1 row_field_list2 &&
+      flag1 = flag2 &&
+      lbl_lst_option1 = lbl_lst_option2
+    | (Ptyp_poly (string_lst1, core_type1), Ptyp_poly (string_lst2, core_type2))->
+      for_all2' string_equal string_lst1 string_lst2 &&
+      loop core_type1 core_type2
+    | (Ptyp_package(longident1, lst1), Ptyp_package (longident2, lst2)) ->
+      longident_same longident1 longident2 &&
+      for_all2' testPackageType lst1 lst2
+    | (Ptyp_extension (s1, _), Ptyp_extension (s2, _)) ->
+      string_equal s1.txt s2.txt
+    | _ -> false
+  and testPackageType (lblLongIdent1, ct1) (lblLongIdent2, ct2) =
+    longident_same lblLongIdent1 lblLongIdent2 &&
+    loop ct1 ct2
+  and rowFieldEqual f1 f2 = match (f1, f2) with
+    | ((Rtag(label1, _, flag1, lst1)), (Rtag (label2, _, flag2, lst2))) ->
+      string_equal label1 label2 &&
+      flag1 = flag2 &&
+      for_all2' loop lst1 lst2
+    | (Rinherit t1, Rinherit t2) -> loop t1 t2
+    | _ -> false
+  in
+  loop t1 t2
+
+let expandLocation pos ~expand:(startPos, endPos) =
+  { pos with
+    loc_start = {
+      pos.loc_start with
+        Lexing.pos_cnum = pos.loc_start.Lexing.pos_cnum + startPos
+    };
+    loc_end = {
+      pos.loc_end with
+        Lexing.pos_cnum = pos.loc_end.Lexing.pos_cnum + endPos
+    }
+  }
+
+(* Computes the location of the attribute with the lowest line number
+ * that isn't ghost. Useful to determine the start location of an item
+ * in the parsetree that has attributes.
+ * If there are no valid attributes, defaults to the passed location.
+ * 1| [@attr]           --> notice how the "start" is determined
+ * 2| let f = ...           by the attr on line 1, not the lnum of the `let`
+ *)
+let rec firstAttrLoc loc = function
+  | ((attrLoc, _) : Ast_404.Parsetree.attribute) ::attrs ->
+      if attrLoc.loc.loc_start.pos_lnum < loc.loc_start.pos_lnum
+         && not attrLoc.loc.loc_ghost
+      then
+        firstAttrLoc attrLoc.loc attrs
+      else
+        firstAttrLoc loc attrs
+  | [] -> loc
+
+let extractLocationFromValBindList expr vbs =
+  let rec extract loc = function
+    | x::xs ->
+        let {pvb_expr} = x in
+        let loc = {loc with loc_end = pvb_expr.pexp_loc.loc_end} in
+        extract loc xs
+    | [] -> loc
+  in
+  let loc = match vbs with
+    | x::xs ->
+        let {pvb_pat; pvb_expr} = x in
+        let loc = {pvb_pat.ppat_loc with loc_end = pvb_expr.pexp_loc.loc_end} in
+        extract loc xs
+    | [] -> expr.pexp_loc
+  in
+  { loc with loc_start = expr.pexp_loc.loc_start }
+
+let extractLocValBinding {pvb_pat; pvb_expr; pvb_attributes;} =
+  let estimatedLoc = firstAttrLoc pvb_pat.ppat_loc pvb_attributes in
+  {estimatedLoc with loc_end = pvb_expr.pexp_loc.loc_end}
+
+let extractLocModuleBinding {pmb_expr; pmb_attributes} =
+  let estimatedLoc = firstAttrLoc pmb_expr.pmod_loc pmb_attributes in
+  {estimatedLoc with loc_end = pmb_expr.pmod_loc.loc_end}
+
+let extractLocModDecl {pmd_type; pmd_attributes} =
+  let estimatedLoc = firstAttrLoc pmd_type.pmty_loc pmd_attributes in
+  {estimatedLoc with loc_end = pmd_type.pmty_loc.loc_end}
+
+let rec sequentialIfBlocks x =
+  match x with
+    | Some ({pexp_desc=Pexp_ifthenelse (e1, e2, els)}) -> (
+       let (nestedIfs, finalExpression) = (sequentialIfBlocks els) in
+       ((e1, e2)::nestedIfs, finalExpression)
+      )
+    | Some e -> ([], Some e)
+    | None -> ([], None)
+
+(*
+  TODO: IDE integration beginning with Vim:
+
+  - Create recovering version of parser that creates regions of "unknown"
+    content in between let sequence bindings (anything between semicolons,
+    really).
+  - Use Easy_format's "style" features to tag each known node.
+  - Turn those style annotations into editor highlight commands.
+  - Editors have a set of keys that retrigger the parsing/rehighlighting
+    process (typically newline/semi/close-brace).
+  - On every parsing/rehighlighting, this pretty printer can be used to
+    determine the highlighting of recovered regions, and the editor plugin can
+    relegate highlighting of malformed regions to the editor which mostly does
+    so based on token patterns.
+
+*)
+
+(*
+     @avoidSingleTokenWrapping
+
+  +-----------------------------+
+  |+------+                     |     Another label
+  || let ( \                    |
+  ||    a  | Label              |
+  ||    o  |                    |     The thing to the right of any label must be a
+  ||    p _+ label RHS          |     list in order for it to wrap correctly. Lists
+  ||  ): /   v                  |     will wrap if they need to/can. NON-lists will
+  |+--+ sixteenTuple = echoTuple|(    wrap (indented) even though they're no lists!
+  +---/ 0,\---------------------+     To prevent a single item from wrapping, make
+        0,                            an unbreakable list via ensureSingleTokenSticksToLabel.
+        0
+      );                              In general, the best approach for indenting
+                                      let bindings is to keep building up labels from
+                                      the "let", always ensuring things that you want
+                                      to wrap will either be lists or guarded in
+                                      [ensureSingleTokenSticksToLabel].
+                                      If you must join several lists together (via =)
+                                      (or colon), ensure that joining is done via
+                                      [makeList] (which won't break), and that new
+                                      list is always appended to the left
+                                      hand side of the label. (So that the right hand
+                                      side may always be the untouched list that you want
+                                      to wrap with aligned closing).
+                                      Always make sure rhs of the label are the
+
+                                      Creating nested labels will preserve the original
+                                      indent location ("let" in this
+                                      case) as long as that nesting is
+                                      done on the left hand side of the labels.
+
+*)
+
+(*
+    Table 2.1. Precedence and associativity.
+    Precedence from highest to lowest: From RWOC, modified to include !=
+    ---------------------------------------
+
+    Operator prefix	Associativity
+    !..., ?..., ~...	                              Prefix
+    ., .(, .[	-
+    function application, constructor, assert, lazy	Left associative
+    -, -.                                           Prefix
+    **..., lsl, lsr, asr                            Right associative
+    *..., /..., %..., mod, land, lor, lxor          Left associative
+    +..., -...                                      Left associative
+    ::                                              Right associative
+    @..., ^...                                      Right associative
+---
+    !=                                              Left associative (INFIXOP0 listed first in lexer)
+    =..., <..., >..., |..., &..., $...              Left associative (INFIXOP0)
+    =, <, >                                         Left associative (IN SAME row as INFIXOP0 listed after)
+---
+    &, &&                                           Right associative
+    or, ||                                          Right associative
+    ,                                               -
+    :=, =                                         	Right associative
+    if                                              -
+    ;                                               Right associative
+
+
+   Note: It would be much better if &... and |... were in separate precedence
+   groups just as & and | are. This way, we could encourage custom infix
+   operators to use one of the two precedences and no one would be confused as
+   to precedence (leading &, | are intuitive). Two precedence classes for the
+   majority of infix operators is totally sufficient.
+
+   TODO: Free up the (&) operator from pervasives so it can be reused for
+   something very common such as string concatenation or list appending.
+
+   let x = tail & head;
+ *)
+
+(* "Almost Simple Prefix" function applications parse with the rule:
+
+   `PREFIXOP simple_expr %prec below_DOT_AND_SHARP`, which in turn is almost
+   considered a "simple expression" (it's acceptable anywhere a simple
+   expression is except in a couple of edge cases.
+
+   "Unary Prefix" function applications parse with the rule:
+
+   `MINUS epxr %prec prec_unary_minus`, which in turn is considered an
+   "expression" (not simple). All unary operators are mapped into an identifier
+   beginning with "~".
+
+   TODO: Migrate all "almost simple prefix" to "unsary prefix". When `!`
+   becomes "not", then it will make more sense that !myFunc (arg) is parsed as
+   !(myFunc arg) instead of (!myFunc) arg.
+
+ *)
+let almost_simple_prefix_symbols  = [ '!'; '?'; '~'] ;;
+(* Subset of prefix symbols that have special "unary precedence" *)
+let unary_minus_prefix_symbols  = [ "~-"; "~-."] ;;
+let unary_plus_prefix_symbols  = ["~+"; "~+." ] ;;
+let infix_symbols = [ '='; '<'; '>'; '@'; '^'; '|'; '&'; '+'; '-'; '*'; '/';
+                      '$'; '%'; '\\'; '#' ]
+
+let special_infix_strings =
+  ["asr"; "land"; "lor"; "lsl"; "lsr"; "lxor"; "mod"; "or"; ":="; "!="; "!=="]
+
+let updateToken = "="
+let sharpOpEqualToken = "#="
+let pipeFirstToken = "->"
+let requireIndentFor = [updateToken; ":="]
+
+let namedArgSym = "~"
+
+let requireNoSpaceFor tok =
+  tok = pipeFirstToken || (tok.[0] = '#' && tok <> "#=")
+
+let funToken = "fun"
+
+let getPrintableUnaryIdent s =
+  if List.mem s unary_minus_prefix_symbols ||
+     List.mem s unary_plus_prefix_symbols
+  then String.sub s 1 (String.length s -1)
+  else s
+
+(* determines if the string is an infix string.
+   checks backwards, first allowing a renaming postfix ("_102") which
+   may have resulted from Pexp -> Texp -> Pexp translation, then checking
+   if all the characters in the beginning of the string are valid infix
+   characters. *)
+let printedStringAndFixity = function
+  | s when List.mem s special_infix_strings -> Infix s
+  | "^" -> UnaryPostfix "^"
+  | s when List.mem s.[0] infix_symbols -> Infix s
+  (* Correctness under assumption that unary operators are stored in AST with
+     leading "~" *)
+  | s when List.mem s.[0] almost_simple_prefix_symbols &&
+           not (List.mem s special_infix_strings) &&
+           not (s = "?") -> (
+      (* What *kind* of prefix fixity? *)
+      if List.mem s unary_plus_prefix_symbols then
+        UnaryPlusPrefix (getPrintableUnaryIdent s)
+      else if List.mem s unary_minus_prefix_symbols then
+        UnaryMinusPrefix (getPrintableUnaryIdent s)
+      else if s = "!" then
+        UnaryNotPrefix s
+      else
+        AlmostSimplePrefix s
+  )
+  | _ -> Normal
+
+
+(* Also, this doesn't account for != and !== being infixop!!! *)
+let isSimplePrefixToken s = match printedStringAndFixity s with
+  | AlmostSimplePrefix _ | UnaryPostfix "^" -> true
+  | _ -> false
+
+
+(* Convenient bank of information that represents the parser's precedence
+   rankings.  Each instance describes a precedence table entry. The function
+   tests either a token string encountered by the parser, or (in the case of
+   `CustomPrecedence`) the string name of a custom rule precedence declared
+   using %prec *)
+let rules = [
+  [
+    (TokenPrecedence, (fun s -> (Left, s = pipeFirstToken)));
+    (TokenPrecedence, (fun s -> (Left, s.[0] = '#' &&
+                                       s <> sharpOpEqualToken &&
+                                       s <> "#")));
+    (TokenPrecedence, (fun s -> (Left, s = ".")));
+    (CustomPrecedence, (fun s -> (Left, s = "prec_lbracket")));
+  ];
+  [
+    (CustomPrecedence, (fun s -> (Nonassoc, s = "prec_functionAppl")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, isSimplePrefixToken s)));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Left, s = sharpOpEqualToken)));
+  ];
+  [
+    (CustomPrecedence, (fun s -> (Nonassoc, s = "prec_unary")));
+  ];
+  (* Note the special case for "*\*", BARBAR, and LESSMINUS, AMPERSAND(s) *)
+  [
+    (TokenPrecedence, (fun s -> (Right, s = "**")));
+    (TokenPrecedence, (fun s -> (Right, String.length s > 1 && s.[0] == '*' && s.[1] == '\\' && s.[2] == '*')));
+    (TokenPrecedence, (fun s -> (Right, s = "lsl")));
+    (TokenPrecedence, (fun s -> (Right, s = "lsr")));
+    (TokenPrecedence, (fun s -> (Right, s = "asr")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '*' && (String.length s == 1 || s != "*\\*"))));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '/')));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '%' )));
+    (TokenPrecedence, (fun s -> (Left, s = "mod" )));
+    (TokenPrecedence, (fun s -> (Left, s = "land" )));
+    (TokenPrecedence, (fun s -> (Left, s = "lor" )));
+    (TokenPrecedence, (fun s -> (Left, s = "lxor" )));
+  ];
+  [
+    (* Even though these use the same *tokens* as unary plus/minus at parse
+       time, when unparsing infix -/+, the CustomPrecedence rule would be
+       incorrect to use, and instead we need a rule that models what infix
+       parsing would use - just the regular token precedence without a custom
+       precedence. *)
+    (TokenPrecedence,
+    (fun s -> (
+      Left,
+      if String.length s > 1 && s.[0] == '+' && s.[1] == '+' then
+        (*
+          Explicitly call this out as false because the other ++ case below
+          should have higher *lexing* priority. ++operator_chars* is considered an
+          entirely different token than +(non_plus_operator_chars)*
+        *)
+        false
+      else
+        s.[0] == '+'
+    )));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '-' && s <> pipeFirstToken)));
+    (TokenPrecedence, (fun s -> (Left, s = "!" )));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s = "::")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s.[0] == '@')));
+    (TokenPrecedence, (fun s -> (Right, s.[0] == '^')));
+    (TokenPrecedence, (fun s -> (Right, String.length s > 1 && s.[0] == '+' && s.[1] == '+')));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '=' && not (s = "=") && not (s = "=>"))));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '<' && not (s = "<"))));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '>' && not (s = ">"))));
+    (TokenPrecedence, (fun s -> (Left, s = "!=")));  (* Not preset in the RWO table! *)
+    (TokenPrecedence, (fun s -> (Left, s = "!==")));  (* Not preset in the RWO table! *)
+    (TokenPrecedence, (fun s -> (Left, s = "==")));
+    (TokenPrecedence, (fun s -> (Left, s = "===")));
+    (TokenPrecedence, (fun s -> (Left, s = "<")));
+    (TokenPrecedence, (fun s -> (Left, s = ">")));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '|' && not (s = "||"))));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '&' && not (s = "&") && not (s = "&&"))));
+    (TokenPrecedence, (fun s -> (Left, s.[0] == '$')));
+  ];
+  [
+    (CustomPrecedence, (fun s -> (Left, s = funToken)));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s = "&")));
+    (TokenPrecedence, (fun s -> (Right, s = "&&")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s = "or")));
+    (TokenPrecedence, (fun s -> (Right, s = "||")));
+  ];
+  [
+    (* The Left shouldn't ever matter in practice. Should never get in a
+       situation with two consecutive infix ? - the colon saves us. *)
+    (TokenPrecedence, (fun s -> (Left, s = "?")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s = ":=")));
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Right, s = updateToken)));
+  ];
+  (* It's important to account for ternary ":" being lower precedence than "?" *)
+  [
+    (TokenPrecedence, (fun s -> (Right, s = ":")))
+  ];
+  [
+    (TokenPrecedence, (fun s -> (Nonassoc, s = "=>")));
+  ];
+]
+
+(* remove all prefixing backslashes, e.g. \=== becomes === *)
+let without_prefixed_backslashes str =
+  if str = "" then str
+  else if String.get str 0 = '\\' then String.sub str 1 (String.length str - 1)
+  else str
+
+let indexOfFirstMatch ~prec lst =
+  let rec aux n = function
+    | [] -> None
+    | [] :: tl -> aux (n + 1) tl
+    | ((kind, tester) :: hdTl) :: tl ->
+      match prec, kind with
+      | Token str, TokenPrecedence | Custom str, CustomPrecedence ->
+        let associativity, foundMatch = tester str in
+        if foundMatch
+        then Some (associativity, n)
+        else aux n (hdTl::tl)
+      | _ -> aux n (hdTl::tl)
+  in
+  aux 0 lst
+
+(* Assuming it's an infix function application. *)
+let precedenceInfo ~prec =
+  (* Removes prefixed backslashes in order to do proper conversion *)
+  let prec = match prec with
+    | Token str -> Token (without_prefixed_backslashes str)
+    | Custom _ -> prec
+  in
+  indexOfFirstMatch ~prec rules
+
+let isLeftAssociative ~prec = match precedenceInfo ~prec with
+  | None -> false
+  | Some (Left, _) -> true
+  | Some (Right, _) -> false
+  | Some (Nonassoc, _) -> false
+
+let isRightAssociative ~prec = match precedenceInfo ~prec with
+  | None -> false
+  | Some (Right, _) -> true
+  | Some (Left, _) -> false
+  | Some (Nonassoc, _) -> false
+
+let higherPrecedenceThan c1 c2 =
+  match ((precedenceInfo ~prec:c1), (precedenceInfo ~prec:c2)) with
+  | (_, None)
+  | (None, _) ->
+    let (str1, str2) = match (c1, c2) with
+      | (Token s1, Token s2) -> ("Token " ^ s1, "Token " ^ s2)
+      | (Token s1, Custom s2) -> ("Token " ^ s1, "Custom " ^ s2)
+      | (Custom s1, Token s2) -> ("Custom " ^ s1, "Token " ^ s2)
+      | (Custom s1, Custom s2) -> ("Custom " ^ s1, "Custom " ^ s2)
+    in
+    raise (NotPossible ("Cannot determine precedence of two checks " ^ str1 ^ " vs. " ^ str2))
+  | (Some (_, p1), Some (_, p2)) -> p1 < p2
+
+let printedStringAndFixityExpr = function
+  | {pexp_desc = Pexp_ident {txt=Lident l}} -> printedStringAndFixity l
+  | _ -> Normal
+
+(* which identifiers are in fact operators needing parentheses *)
+let needs_parens txt =
+  match printedStringAndFixity txt with
+  | Infix _ -> true
+  | UnaryPostfix _ -> true
+  | UnaryPlusPrefix _ -> true
+  | UnaryMinusPrefix _ -> true
+  | UnaryNotPrefix _ -> true
+  | AlmostSimplePrefix _ -> true
+  | Normal -> false
+
+(* some infixes need spaces around parens to avoid clashes with comment
+   syntax. This isn't needed for comment syntax /* */ *)
+let needs_spaces txt =
+  txt.[0]='*' || txt.[String.length txt - 1] = '*'
+
+let rec orList = function (* only consider ((A|B)|C)*)
+  | {ppat_desc = Ppat_or (p1, p2)} -> (orList p1) @ (orList p2)
+  | x -> [x]
+
+let override = function
+  | Override -> "!"
+  | Fresh -> ""
+
+(* variance encoding: need to sync up with the [parser.mly] *)
+let type_variance = function
+  | Invariant -> ""
+  | Covariant -> "+"
+  | Contravariant -> "-"
+
+type construct =
+  [ `cons of expression list
+  | `list of expression list
+  | `nil
+  | `normal
+  | `simple of Longident.t
+  | `tuple ]
+
+let view_expr x =
+  match x.pexp_desc with
+  | Pexp_construct ( {txt= Lident "()"},_) -> `tuple
+  | Pexp_construct ( {txt= Lident "[]"},_) -> `nil
+  | Pexp_construct ( {txt= Lident"::"},Some _) ->
+    let rec loop exp acc = match exp with
+      | {pexp_desc=Pexp_construct ({txt=Lident "[]"},_)} ->
+        (List.rev acc,true)
+      | {pexp_desc=
+          Pexp_construct ({txt=Lident "::"},
+                           Some ({pexp_desc= Pexp_tuple([e1;e2])}))} ->
+        loop e2 (e1::acc)
+      | e -> (List.rev (e::acc),false) in
+    let (ls,b) = loop x []  in
+    if b
+    then `list ls
+    else `cons ls
+  | Pexp_construct (x,None) -> `simple x.txt
+  | _ -> `normal
+
+let is_simple_list_expr x =
+  match view_expr x with
+  | `list _ | `cons _ -> true
+  | _ -> false
+
+let is_simple_construct : construct -> bool = function
+  | `nil | `tuple | `list _ | `simple _ | `cons _  -> true
+  | `normal -> false
+
+let uncurriedTable = Hashtbl.create 42
+
+(* Determines if a list of expressions contains a single unit construct
+ * e.g. used to check: MyConstructor() -> exprList == [()]
+ * useful to determine if MyConstructor(()) should be printed as MyConstructor()
+ * *)
+let is_single_unit_construct exprList =
+  match exprList with
+  | x::[] ->
+    let view = view_expr x in
+    (match view with
+    | `tuple -> true
+    | _ -> false)
+  | _ -> false
+
+let detectTernary l = match l with
+  | [{
+      pc_lhs={ppat_desc=Ppat_construct ({txt=Lident "true"}, _)};
+      pc_guard=None;
+      pc_rhs=ifTrue
+    };
+    {
+      pc_lhs={ppat_desc=Ppat_construct ({txt=Lident "false"}, _)};
+      pc_guard=None;
+      pc_rhs=ifFalse
+    }] -> Some (ifTrue, ifFalse)
+  | _ -> None
+type funcApplicationLabelStyle =
+  (* No attaching to the label, but if the entire application fits on one line,
+     the entire application will appear next to the label as you 'd expect. *)
+  | NeverWrapFinalItem
+  (* Attach the first term if there are exactly two terms involved in the
+     application.
+
+     let x = firstTerm (secondTerm_1 secondTerm_2) thirdTerm;
+
+     Ideally, we'd be able to attach all but the last argument into the label any
+     time all but the last term will fit - and *not* when (attaching all but
+     the last term isn't enough to prevent a wrap) - But there's no way to tell
+     ahead of time if it would prevent a wrap.
+
+     However, the number two is somewhat convenient. This models the
+     indentation that you'd prefer in non-curried syntax languages like
+     JavaScript, where application only ever has two terms.
+  *)
+  | WrapFinalListyItemIfFewerThan of int
+
+type formatSettings = {
+  (* Whether or not to expect that the original parser that generated the AST
+     would have annotated constructor argument tuples with explicit arity to
+     indicate that they are multiple arguments. (True if parsed in original
+     OCaml AST, false if using Reason parser).
+  *)
+  constructorTupleImplicitArity: bool;
+  space: int;
+
+  (* For curried arguments in function *definitions* only: Number of [space]s
+     to offset beyond the [let] keyword. Default 1.
+  *)
+  listsRecordsIndent: int;
+
+  indentWrappedPatternArgs: int;
+
+  indentMatchCases: int;
+
+  (* Amount to indent in label-like constructs such as wrapped function
+     applications, etc - or even record fields. This is not the same concept as an
+     indented curried argument list. *)
+  indentAfterLabels: int;
+
+  (* Amount to indent after the opening brace of switch/try.
+     Here's an example of what it would look like w/ [trySwitchIndent = 2]:
+     Sticks the expression to the last item in a sequence in several [X | Y | Z
+     => expr], and forces X, Y, Z to be split onto several lines. (Otherwise,
+     sticking to Z would result in hanging expressions).  TODO: In the first case,
+     it's clear that we want patterns to have an "extra" indentation with matching
+     in a "match". Create extra config param to pass to [self#pattern] for extra
+     indentation in this one case.
+
+      switch x {
+      | TwoCombos
+          (HeresTwoConstructorArguments x y)
+          (HeresTwoConstructorArguments a b) =>
+          ((a + b) + x) + y;
+      | Short
+      | AlsoHasARecord a b {x, y} => (
+          retOne,
+          retTwo
+        )
+      | AlsoHasARecord a b {x, y} =>
+        callMyFunction
+          withArg
+          withArg
+          withArg
+          withArg;
+      }
+  *)
+  trySwitchIndent: int;
+
+
+  (* In the case of two term function application (when flattened), the first
+     term should become part of the label, and the second term should be able to wrap
+     This doesn't effect n != 2.
+
+       [true]
+       let x = reallyShort allFitsOnOneLine;
+       let x = someFunction {
+         reallyLongObject: true,
+         thatWouldntFitOnThe: true,
+         firstLine: true
+       };
+
+       [false]
+       let x = reallyShort allFitsOnOneLine;
+       let x =
+        someFunction
+          {
+            reallyLongObject: true,
+            thatWouldntFitOnThe: true,
+            firstLine: true
+          };
+  *)
+  funcApplicationLabelStyle: funcApplicationLabelStyle;
+
+  funcCurriedPatternStyle: funcApplicationLabelStyle;
+
+  width: int;
+
+  assumeExplicitArity: bool;
+
+  constructorLists: string list;
+}
+
+let defaultSettings = {
+  constructorTupleImplicitArity = false;
+  space = 1;
+  listsRecordsIndent = 2;
+  indentWrappedPatternArgs = 2;
+  indentMatchCases = 2;
+  indentAfterLabels = 2;
+  trySwitchIndent = 0;
+  funcApplicationLabelStyle = WrapFinalListyItemIfFewerThan 3;
+  (* WrapFinalListyItemIfFewerThan is currently a bad idea for curried
+     arguments: It looks great in some cases:
+
+        let myFun (a:int) :(
+          int,
+          string
+        ) => (a, "this is a");
+
+     But horrible in others:
+
+        let myFun
+            {
+              myField,
+              yourField
+            } :someReturnType => myField + yourField;
+
+        let myFun
+            {            // Curried arg wraps
+              myField,
+              yourField
+            } : (       // But the last is "listy" so it docks
+          int,          // To the [let].
+          int,
+          int
+        ) => myField + yourField;
+
+     We probably want some special listy label docking/wrapping mode for
+     curried function bindings.
+
+  *)
+  funcCurriedPatternStyle = NeverWrapFinalItem;
+  width = 80;
+  assumeExplicitArity = false;
+  constructorLists = [];
+}
+let configuredSettings = ref defaultSettings
+
+let configure ~width ~assumeExplicitArity ~constructorLists = (
+  configuredSettings := {defaultSettings with width; assumeExplicitArity; constructorLists}
+)
+
+let createFormatter () =
+let module Formatter = struct
+
+let settings = !configuredSettings
+
+
+(* How do we make
+   this a label?
+
+   /---------------------\
+   let myVal = (oneThing, {
+   field: [],
+   anotherField: blah
+   });
+
+   But in this case, this wider region a label?
+   /------------------------------------------------------\
+   let myVal = callSomeFunc (oneThing, {field: [], anotherField: blah}, {
+   boo: 'hi'
+   });
+
+   This is difficult. You must form a label from the preorder traversal of every
+   node - except the last encountered in the traversal. An easier heuristic is:
+
+   - The last argument to a functor application is expanded.
+
+   React.CreateClass SomeThing {
+   let render {props} => {
+   };
+   }
+
+   - The last argument to a function application is expanded on the same line.
+   - Only if it's not curried with another invocation.
+   -- Optionally: "only if everything else is an atom"
+   -- Optionally: "only if there are no other args"
+
+   React.createClass someThing {
+   render: fn x => y,
+   }
+
+   !!! NOT THIS
+   React.createClass someThing {
+   render: fn x => y,
+   }
+   somethingElse
+*)
+
+let isArityClear attrs =
+  (!configuredSettings).assumeExplicitArity ||
+  List.exists
+    (function
+      | ({txt="explicit_arity"}, _) -> true
+      | _ -> false
+    )
+    attrs
+
+let default_indent_body =
+  settings.listsRecordsIndent * settings.space
+
+let makeList
+    ?listConfigIfCommentsInterleaved
+    ?listConfigIfEolCommentsInterleaved
+    ?(break=Layout.Never)
+    ?(wrap=("", ""))
+    ?(inline=(true, false))
+    ?(sep=Layout.NoSep)
+    ?(indent=default_indent_body)
+    ?(sepLeft=true)
+    ?(preSpace=false)
+    ?(postSpace=false)
+    ?(pad=(false,false))
+    lst =
+  let config =
+    { Layout.
+      listConfigIfCommentsInterleaved; listConfigIfEolCommentsInterleaved;
+      break; wrap; inline; sep; indent; sepLeft; preSpace; postSpace; pad;
+    }
+  in
+  Layout.Sequence (config, lst)
+
+let makeAppList = function
+  | [hd] -> hd
+  | l -> makeList ~inline:(true, true) ~postSpace:true ~break:IfNeed l
+
+let makeTup ?(wrap=("", ""))?(trailComma=true) ?(uncurried = false) l =
+  let (lwrap, rwrap) = wrap in
+  let lparen = lwrap ^ (if uncurried then "(. " else "(") in
+  makeList
+    ~wrap:(lparen, ")" ^ rwrap)
+    ~sep:(if trailComma then commaTrail else commaSep)
+    ~postSpace:true
+    ~break:IfNeed l
+
+let ensureSingleTokenSticksToLabel x =
+  let listConfigIfCommentsInterleaved cfg =
+    let inline = (true, true) and postSpace = true and indent = 0 in
+    {cfg with Layout.break=Always_rec; postSpace; indent; inline}
+  in
+  makeList ~listConfigIfCommentsInterleaved [x]
+
+let unbreakLabelFormatter formatter =
+  let newFormatter labelTerm term =
+    match formatter labelTerm term with
+    | Easy_format.Label ((labelTerm, settings), term) ->
+       Easy_format.Label ((labelTerm,
+                           {settings with label_break = `Never}),
+                          term)
+    | _ -> failwith "not a label"
+  in newFormatter
+
+let inlineLabel labelTerm term =
+  let settings = {
+    label_break = `Never;
+    space_after_label = true;
+    indent_after_label = 0;
+    label_style = Some "inlineLabel";
+  } in
+  Easy_format.Label ((labelTerm, settings), term)
+
+
+(* Just for debugging: Set debugWithHtml = true *)
+let debugWithHtml = ref false
+
+let html_escape_string s =
+  let buf = Buffer.create (2 * String.length s) in
+  for i = 0 to String.length s - 1 do
+    match s.[i] with
+        '&' -> Buffer.add_string buf "&amp;"
+      | '<' -> Buffer.add_string buf "&lt;"
+      | '>' -> Buffer.add_string buf "&gt;"
+      | c -> Buffer.add_char buf c
+  done;
+  Buffer.contents buf
+
+let html_escape = `Escape_string html_escape_string
+
+let html_style = [
+  "atom", { Easy_format.tag_open = "<a>"; tag_close = "</a>" };
+  "body", { tag_open = "<lb>"; tag_close = "</lb>" };
+  "list", { tag_open = "<l>"; tag_close = "</l>" };
+  "op", { tag_open = "<op>"; tag_close = "</op>" };
+  "cl", { tag_open = "<cl>"; tag_close = "</cl>" };
+  "sep", { tag_open = "<sep>"; tag_close = "</sep>" };
+  "label", { tag_open = "<la>"; tag_close = "</la>" };
+]
+
+let easyLabel
+    ?(break=`Auto) ?(space=false) ?(indent=settings.indentAfterLabels)
+    labelTerm term =
+  let settings = {
+    label_break = break;
+    space_after_label = space;
+    indent_after_label = indent;
+    label_style = Some "label";
+  } in
+  Easy_format.Label ((labelTerm, settings), term)
+
+let label ?break ?space ?indent (labelTerm:Layout.t) (term:Layout.t) =
+  Layout.Label (easyLabel ?break ?indent ?space, labelTerm, term)
+
+let atom ?loc str =
+  let style = { Easy_format.atom_style = Some "atomClss" } in
+  source_map ?loc (Layout.Easy (Easy_format.Atom(str, style)))
+
+(** Take x,y,z and n and generate [x, y, z, ...n] *)
+let makeES6List ?wrap:((lwrap,rwrap)=("", "")) lst last =
+  makeList
+    ~wrap:(lwrap ^ "[", "]" ^ rwrap)
+    ~break:IfNeed ~postSpace:true ~sep:commaTrail
+    (lst @ [makeList [atom "..."; last]])
+
+let makeNonIndentedBreakingList lst =
+    (* No align closing: So that semis stick to the ends of every break *)
+  makeList ~break:Always_rec ~indent:0 ~inline:(true, true) lst
+
+(* Like a <span> could place with other breakableInline lists without upsetting final semicolons *)
+let makeSpacedBreakableInlineList lst =
+  makeList ~break:IfNeed ~inline:(true, true) ~postSpace:true lst
+
+let makeCommaBreakableListSurround opn cls lst =
+  makeList ~break:IfNeed ~postSpace:true ~sep:(Sep ",") ~wrap:(opn, cls) lst
+
+(* TODO: Allow configuration of spacing around colon symbol *)
+
+let formatPrecedence ?(inline=false) ?(wrap=("(", ")")) ?loc formattedTerm =
+  source_map ?loc (makeList ~inline:(true, inline) ~wrap ~break:IfNeed [formattedTerm])
+
+let wrap fn term =
+  ignore (Format.flush_str_formatter ());
+  fn Format.str_formatter term;
+  atom (Format.flush_str_formatter ())
+
+(* Don't use `trim` since it kills line return too? *)
+let rec beginsWithStar_ line length idx =
+  if idx = length then false else
+    match String.get line idx with
+    | '*' -> true
+    | '\t' | ' ' -> beginsWithStar_ line length (idx + 1)
+    | _ -> false
+
+let beginsWithStar line = beginsWithStar_ line (String.length line) 0
+
+let rec numLeadingSpace_ line length idx accum =
+  if idx = length then accum else
+    match String.get line idx with
+    | '\t' | ' ' -> numLeadingSpace_ line length (idx + 1) (accum + 1)
+    | _ -> accum
+
+let numLeadingSpace line = numLeadingSpace_ line (String.length line) 0 0
+
+(* Computes the smallest leading spaces for non-empty lines *)
+let smallestLeadingSpaces strs =
+  let rec smallestLeadingSpaces curMin strs = match strs with
+    | [] -> curMin
+    | ""::tl -> smallestLeadingSpaces curMin tl
+    | hd::tl ->
+      let leadingSpace = numLeadingSpace hd in
+      let nextMin = min curMin leadingSpace in
+      smallestLeadingSpaces nextMin tl
+  in
+  smallestLeadingSpaces 99999 strs
+
+let rec isSequencey = function
+  | Layout.SourceMap (_, sub) -> isSequencey sub
+  | Layout.Sequence _ -> true
+  | Layout.Label (_, _, _) -> false
+  | Layout.Easy (Easy_format.List _) -> true
+  | Layout.Easy _ -> false
+  | Layout.Whitespace (_, sub) -> isSequencey sub
+
+let inline ?(preSpace=false) ?(postSpace=false) labelTerm term =
+  makeList [labelTerm; term]
+    ~inline:(true, true) ~postSpace ~preSpace ~indent:0 ~break:Layout.Never
+
+let breakline labelTerm term =
+  makeList [labelTerm; term]
+    ~inline:(true, true) ~indent:0 ~break:Always_rec
+
+let insertBlankLines n term =
+  if n = 0
+  then term
+  else makeList ~inline:(true, true) ~indent:0 ~break:Always_rec
+      (Array.to_list (Array.make n (atom "")) @ [term])
+
+let string_after s n = String.sub s n (String.length s - n)
+
+(* This is a special-purpose functions only used by `formatComment_`. Notice we
+skip a char below during usage because we know the comment starts with `/*` *)
+let rec lineZeroMeaningfulContent_ line length idx accum =
+  if idx = length then None
+  else
+    let ch = String.get line idx in
+    if ch = '\t' || ch = ' ' || ch = '*' then
+      lineZeroMeaningfulContent_ line length (idx + 1) (accum + 1)
+    else Some accum
+
+let lineZeroMeaningfulContent line =
+  lineZeroMeaningfulContent_ line (String.length line) 1 0
+
+let formatComment_ txt =
+  let commLines =
+    Reason_syntax_util.split_by ~keep_empty:true (fun x -> x = '\n')
+      (Comment.wrap txt)
+  in
+  match commLines with
+  | [] -> atom ""
+  | [hd] ->
+    atom hd
+  | zero::one::tl ->
+    let attemptRemoveCount = (smallestLeadingSpaces (one::tl)) in
+    let leftPad =
+      if beginsWithStar one then 1
+      else match lineZeroMeaningfulContent zero with
+        | None -> 1
+        | Some num -> num + 1
+    in
+    let padNonOpeningLine s =
+      let numLeadingSpaceForThisLine = numLeadingSpace s in
+      if String.length s == 0 then ""
+      else (String.make leftPad ' ') ^
+           (string_after s (min attemptRemoveCount numLeadingSpaceForThisLine)) in
+    let lines = zero :: List.map padNonOpeningLine (one::tl) in
+    makeList ~inline:(true, true) ~indent:0 ~break:Always_rec (List.map atom lines)
+
+let formatComment comment =
+  source_map ~loc:(Comment.location comment) (formatComment_ comment)
+
+let rec append ?(space=false) txt = function
+  | Layout.SourceMap (loc, sub) ->
+    Layout.SourceMap (loc, append ~space txt sub)
+  | Sequence (config, l) when snd config.wrap <> "" ->
+    let sep = if space then " " else "" in
+    Sequence ({config with wrap=(fst config.wrap, snd config.wrap ^ sep ^ txt)}, l)
+  | Sequence (config, []) ->
+    Sequence (config, [atom txt])
+  | Sequence ({sep=NoSep} as config, l)
+  | Sequence ({sep=Sep("")} as config, l) ->
+    let len = List.length l in
+    let sub = List.mapi (fun i layout ->
+        (* append to the end of the list *)
+        if i + 1 = len then
+          append ~space txt layout
+        else
+          layout
+      ) l in
+    Sequence (config, sub)
+  | Label (formatter, left, right) ->
+    Label (formatter, left, append ~space txt right)
+  | Whitespace(info, sub) ->
+      Whitespace(info, append ~space txt sub)
+  | layout ->
+    inline ~postSpace:space layout (atom txt)
+
+let appendSep spaceBeforeSep sep layout =
+  append (if spaceBeforeSep then " " ^ sep else sep) layout
+
+let rec flattenCommentAndSep ?spaceBeforeSep:(spaceBeforeSep=false) ?sepStr = function
+  | Layout.SourceMap (loc, sub) ->
+     Layout.SourceMap (loc, flattenCommentAndSep ~spaceBeforeSep ?sepStr sub)
+  | Layout.Whitespace(info, sub) ->
+     Layout.Whitespace(info, flattenCommentAndSep ~spaceBeforeSep ?sepStr sub)
+  | layout ->
+     begin
+       match sepStr with
+       | None -> layout
+       | Some sep -> appendSep spaceBeforeSep sep layout
+     end
+
+let rec preOrderWalk f layout =
+  match f layout with
+  | Layout.Sequence (listConfig, sublayouts) ->
+    let newSublayouts = List.map (preOrderWalk f) sublayouts in
+    Layout.Sequence (listConfig, newSublayouts)
+  | Layout.Label (formatter, left, right) ->
+    let newLeftLayout = preOrderWalk f left in
+    let newRightLayout = preOrderWalk f right in
+    Layout.Label (formatter, newLeftLayout, newRightLayout)
+  | Layout.SourceMap (loc, sub) ->
+    Layout.SourceMap (loc, preOrderWalk f sub)
+  | Layout.Easy _ as layout -> layout
+  | Layout.Whitespace (info, sub) ->
+      Layout.Whitespace(info, preOrderWalk f sub)
+
+(** Recursively unbreaks a layout to make sure they stay within the same line *)
+let unbreaklayout = preOrderWalk (function
+  | Layout.Sequence (listConfig, sublayouts) ->
+    Layout.Sequence ({listConfig with break=Layout.Never}, sublayouts)
+  | Layout.Label (formatter, left, right) ->
+    Layout.Label (unbreakLabelFormatter formatter, left, right)
+  | layout -> layout
+)
+
+(** [consolidateSeparator layout] walks the [layout], extract separators out of each
+ *  list and insert them into PrintTree as separated items
+ *)
+let consolidateSeparator l = preOrderWalk (function
+  | Sequence (listConfig, sublayouts) when listConfig.sep != NoSep && listConfig.sepLeft ->
+     (* TODO: Support !sepLeft, and this should apply to the *first* separator if !sepLeft.  *)
+     let sublayoutsLen = List.length sublayouts in
+     let mapSublayout i layout =
+        match (listConfig.sep, (i + 1 = sublayoutsLen)) with
+        | (NoSep, _) -> raise (NotPossible "We already covered this case. This shouldn't happen.")
+        | (Sep _, true) -> layout
+        | (SepFinal (sepStr, _), false)
+        | (Sep sepStr, false) ->
+          flattenCommentAndSep ~spaceBeforeSep:listConfig.preSpace ~sepStr:sepStr layout
+        | (SepFinal (_, finalSepStr), true) ->
+          flattenCommentAndSep ~spaceBeforeSep:listConfig.preSpace ~sepStr:finalSepStr layout
+     in
+     let layoutsWithSepAndComment = List.mapi mapSublayout sublayouts in
+     let sep = Layout.NoSep in
+     let preSpace = false in
+     Sequence ({listConfig with sep; preSpace}, layoutsWithSepAndComment)
+  | layout -> layout
+) l
+
+
+(** [insertLinesAboveItems layout] walks the [layout] and insert empty lines *)
+let insertLinesAboveItems items = preOrderWalk (function
+  | Whitespace(region, sub) ->
+      insertBlankLines (WhitespaceRegion.newlines region) sub
+  | layout -> layout
+) items
+
+let insertCommentIntoWhitespaceRegion comment region subLayout =
+  let cl = Comment.location comment in
+  let range = WhitespaceRegion.range region in
+  (* append the comment to the list of inserted comments in the whitespace region *)
+  let nextRegion = WhitespaceRegion.addComment region comment in
+  let formattedComment = formatComment comment in
+  match WhitespaceRegion.comments region with
+  (* the comment inserted into the whitespace region is the first in the region *)
+  | [] ->
+      (*
+       * 1| let a = 1;
+       * 2|
+       * 3| /* comment at end of whitespace region */
+       * 4| let b = 2;
+       *)
+      if range.lnum_end = cl.loc_end.pos_lnum then
+        let subLayout = breakline formattedComment subLayout in
+        Layout.Whitespace(nextRegion, subLayout)
+
+      (*
+       * 1| let a = 1;
+       * 2| /* comment at start of whitespace region */
+       * 3|
+       * 4| let b = 2;
+       *)
+      else if range.lnum_start = cl.loc_start.pos_lnum then
+        let subLayout = breakline formattedComment (insertBlankLines 1 subLayout) in
+        let nextRegion = WhitespaceRegion.modifyNewlines nextRegion 0 in
+        Whitespace(nextRegion, subLayout)
+
+      (*
+       * 1| let a = 1;
+       * 2|
+       * 3| /* comment floats in whitespace region */
+       * 4|
+       * 5| let b = 2;
+       *)
+      else
+        let subLayout = breakline formattedComment (insertBlankLines 1 subLayout) in
+        Whitespace(nextRegion, subLayout)
+
+  (* The whitespace region contains already inserted comments *)
+  | prevComment::_cs ->
+      let pcl = Comment.location prevComment in
+      (* check if the comment is attached to the start of the region *)
+      let attachedToStartRegion = cl.loc_start.pos_lnum = range.lnum_start in
+      let nextRegion =
+        (*
+         * 1| let a = 1;
+         * 2| /* comment sits on the beginning of the region */
+         * 3| /* previous comment */
+         * 4|
+         * 5| let b = 2;
+         *)
+        if attachedToStartRegion then
+          (* we don't want a newline between `let a = 1` and the `comment sits
+           * on the beginning of the region` comment*)
+          WhitespaceRegion.modifyNewlines nextRegion 0
+        (*
+         * 1| let a = 1;
+         * 2|
+         * 3| /* comment isn't located at the beginnin of a region*/
+         * 4| /* previous comment */
+         * 5|
+         * 6| let b = 2;
+         *)
+        else
+          nextRegion
+      in
+      (*
+       * 1| let a = 1;
+       * 2| /* comment */
+       * 3|                      --> whitespace between
+       * 4| /* previous comment */
+       * 5| let b = 1;
+       *)
+      if Reason_location.hasSpaceBetween pcl cl then
+      (* pcl.loc_start.pos_lnum - cl.loc_end.pos_lnum > 1 then *)
+        let subLayout = breakline formattedComment (insertBlankLines 1 subLayout) in
+        let withComment = Layout.Whitespace(nextRegion, subLayout) in
+        withComment
+
+      (*
+       * 1| let a = 1;
+       * 2|
+       * 3| /* comment */          | no whitespace between `comment`
+       * 4| /* previous comment */ | and `previous comment`
+       * 5| let b = 1;
+       *)
+      else
+        let subLayout = breakline formattedComment subLayout in
+        let withComment =  Layout.Whitespace(nextRegion, subLayout) in
+        withComment
+
+(**
+ * prependSingleLineComment inserts a single line comment right above layout
+ *)
+let rec prependSingleLineComment comment layout =
+  match layout with
+  | Layout.SourceMap (loc, sub) ->
+     Layout.SourceMap (loc, prependSingleLineComment comment sub)
+  | Sequence (config, hd::tl) when config.break = Always_rec->
+     Sequence(config, (prependSingleLineComment comment hd)::tl)
+  | Whitespace(info, sub) ->
+      insertCommentIntoWhitespaceRegion comment info sub
+  | layout ->
+      breakline (formatComment comment) layout
+
+(* breakAncestors break ancestors above node, but not comment attachment itself.*)
+let appendComment ~breakAncestors layout comment =
+  let text = Comment.wrap comment in
+  let layout = match layout with
+  | Layout.Whitespace(info, sublayout) ->
+    Layout.Whitespace(info, makeList ~break:Layout.Never ~postSpace:true [sublayout; atom text])
+  | layout ->
+      makeList ~break:Layout.Never ~postSpace:true [layout; atom text]
+  in
+  if breakAncestors then
+    makeList ~inline:(true, true) ~postSpace:false ~preSpace:true ~indent:0
+      ~break:Always_rec [layout]
+  else
+    layout
+
+(**
+ * [looselyAttachComment layout comment] preorderly walks the layout and
+ * find a place where the comment can be loosely attached to
+ *)
+let rec looselyAttachComment ~breakAncestors layout comment =
+  let location = Comment.location comment in
+  match layout with
+  | Layout.SourceMap (loc, sub) ->
+     Layout.SourceMap (loc, looselyAttachComment ~breakAncestors sub comment)
+  | Layout.Whitespace (info, sub) ->
+     Layout.Whitespace(info, looselyAttachComment ~breakAncestors sub comment)
+  | Easy _ ->
+     inline ~postSpace:true layout (formatComment comment)
+  | Sequence (listConfig, subLayouts)
+    when List.exists (Layout.contains_location ~location) subLayouts ->
+     (* If any of the subLayout strictly contains this comment, recurse into to it *)
+    let recurse_sublayout layout =
+      if Layout.contains_location layout ~location
+      then begin
+        looselyAttachComment ~breakAncestors layout comment
+      end
+      else layout
+    in
+    Sequence (listConfig, List.map recurse_sublayout subLayouts)
+  | Sequence (listConfig, subLayouts) when subLayouts == [] ->
+    (* If there are no subLayouts (empty body), create a Sequence of just the comment *)
+    Sequence (listConfig, [formatComment comment])
+  | Sequence (listConfig, subLayouts) ->
+    let (beforeComment, afterComment) =
+      Reason_syntax_util.pick_while (Layout.is_before ~location) subLayouts in
+    let newSubLayout = match List.rev beforeComment with
+      | [] ->
+        Reason_syntax_util.map_first (prependSingleLineComment comment) afterComment
+      | hd :: tl ->
+        List.rev_append
+          (appendComment ~breakAncestors hd comment :: tl) afterComment
+    in
+    Sequence (listConfig, newSubLayout)
+  | Label (formatter, left, right) ->
+    let newLeft, newRight =
+      match (Layout.get_location left, Layout.get_location right) with
+      | (None, None) ->
+        (left, looselyAttachComment ~breakAncestors right comment)
+      | (_, Some loc2) when location_contains loc2 location ->
+        (left, looselyAttachComment ~breakAncestors right comment)
+      | (Some loc1, _) when location_contains loc1 location ->
+        (looselyAttachComment ~breakAncestors left comment, right)
+      | (Some loc1, Some _) when location_is_before location loc1 ->
+        (prependSingleLineComment comment left, right)
+      | (Some _, Some loc2) when location_is_before location loc2 ->
+        (left, prependSingleLineComment comment right)
+      | _ -> (left, appendComment ~breakAncestors right comment)
+    in
+    Label (formatter, newLeft, newRight)
+
+(**
+ * [insertSingleLineComment layout comment] preorderly walks the layout and
+ * find a place where the SingleLineComment can be fit into
+ *)
+let rec insertSingleLineComment layout comment =
+  let location = Comment.location comment in
+  match layout with
+  | Layout.SourceMap (loc, sub) ->
+    Layout.SourceMap (loc, insertSingleLineComment sub comment)
+  | Layout.Whitespace (info, sub) ->
+      let range = WhitespaceRegion.range info in
+      if Range.containsLoc range location then
+        insertCommentIntoWhitespaceRegion comment info sub
+      else
+        Layout.Whitespace(info, insertSingleLineComment sub comment)
+  | Easy _ ->
+    prependSingleLineComment comment layout
+  | Sequence (listConfig, subLayouts) when subLayouts == [] ->
+    (* If there are no subLayouts (empty body), create a Sequence of just the
+     * comment. We need to be careful when the empty body contains a //-style
+     * comment. Example:
+     *   let make = () => {
+     *     //
+     *   };
+     * It is clear that the sequence needs to always break here, otherwise
+     * we get a parse error: let make = () => { // };
+     * The closing brace and semicolon `};` would become part of the comment…
+     *)
+    let listConfig =
+      if Reason_comment.isLineComment comment then
+        {listConfig with break = Always_rec}
+      else
+        listConfig
+    in
+    Sequence (listConfig, [formatComment comment])
+  | Sequence (listConfig, subLayouts) ->
+    let (beforeComment, afterComment) =
+      Reason_syntax_util.pick_while (Layout.is_before ~location) subLayouts in
+    begin match afterComment with
+      (* Nothing in the list is after comment, attach comment to the statement before the comment *)
+      | [] ->
+        let break sublayout = breakline sublayout (formatComment comment) in
+        Sequence (listConfig, Reason_syntax_util.map_last break beforeComment)
+      | hd::tl ->
+        let afterComment =
+          match Layout.get_location hd with
+          | Some loc when location_contains loc location ->
+            insertSingleLineComment hd comment :: tl
+          | Some loc ->
+            Layout.SourceMap (loc, (prependSingleLineComment comment hd)) :: tl
+          | _ ->
+            prependSingleLineComment comment hd :: tl
+        in
+        Sequence (listConfig, beforeComment @ afterComment)
+    end
+  | Label (formatter, left, right) ->
+    let leftLoc = Layout.get_location left in
+    let rightLoc = Layout.get_location right in
+    let newLeft, newRight = match (leftLoc, rightLoc) with
+      | (None, None) ->
+        (left, insertSingleLineComment right comment)
+      | (_, Some loc2) when location_contains loc2 location ->
+        (left, insertSingleLineComment right comment)
+      | (Some loc1, _) when location_contains loc1 location ->
+        (insertSingleLineComment left comment, right)
+      | (Some loc1, Some _) when location_is_before location loc1 ->
+        (prependSingleLineComment comment left, right)
+      | (Some _, Some loc2) when location_is_before location loc2 ->
+        (left, prependSingleLineComment comment right)
+      | _ ->
+        (left, breakline right (formatComment comment))
+    in
+    Label (formatter, newLeft, newRight)
+
+let rec attachCommentToNodeRight layout comment =
+  match layout with
+  | Layout.Sequence (config, sub) when snd config.wrap <> "" ->
+    (* jwalke: This is quite the abuse of the "wrap" config *)
+    let lwrap, rwrap = config.wrap in
+    let rwrap = rwrap ^ " " ^ Comment.wrap comment in
+    Layout.Sequence ({config with wrap=(lwrap, rwrap)}, sub)
+  | Layout.SourceMap (loc, sub) ->
+    Layout.SourceMap (loc, attachCommentToNodeRight sub comment)
+  | layout -> inline ~postSpace:true layout (formatComment comment)
+
+let rec attachCommentToNodeLeft comment layout =
+  match layout with
+  | Layout.Sequence (config, sub) when snd config.wrap <> "" ->
+    let lwrap, rwrap = config.wrap in
+    let lwrap = Comment.wrap comment ^ " " ^ lwrap in
+    Layout.Sequence ({config with wrap = (lwrap, rwrap)}, sub)
+  | Layout.SourceMap (loc, sub) ->
+    Layout.SourceMap (loc, attachCommentToNodeLeft comment sub )
+  | layout ->
+    Layout.Label (inlineLabel, formatComment comment, layout)
+
+(** [tryPerfectlyAttachComment layout comment] postorderly walk the [layout] and tries
+ *  to perfectly attach a comment with a layout node.
+ *
+ *  Perfectly attach here means a comment's start location is equal to the node's end location
+ *  and vice versa.
+ *
+ *  If the comment can be perfectly attached to any layout node, returns (newLayout, None),
+ *  meaning the comment is consumed. Otherwise returns the (unchangedLayout, Some comment),
+ *  meaning the comment is not consumed.
+ *
+ * "perfect attachment" doesn't make sense for end of line comments:
+ *
+ *       {
+ *         x: 0,
+ *         y: 0
+ *       }
+ *
+ * One of these will be "perfectly attached" to the zero and the other won't.
+ * Why should the comma have such an influence? Trailing commas and semicolons
+ * may be inserted or removed, an we need end-of-line comments to never be
+ * impacted by that. Therefore, never try to "perfectly" attach EOL comments.
+ *)
+let rec tryPerfectlyAttachComment layout = function
+  | None -> (layout, None)
+  | Some comment -> perfectlyAttachComment comment layout
+
+and perfectlyAttachComment comment = function
+  | Layout.Sequence (listConfig, subLayouts) ->
+    let distributeCommentIntoSubLayouts (i, processed, newComment) layout =
+      let (layout, newComment) =
+        tryPerfectlyAttachComment layout newComment in
+      (i + 1, layout::processed, newComment)
+    in
+    let (_, processed, consumed) =
+      List.fold_left
+        distributeCommentIntoSubLayouts
+        (0, [], Some comment) (List.rev subLayouts)
+    in
+    Layout.Sequence (listConfig, processed), consumed
+  | Layout.Label (labelFormatter, left, right) ->
+    let (newRight, comment) = perfectlyAttachComment comment right in
+    let (newLeft, comment) = tryPerfectlyAttachComment left comment in
+    Layout.Label (labelFormatter, newLeft, newRight), comment
+  | Layout.SourceMap (loc, subLayout) ->
+    let commloc = Comment.location comment in
+    if loc.loc_end.Lexing.pos_lnum = loc.loc_start.Lexing.pos_lnum &&
+       commloc.loc_start.Lexing.pos_cnum = loc.loc_end.Lexing.pos_cnum
+    then
+      (Layout.SourceMap (loc, makeList ~inline:(true, true) ~break:Always
+                    [unbreaklayout (attachCommentToNodeRight subLayout comment)]),
+       None)
+    else
+      let (layout, comment) = perfectlyAttachComment comment subLayout in
+      begin match comment with
+        | None -> (Layout.SourceMap (loc, layout), None)
+        | Some comment ->
+          if commloc.loc_end.Lexing.pos_cnum =
+             loc.loc_start.Lexing.pos_cnum  then
+            (Layout.SourceMap (loc, attachCommentToNodeLeft comment layout), None)
+          else if commloc.loc_start.Lexing.pos_cnum = loc.loc_end.Lexing.pos_cnum then
+            (Layout.SourceMap (loc, attachCommentToNodeRight layout comment), None)
+          else
+            (Layout.SourceMap (loc, layout), Some comment)
+      end
+  | Whitespace(info, subLayout) ->
+      begin match perfectlyAttachComment comment subLayout with
+      | (newLayout, None) -> (Whitespace(info, newLayout), None)
+      | (newLayout, Some c) -> (Whitespace(info, newLayout), Some c)
+      end
+  | layout -> (layout, Some comment)
+
+let insertRegularComment layout comment =
+  match perfectlyAttachComment comment layout with
+  | (layout, None) -> layout
+  | (layout, Some _) ->
+      looselyAttachComment ~breakAncestors:false layout comment
+
+let insertEndOfLineComment layout comment =
+  looselyAttachComment ~breakAncestors:true layout comment
+
+let rec partitionComments_ ((singleLines, endOfLines, regulars) as soFar) = function
+  | [] -> soFar
+  | com :: tl ->
+    match Comment.category com with
+    | Comment.EndOfLine ->
+      partitionComments_ (singleLines, (com :: endOfLines), regulars) tl
+    | Comment.SingleLine ->
+      partitionComments_ ((com :: singleLines), endOfLines, regulars) tl
+    | Comment.Regular ->
+      partitionComments_ (singleLines, endOfLines, (com :: regulars)) tl
+
+let partitionComments comments =
+  let (singleLines, endOfLines, regulars) =
+    partitionComments_ ([], [], []) comments in
+  (singleLines, List.rev endOfLines, regulars)
+
+(*
+ * Partition single line comments based on a location into two lists:
+ * - one contains the comments before/same height of that location
+ * - the other contains the comments after the location
+ *)
+let partitionSingleLineComments loc singleLineComments =
+  let (before, after) = List.fold_left (fun (before, after) comment ->
+    let cl = Comment.location comment in
+    let isAfter = loc.loc_end.pos_lnum < cl.loc_start.pos_lnum in
+    if isAfter then
+      (before, comment::after)
+    else
+      (comment::before, after)
+  ) ([], []) singleLineComments
+  in (List.rev before, after)
+
+(*
+ * appends all [singleLineComments] after the [layout].
+ * [loc] marks the end of [layout]
+ *)
+let appendSingleLineCommentsToEnd loc layout singleLineComments =
+  let rec aux prevLoc layout i = function
+    | comment::cs ->
+        let loc = Comment.location comment in
+        let formattedComment = formatComment comment in
+        let commentLayout = if Reason_location.hasSpaceBetween loc prevLoc then
+          insertBlankLines 1 formattedComment
+        else
+          formattedComment
+        in
+        (* The initial layout breaks ugly with `breakline`,
+         * an inline list (that never breaks) fixes this *)
+        let newLayout = if i == 0 then
+          makeList ~inline:(true, true) ~break:Never [layout; commentLayout]
+        else
+          breakline layout commentLayout
+        in
+        aux loc newLayout (i + 1) cs
+    | [] -> layout
+  in
+  aux loc layout 0 singleLineComments
+
+(*
+ * For simplicity, the formatting of comments happens in two parts in context of a source map:
+ * 1) insert the singleLineComments with the interleaving algorithm contained in
+ *    `insertSingleLineComment` for all comments overlapping with the sourcemap.
+ *    A `Layout.Whitespace` node signals an intent to preserve whitespace here.
+ * 2) SingleLineComments after the sourcemap, e.g. at the end of .re/.rei file,
+ *    get attached with `appendSingleLineCommentsToEnd`. Due to the fact there
+ *    aren't any real ocaml ast nodes anymore after the sourcemap (end of a
+ *    file), the printing of the comments can be done in one pass with
+ *    `appendSingleLineCommentsToEnd`. This is more performant and
+ *    simplifies the implementation of comment attachment.
+ *)
+let attachSingleLineComments singleLineComments = function
+  | Layout.SourceMap(loc, subLayout) ->
+      let (before, after) = partitionSingleLineComments loc singleLineComments in
+      let layout = List.fold_left insertSingleLineComment subLayout before in
+      appendSingleLineCommentsToEnd loc layout after
+  | layout ->
+    List.fold_left insertSingleLineComment layout singleLineComments
+
+let format_layout ?comments ppf layout =
+  let easy = match comments with
+    | None -> Layout.to_easy_format layout
+    | Some comments ->
+      let (singleLines, endOfLines, regulars) = partitionComments comments in
+      (* TODO: Stop generating multiple versions of the tree, and instead generate one new tree. *)
+      (* Layout.dump Format.std_formatter layout; *)
+      let layout = List.fold_left insertRegularComment layout regulars in
+      let layout = consolidateSeparator layout in
+      let layout = List.fold_left insertEndOfLineComment layout endOfLines in
+      (* Layout.dump Format.std_formatter layout; *)
+      let layout = attachSingleLineComments singleLines layout in
+      (* Layout.dump Format.std_formatter layout; *)
+      let layout = insertLinesAboveItems layout in
+      let layout = Layout.to_easy_format layout in
+      (* Layout.dump_easy Format.std_formatter layout; *)
+      layout
+  in
+  let buf = Buffer.create 1000 in
+  let fauxmatter = Format.formatter_of_buffer buf in
+  let _ = Format.pp_set_margin fauxmatter settings.width in
+  if debugWithHtml.contents then
+    Easy_format.Pretty.define_styles fauxmatter html_escape html_style;
+  let _ = Easy_format.Pretty.to_formatter fauxmatter easy in
+  let trimmed = Reason_syntax_util.processLineEndingsAndStarts (Buffer.contents buf) in
+  Format.fprintf ppf "%s\n" trimmed;
+  Format.pp_print_flush ppf ()
+
+let partitionFinalWrapping listTester wrapFinalItemSetting x =
+  let rev = List.rev x in
+  match (rev, wrapFinalItemSetting) with
+    | ([], _) -> raise (NotPossible "shouldnt be partitioning 0 label attachments")
+    | (_, NeverWrapFinalItem) -> None
+    | (last::revEverythingButLast, WrapFinalListyItemIfFewerThan max) ->
+        if not (listTester last) || (List.length x) >= max then
+          None
+        else
+          Some (List.rev revEverythingButLast, last)
+
+let semiTerminated term = makeList [term; atom ";"]
+
+(* postSpace is so that when comments are interleaved, we still use spacing rules. *)
+let makeLetSequence letItems =
+  makeList
+    ~break:Always_rec
+    ~inline:(true, false)
+    ~wrap:("{", "}")
+    ~postSpace:true
+    ~sep:(SepFinal (";", ";"))
+    letItems
+
+let makeLetSequenceSingleLine letItems =
+  makeList
+    ~break:IfNeed
+    ~inline:(true, false)
+    ~wrap:("{", "}")
+    ~preSpace:true
+    ~postSpace:true
+    ~sep:(Sep ";")
+    letItems
+
+(* postSpace is so that when comments are interleaved, we still use spacing rules. *)
+let makeUnguardedLetSequence ?(sep=(Layout.SepFinal (";", ";"))) letItems =
+  makeList
+    ~break:Always_rec
+    ~inline:(true, true)
+    ~wrap:("", "")
+    ~indent:0
+    ~postSpace:true
+    ~sep
+    letItems
+
+let formatSimpleAttributed x y =
+  makeList
+    ~wrap:("(", ")")
+    ~break:IfNeed
+    ~indent:0
+    ~postSpace:true
+    (List.concat [y; [x]])
+
+let formatAttributed ?(labelBreak=`Auto) x y =
+  label
+    ~break:labelBreak
+    ~indent:0
+    ~space:true
+    (makeList ~inline:(true, true) ~postSpace:true y)
+    x
+
+(* For when the type constraint should be treated as a separate breakable line item itself
+   not docked to some value/pattern label.
+   fun x
+       y
+       : retType => blah;
+ *)
+let formatJustTheTypeConstraint typ =
+  makeList ~postSpace:false ~sep:(Sep " ") [atom ":"; typ]
+
+let formatTypeConstraint one two =
+  label ~space:true (makeList ~postSpace:false [one; atom ":"]) two
+
+let formatCoerce expr optType coerced =
+  match optType with
+    | None ->
+      label ~space:true (makeList ~postSpace:true [expr; atom ":>"]) coerced
+    | Some typ ->
+      label ~space:true (makeList ~postSpace:true [formatTypeConstraint expr typ; atom ":>"]) coerced
+
+
+(* Standard function application style indentation - no special wrapping
+ * behavior.
+ *
+ * Formats like this:
+ *
+ *   let result =
+ *     someFunc
+ *       (10, 20);
+ *
+ *
+ * Instead of this:
+ *
+ *   let result =
+ *     someFunc (
+ *       10,
+ *       20
+ *     );
+ *
+ * The outer list wrapping fixes #566: format should break the whole
+ * application before breaking arguments.
+ *)
+let formatIndentedApplication headApplicationItem argApplicationItems =
+  makeList ~inline:(true, true) ~postSpace:true ~break:IfNeed [
+    label
+      ~space:true
+      headApplicationItem
+      (makeAppList argApplicationItems)
+  ]
+
+
+(* The loc, is an optional location or the returned app terms *)
+let formatAttachmentApplication finalWrapping (attachTo: (bool * Layout.t) option) (appTermItems, loc) =
+  let partitioning = finalWrapping appTermItems in
+  match partitioning with
+    | None -> (
+        match (appTermItems, attachTo) with
+          | ([], _) -> raise (NotPossible "No app terms")
+          | ([hd], None) -> source_map ?loc hd
+          | ([hd], (Some (useSpace, toThis))) -> label ~space:useSpace toThis (source_map ?loc hd)
+          | (hd::tl, None) ->
+            source_map ?loc (formatIndentedApplication hd tl)
+          | (hd::tl, (Some (useSpace, toThis))) ->
+            label
+              ~space:useSpace
+              toThis
+              (source_map ?loc (formatIndentedApplication hd tl))
+      )
+    | Some (attachedList, wrappedListy) -> (
+        match (attachedList, attachTo) with
+        | ([], Some (useSpace, toThis)) ->
+          label ~space:useSpace toThis (source_map ?loc wrappedListy)
+        | ([], None) ->
+          (* Not Sure when this would happen *)
+          source_map ?loc wrappedListy
+        | (_::_, Some (useSpace, toThis)) ->
+          (* TODO: Can't attach location to this - maybe rewrite anyways *)
+          let attachedArgs = makeAppList attachedList in
+          label ~space:useSpace toThis
+            (label ~space:true attachedArgs wrappedListy)
+        | (_::_, None) ->
+          (* Args that are "attached to nothing" *)
+          let appList = makeAppList attachedList in
+          source_map ?loc (label ~space:true appList wrappedListy)
+      )
+
+(*
+  Preprocesses an expression term for the sake of label attachments ([letx =
+  expr]or record [field: expr]). Function application should have special
+  treatment when placed next to a label. (The invoked function term should
+  "stick" to the label in some cases). In others, the invoked function term
+  should become a new label for the remaining items to be indented under.
+ *)
+let applicationFinalWrapping x =
+  partitionFinalWrapping isSequencey settings.funcApplicationLabelStyle x
+
+let curriedFunctionFinalWrapping x =
+  partitionFinalWrapping isSequencey settings.funcCurriedPatternStyle x
+
+let typeApplicationFinalWrapping typeApplicationItems =
+  partitionFinalWrapping isSequencey settings.funcApplicationLabelStyle typeApplicationItems
+
+
+(* add parentheses to binders when they are in fact infix or prefix operators *)
+let protectIdentifier txt =
+  if not (needs_parens txt) then atom txt
+  else if needs_spaces txt then makeList ~wrap:("(", ")") ~pad:(true, true) [atom txt]
+  else atom ("(" ^ txt ^ ")")
+
+let protectLongIdentifier longPrefix txt =
+  makeList [longPrefix; atom "."; protectIdentifier txt]
+
+let paren b fu ppf x =
+  if b
+  then Format.fprintf ppf "(%a)" fu x
+  else fu ppf x
+
+let constant_string ppf s =
+  Format.fprintf ppf "%S" s
+
+let tyvar ppf str =
+  Format.fprintf ppf "'%s" str
+
+(* In some places parens shouldn't be printed for readability:
+ * e.g. Some((-1)) should be printed as Some(-1)
+ * In `1 + (-1)` -1 should be wrapped in parens for readability
+ *)
+let constant ?raw_literal ?(parens=true) ppf = function
+  | Pconst_char i ->
+    Format.fprintf ppf "%C"  i
+  | Pconst_string (i, None) ->
+    begin match raw_literal with
+      | Some text ->
+        Format.fprintf ppf "\"%s\"" text
+      | None ->
+        Format.fprintf ppf "\"%s\"" (Reason_syntax_util.escape_string i)
+    end
+  | Pconst_string (i, Some delim) ->
+    Format.fprintf ppf "{%s|%s|%s}" delim i delim
+  | Pconst_integer (i, None) ->
+    paren (parens && i.[0] = '-')
+      (fun ppf -> Format.fprintf ppf "%s") ppf i
+  | Pconst_integer (i, Some m) ->
+    paren (parens && i.[0] = '-')
+      (fun ppf (i, m) -> Format.fprintf ppf "%s%c" i m) ppf (i,m)
+  | Pconst_float (i, None) ->
+    paren (parens && i.[0] = '-')
+      (fun ppf -> Format.fprintf ppf "%s") ppf i
+  | Pconst_float (i, Some m) ->
+    paren (parens && i.[0] = '-')
+      (fun ppf (i,m) -> Format.fprintf ppf "%s%c" i m) ppf (i,m)
+
+let is_punned_labelled_expression e lbl = match e.pexp_desc with
+  | Pexp_ident { txt }
+  | Pexp_constraint ({pexp_desc = Pexp_ident { txt }}, _)
+  | Pexp_coerce ({pexp_desc = Pexp_ident { txt }}, _, _)
+    -> txt = Longident.parse lbl
+  | _ -> false
+
+let is_punned_labelled_pattern p lbl = match p.ppat_desc with
+  | Ppat_constraint ({ ppat_desc = Ppat_var _; ppat_attributes = _::_ }, _)
+    -> false
+  | Ppat_constraint ({ ppat_desc = Ppat_var { txt } }, _)
+  | Ppat_var { txt }
+    -> txt = lbl
+  | _ -> false
+
+let isLongIdentWithDot = function
+  | Ldot _ -> true
+  | _ -> false
+
+(* Js.t -> useful for bucklescript sugar `Js.t({. foo: bar})` -> `{. "foo": bar}` *)
+let isJsDotTLongIdent ident = match ident with
+  | Ldot (Lident "Js", "t") -> true
+  | _ -> false
+
+let recordRowIsPunned pld =
+      let name = pld.pld_name.txt in
+      (match pld.pld_type with
+        | { ptyp_desc = (
+            Ptyp_constr (
+              { txt },
+              (* don't pun parameterized types, e.g. {tag: tag 'props} *)
+              [])
+            );
+            (* Don't pun types that have attributes attached, e.g. { foo: [@bar] foo } *)
+            ptyp_attributes = [];
+          _}
+            when
+            (Longident.last txt = name
+              (* Don't pun types from other modules, e.g. type bar = {foo: Baz.foo}; *)
+              && isLongIdentWithDot txt == false) -> true
+        | _ -> false)
+
+let isPunnedJsxArg lbl ident =
+  not (isLongIdentWithDot ident.txt) && (Longident.last ident.txt) = lbl
+
+let is_unit_pattern x = match x.ppat_desc with
+  | Ppat_construct ( {txt= Lident"()"}, None) -> true
+  | _ -> false
+
+let is_ident_pattern x = match x.ppat_desc with
+  | Ppat_var _ -> true
+  | _ -> false
+
+let is_any_pattern x = x.ppat_desc = Ppat_any
+
+let is_direct_pattern x = x.ppat_attributes == [] && match x.ppat_desc with
+  | Ppat_construct ( {txt= Lident"()"}, None) -> true
+  | _ -> false
+
+let isJSXComponent expr =
+  match expr with
+  | ({pexp_desc= Pexp_apply ({pexp_desc=Pexp_ident _}, args); pexp_attributes})
+  | ({pexp_desc= Pexp_apply ({pexp_desc=Pexp_letmodule(_,_,_)}, args); pexp_attributes}) ->
+    let {jsxAttrs} = partitionAttributes pexp_attributes in
+    let hasLabelledChildrenLiteral = List.exists (function
+      | (Labelled "children", _) -> true
+      | _ -> false
+    ) args in
+    let rec hasSingleNonLabelledUnitAndIsAtTheEnd l = match l with
+    | [] -> false
+    | (Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, _)}) :: [] -> true
+    | (Nolabel, _) :: _ -> false
+    | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
+    in
+    if jsxAttrs != []
+       && hasLabelledChildrenLiteral
+       && hasSingleNonLabelledUnitAndIsAtTheEnd args
+    then
+      true
+    else
+      false
+  | _ -> false
+
+(* Some cases require special formatting when there's a function application
+ * with a single argument containing some kind of structure with braces/parens/brackets.
+ * Example: `foo({a: 1, b: 2})` needs to be formatted as
+ *  foo({
+ *    a: 1,
+ *    b: 2
+ *  })
+ *  when the line length dictates breaking. Notice how `({` and `})` 'hug'.
+ *  Also applies to (poly)variants because they can be seen as a form of "function application".
+ *  This function says if a list of expressions fulfills the need to be formatted like
+ *  the example above. *)
+let isSingleArgParenApplication = function
+  | [{pexp_attributes = []; pexp_desc = Pexp_record _}]
+  | [{pexp_attributes = []; pexp_desc = Pexp_tuple _}]
+  | [{pexp_attributes = []; pexp_desc = Pexp_array _}]
+  | [{pexp_attributes = []; pexp_desc = Pexp_object _}] -> true
+  | [{pexp_attributes = []; pexp_desc = Pexp_extension (s, _)}] when s.txt = "bs.obj" -> true
+  | [({pexp_attributes = []} as exp)] when (is_simple_list_expr exp) -> true
+  | _ -> false
+
+(*
+ * Determines if the arguments of a constructor pattern match need
+ * special printing. If there's one argument & they have some kind of wrapping,
+ * they're wrapping need to 'hug' the surrounding parens.
+ * Example:
+ *  switch x {
+ *  | Some({
+ *      a,
+ *      b,
+ *    }) => ()
+ *  }
+ *
+ *  Notice how ({ and }) hug.
+ *  This applies for records, arrays, tuples & lists.
+ *  See `singleArgParenPattern` for the acutal formatting
+ *)
+let isSingleArgParenPattern = function
+  | [{ppat_attributes = []; ppat_desc = Ppat_record _}]
+  | [{ppat_attributes = []; ppat_desc = Ppat_array _}]
+  | [{ppat_attributes = []; ppat_desc = Ppat_tuple _}] -> true
+  | [{ppat_attributes = []; ppat_desc = Ppat_construct (({txt=Lident "::"}), _)}] -> true
+  | _ -> false
+
+(* Flattens a resolvedRule into a list of infixChain nodes.
+ * When foo |> f |> z gets parsed, we get the following tree:
+ *         |>
+ *        /  \
+ *    foo      |>
+ *            /  \
+ *          f      z
+ * To format this recursive tree in a way that allows nice breaking
+ * & respects the print-width, we need some kind of flattened
+ * version of the above tree. `computeInfixChain` transforms the tree
+ * in a flattened version which allows flexible formatting.
+ * E.g. we get
+ *  [LayoutNode foo; InfixToken |>; LayoutNode f; InfixToken |>; LayoutNode z]
+ *)
+let rec computeInfixChain = function
+  | LayoutNode layoutNode -> [Layout layoutNode]
+  | InfixTree (op, leftResolvedRule, rightResolvedRule) ->
+      (computeInfixChain leftResolvedRule) @ [InfixToken op] @ (computeInfixChain rightResolvedRule)
+
+let equalityOperators = ["!="; "!=="; "==="; "=="; ">="; "<="; "<"; ">"]
+
+(* Formats a flattened list of infixChain nodes into a list of layoutNodes
+ * which allow smooth line-breaking
+ * e.g. [LayoutNode foo; InfixToken |>; LayoutNode f; InfixToken |>; LayoutNode z]
+ * becomes
+ * [
+ *   foo
+ * ; |> f        --> label
+ * ; |> z        --> label
+ * ]
+ * If you make a list out of this items, we get smooth line breaking
+ *  foo |> f |> z
+ * becomes
+ *  foo
+ *  |> f
+ *  |> z
+ *  when the print-width forces line breaks.
+ *)
+let formatComputedInfixChain infixChainList =
+  let layout_of_group group currentToken =
+    (* Represents the `foo` in
+     * foo
+     * |> f
+     * |> z *)
+    if List.length group < 2 then
+      makeList ~inline:(true, true) ~sep:(Sep " ") group
+    (* Basic equality operators require special formatting, we can't give it
+     * 'classic' infix operator formatting, otherwise we would get
+     * let example =
+     *  true
+     *  != false
+     *  && "a"
+     *  == "b"
+     *  *)
+    else if List.mem currentToken equalityOperators then
+      let hd = List.hd group in
+      let tl = makeList ~inline:(true, true) ~sep:(Sep " ") (List.tl group) in
+      makeList ~inline:(true, true) ~sep:(Sep " ") ~break:IfNeed [hd; tl]
+    else if currentToken.[0] = '#' then
+      let isSharpEqual = currentToken = sharpOpEqualToken in
+      makeList ~postSpace:isSharpEqual group
+    else
+      (* Represents `|> f` in foo |> f
+       * We need a label here to indent possible closing parens
+       * on the same height as the infix operator
+       * e.g.
+       * >|= (
+       *   fun body =>
+       *     Printf.sprintf
+       *       "okokok" uri meth headers body
+       * )   <-- notice how this closing paren is on the same height as >|=
+       *)
+      label ~break:`Never ~space:true (atom currentToken) (List.nth group 1)
+  in
+  let rec print acc group currentToken l =
+    match l with
+    | x::xs -> (match x with
+      | InfixToken t ->
+          (* = or := *)
+          if List.mem t requireIndentFor then
+            let groupNode =
+              makeList ~inline:(true, true) ~sep:(Sep " ") ((print [] group currentToken []) @ [atom t])
+            in
+            let children =
+              makeList ~inline:(true, true) ~preSpace:true ~break:IfNeed
+                (print [] [] t xs)
+            in
+            print (acc @ [label ~space:true groupNode children]) [] t []
+          (* Represents:
+           * List.map @@
+           * List.length
+           *
+           * Notice how we want the `@@` on the first line.
+           * Extra indent puts pressure on the subsequent line lengths
+           * *)
+          else if t = "@@" then
+            let groupNode =
+              makeList ~inline:(true, true) ~sep:(Sep " ") (group @ [atom t])
+            in
+            print (acc @ [groupNode]) [] t xs
+          (* != !== === == >= <= < > etc *)
+          else if List.mem t equalityOperators then
+            print acc ((print [] group currentToken []) @ [atom t]) t xs
+          else
+            begin if requireNoSpaceFor t then
+              begin if (currentToken = "" || requireNoSpaceFor currentToken) then
+                print acc (group@[atom t]) t xs
+              else
+                (* a + b + foo##bar##baz
+                 * `foo` needs to be picked from the current group
+                 * and inserted into a new one. This way `foo`
+                 * gets the special "chained"-printing:
+                 * foo##bar##baz. *)
+                 begin match List.rev group with
+                 |  hd::tl ->
+                     let acc =
+                       acc @ [layout_of_group (List.rev tl) currentToken]
+                      in
+                     print acc [hd; atom t] t xs
+                 | [] -> print acc (group@[atom t]) t xs
+                 end
+              end
+            else
+              print (acc @ [layout_of_group group currentToken]) [(atom t)] t xs
+            end
+      | Layout layoutNode -> print acc (group @ [layoutNode]) currentToken xs
+      )
+    | [] ->
+      if List.mem currentToken requireIndentFor then
+        acc @ group
+        else
+          acc @ [layout_of_group group currentToken]
+  in
+  let l = print [] [] "" infixChainList in
+  makeList ~inline:(true, true) ~sep:(Sep " ") ~break:IfNeed l
+
+(**
+ * [groupAndPrint] will print every item in [items] according to the function [xf].
+ * [getLoc] will extract the location from an item. Based on the difference
+ * between the location of two items, if there's whitespace between the two
+ * (taken possible comments into account), items get grouped.
+ * Every group designates a series of layout nodes "in need
+ * of whitespace above". A group gets decorated with a Whitespace node
+ * containing enough info to interleave whitespace at a later time during
+ * printing.
+ *)
+let groupAndPrint ~xf ~getLoc ~comments items =
+  let rec group prevLoc curr acc = function
+    (* group items *)
+    | x::xs ->
+        let item = xf x in
+        let loc = getLoc x in
+        (* Get the range between the current and previous item
+         * Example:
+         * 1| let a = 1;
+         * 2|            --> this is the range between the two
+         * 3| let b = 2;
+         * *)
+        let range = Range.makeRangeBetween prevLoc loc in
+        (* If there's whitespace interleaved, append the new layout node
+         * to a new group, otherwise keep it in the current group.
+         * Takes possible comments interleaved into account.
+         *
+         * Example:
+         * 1| let a = 1;
+         * 2|
+         * 3| let b = 2;
+         * 4| let c = 3;
+         * `let b = 2` will mark the start of a new group
+         * `let c = 3` will be added to the group containing `let b = 2`
+         *)
+        if Range.containsWhitespace ~range ~comments () then
+          group loc [(range, item)] ((List.rev curr)::acc) xs
+        else
+          group loc ((range, item)::curr) acc xs
+    (* convert groups into "Layout.Whitespace" *)
+    | [] ->
+        let groups = List.rev ((List.rev curr)::acc) in
+        List.mapi (fun i group -> match group with
+          | curr::xs ->
+              let (range, x) = curr in
+              (* if this is the first group of all "items", the number of
+               * newlines interleaved should be 0, else we collapse all newlines
+               * to 1.
+               *
+               * Example:
+               * module Abc = {
+               *   let a = 1;
+               *
+               *   let b = 2;
+               * }
+               * `let a = 1` should be wrapped in a `Layout.Whitespace` because a
+               * user might put comments above the `let a = 1`.
+               * e.g.
+               * module Abc = {
+               *   /* comment 1 */
+               *
+               *   /* comment 2 */
+               *   let a = 1;
+               *
+               *  A Whitespace-node will automatically take care of the whitespace
+               *  interleaving between the comments.
+               *)
+              let newlines = if i > 0 then 1 else 0 in
+              let region = WhitespaceRegion.make ~range ~newlines () in
+              let firstLayout = Layout.Whitespace(region, x) in
+              (* the first layout node of every group taks care of the
+               * whitespace above a group*)
+              (firstLayout::(List.map snd xs))
+          | [] -> []
+        ) groups
+  in
+  match items with
+  | first::rest ->
+      List.concat (group (getLoc first) [] [] (first::rest))
+  | [] -> []
+
+let printer = object(self:'self)
+  val pipe = false
+  val semi = false
+
+  val inline_braces = false
+  val preserve_braces = true
+
+  (* *Mutable state* in the printer to keep track of all comments
+   * Used when whitespace needs to be interleaved.
+   * The printing algorithm needs to take the comments into account in between
+   * two items, to correctly determine if there's whitespace between two items.
+   * The ast doesn't know if there are comments between two items, since
+   * comments are store separately. The location diff between two items
+   * might indicate whitespace between the two. While in reality there are
+   * comments filling that whitespace. The printer needs access to the comments
+   * for this reason.
+   *
+   * Example:
+   * 1| let a = 1;
+   * 2|
+   * 3|
+   * 4| let b = 2;
+   *  -> here we can just diff the locations between `let a = 1` and `let b = 2`
+   *
+   * 1| let a = 1;
+   * 2| /* a comment */
+   * 3| /* another comment */
+   * 4| let b = 2;
+   *  -> here the location diff will result into false info if we don't include
+   *  the comments in the diffing
+   *)
+  val mutable comments = []
+
+  method comments = comments
+  method trackComment comment = comments <- comment::comments
+
+  (* The test and first branch of ternaries must be guarded *)
+  method under_pipe = {<pipe=true>}
+  method under_semi = {<semi=true>}
+  method reset_semi = {<semi=false>}
+  method reset_pipe = {<pipe=false>}
+  method reset = {<pipe=false;semi=false>}
+
+  method inline_braces = {<inline_braces=true>}
+  method dont_preserve_braces = {<preserve_braces=false>}
+  method reset_request_braces = {<inline_braces=false; preserve_braces=true>}
+
+
+  method longident = function
+    | Lident s -> (protectIdentifier s)
+    | Ldot(longPrefix, s) ->
+        (protectLongIdentifier (self#longident longPrefix) s)
+    | Lapply (y,s) -> makeList [self#longident y; atom "("; self#longident s; atom ")";]
+
+  (* This form allows applicative functors. *)
+  method longident_class_or_type_loc x = self#longident x.txt
+  (* TODO: Fail if observing applicative functors for this form. *)
+  method longident_loc (x:Longident.t Location.loc) =
+    source_map ~loc:x.loc (self#longident x.txt)
+
+  method constant ?raw_literal ?(parens=true) =
+    wrap (constant ?raw_literal ~parens)
+
+  method constant_string = wrap constant_string
+  method tyvar = wrap tyvar
+
+  (* c ['a,'b] *)
+  method class_params_def = function
+    | [] -> atom ""
+    | l -> makeTup (List.map self#type_param l)
+
+  (* This will fall through to the simple version. *)
+  method non_arrowed_core_type x = self#non_arrowed_non_simple_core_type x
+
+  method core_type2 x =
+    let {stdAttrs; uncurried} = partitionAttributes x.ptyp_attributes in
+    let uncurried = uncurried || try Hashtbl.find uncurriedTable x.ptyp_loc with | Not_found -> false in
+    if stdAttrs != [] then
+      formatAttributed
+        (self#non_arrowed_simple_core_type {x with ptyp_attributes = []})
+        (self#attributes stdAttrs)
+    else
+      let x = if uncurried then { x with ptyp_attributes = [] } else x in
+      match x.ptyp_desc with
+        | Ptyp_arrow _ ->
+          let rec allArrowSegments ?(uncurried=false) acc = function
+            | { ptyp_desc = Ptyp_arrow (l, ct1, ct2); ptyp_attributes = []} ->
+              allArrowSegments ~uncurried:false
+                ((l,ct1, false || uncurried) :: acc) ct2
+            | rhs ->
+              let rhs = self#core_type2 rhs in
+              let is_tuple typ = match typ.ptyp_desc with
+                | Ptyp_tuple _ -> true
+                | _ -> false
+              in
+              match acc with
+              | [(Nolabel, lhs, uncurried )] when not (is_tuple lhs) ->
+                  let t = self#non_arrowed_simple_core_type lhs in
+                  let lhs = if uncurried then
+                    makeList ~wrap:("(. ", ")") ~postSpace:true [t]
+                  else t in
+                (lhs, rhs)
+              | acc ->
+                let params = List.rev_map self#type_with_label acc in
+                (makeCommaBreakableListSurround "(" ")" params, rhs)
+          in
+          let (lhs, rhs) = allArrowSegments ~uncurried [] x in
+          let normalized = makeList
+              ~preSpace:true ~postSpace:true ~inline:(true, true)
+              ~break:IfNeed ~sep:(Sep "=>") [lhs; rhs]
+          in source_map ~loc:x.ptyp_loc normalized
+        | Ptyp_poly (sl, ct) ->
+          let ct = self#core_type ct in
+          let poly = match sl with
+          | [] -> ct
+          | sl ->
+            makeList ~break:IfNeed ~postSpace:true [
+              makeList [
+                makeList ~postSpace:true (List.map (fun x -> self#tyvar x) sl);
+                atom ".";
+              ];
+              ct
+            ]
+          in source_map ~loc:x.ptyp_loc poly
+        | _ -> self#non_arrowed_core_type x
+
+  (* Same as core_type2 but can be aliased *)
+  method core_type x =
+    let {stdAttrs; uncurried} = partitionAttributes x.ptyp_attributes in
+    let () = if uncurried then Hashtbl.add uncurriedTable x.ptyp_loc true in
+    if stdAttrs != [] then
+      formatAttributed
+        (self#non_arrowed_simple_core_type {x with ptyp_attributes = []})
+        (self#attributes stdAttrs)
+    else match x.ptyp_desc with
+      | (Ptyp_alias (ct, s)) ->
+        source_map ~loc:x.ptyp_loc
+          (label
+             ~space:true
+             (self#core_type ct)
+             (makeList ~postSpace:true [atom "as"; atom ("'" ^ s)]))
+      | _ -> self#core_type2 x
+
+  method type_with_label (lbl, c, uncurried) =
+    let typ = self#core_type c in
+    let t = match lbl with
+    | Nolabel -> typ
+    | Labelled lbl ->
+        makeList ~sep:(Sep " ") [atom (namedArgSym ^ lbl ^ ":"); typ]
+    | Optional lbl ->
+        makeList ~sep:(Sep " ") [atom (namedArgSym ^ lbl ^ ":"); label typ (atom "=?")]
+    in
+    if uncurried then
+      makeList ~postSpace:true [atom "."; t]
+    else t
+
+  method type_param (ct, a) =
+    makeList [atom (type_variance a); self#core_type ct]
+
+  (* According to the parse rule [type_declaration], the "type declaration"'s
+   * physical location (as indicated by [td.ptype_loc]) begins with the
+   * identifier and includes the constraints. *)
+  method formatOneTypeDef prepend name assignToken ({ptype_params; ptype_kind; ptype_loc} as td) =
+    let (equalInitiatedSegments, constraints) = (self#type_declaration_binding_segments td) in
+    let formattedTypeParams = List.map self#type_param ptype_params in
+    let binding = makeList ~postSpace:true [prepend;name] in
+    (*
+        /-----------everythingButConstraints--------------  | -constraints--\
+       /-innerL---| ------innerR--------------------------\
+      /binding\     /typeparams\ /--equalInitiatedSegments-\
+      type name      'v1    'v1  =  foo = private bar        constraint a = b
+    *)
+
+    let labelWithParams = match formattedTypeParams with
+      | [] -> binding
+      | l -> label binding (makeTup l)
+    in
+    let everythingButConstraints =
+      let nameParamsEquals = makeList ~postSpace:true [labelWithParams; assignToken] in
+      match equalInitiatedSegments with
+        | [] -> labelWithParams
+        | _::_::_::_ -> raise (NotPossible "More than two type segments.")
+        | hd::[] ->
+            formatAttachmentApplication
+              typeApplicationFinalWrapping
+              (Some (true, nameParamsEquals))
+              (hd, None)
+        | hd::hd2::[] ->
+            let first = makeList ~postSpace:true ~break:IfNeed ~inline:(true, true) (hd @ [atom "="]) in
+            (*
+             * Because we want a record as a label with the opening brace on the same line
+             * and the closing brace indented at the beginning, we can't wrap it in a list here
+             * Example:
+             * type doubleEqualsRecord =
+             *  myRecordWithReallyLongName = {   <- opening brace on the same line
+             *    xx: int,
+             *    yy: int
+             *  };                               <- closing brace indentation
+             *)
+            let second = match ptype_kind with
+              | Ptype_record _ -> List.hd hd2
+              | _ -> makeList ~postSpace:true ~break:IfNeed ~inline:(true, true) hd2
+            in
+            label ~space:true nameParamsEquals (
+              label ~space:true first second
+            )
+    in
+    let everything =
+      match constraints with
+        | [] -> everythingButConstraints
+        | hd::tl -> makeList ~break:IfNeed ~postSpace:true ~indent:0 ~inline:(true, true) (everythingButConstraints::hd::tl)
+    in
+    source_map ~loc:ptype_loc everything
+
+  method formatOneTypeExt prepend name assignToken te =
+    let privateAtom = (atom "pri") in
+    let privatize scope lst = match scope with
+      | Public -> lst
+      | Private -> privateAtom::lst in
+    let equalInitiatedSegments =
+      let segments = List.map self#type_extension_binding_segments te.ptyext_constructors in
+      let privatized_segments = privatize te.ptyext_private segments in
+      [makeList ~break:Always_rec ~postSpace:true ~inline:(true, true) privatized_segments] in
+    let formattedTypeParams = List.map self#type_param te.ptyext_params in
+    let binding = makeList ~postSpace:true (prepend::name::[]) in
+    let labelWithParams = match formattedTypeParams with
+      | [] -> binding
+      | l -> label binding (makeTup l)
+    in
+    let everything =
+      let nameParamsEquals = makeList ~postSpace:true [labelWithParams; assignToken] in
+      formatAttachmentApplication
+             typeApplicationFinalWrapping
+             (Some (true, nameParamsEquals))
+             (equalInitiatedSegments, None)
+    in
+    source_map ~loc:te.ptyext_path.loc everything
+
+  method type_extension_binding_segments {pext_kind; pext_loc; pext_attributes; pext_name} =
+    let normalize lst = match lst with
+        | [] -> raise (NotPossible "should not be called")
+        | [hd] -> hd
+        | _::_ -> makeList lst
+      in
+      let add_bar name attrs args =
+        let lbl = begin match args with
+        | None -> name
+        | Some args -> label name args
+        end in
+        if attrs != [] then
+         label ~space:true
+            (makeList
+              ~postSpace:true
+              [
+                atom "|";
+                makeList
+                  ~postSpace:true
+                  ~break:Layout.IfNeed
+                  ~inline:(true, true)
+                  (self#attributes attrs)
+              ]
+            )
+            lbl
+        else
+          makeList ~postSpace:true [atom "|"; lbl]
+      in
+    let sourceMappedName = atom ~loc:pext_name.loc pext_name.txt in
+    let resolved = match pext_kind with
+      | Pext_decl (ctor_args, gadt) ->
+        let formattedArgs = match ctor_args with
+          | Pcstr_tuple [] -> []
+          | Pcstr_tuple args -> [makeTup (List.map self#non_arrowed_non_simple_core_type args)]
+          | Pcstr_record r -> [self#record_declaration r]
+        in
+        let formattedGadt = match gadt with
+        | None -> None
+        | Some x -> Some (
+            makeList [
+              formatJustTheTypeConstraint (self#core_type x)
+            ]
+          )
+        in
+        (formattedArgs, formattedGadt)
+      (* type bar += Foo = Attr.Foo *)
+      | Pext_rebind rebind ->
+        let r = self#longident_loc rebind in
+        (* we put an empty space before the '=': we don't have access to the fact
+         * that we need a space because of the Pext_rebind later *)
+        let prepend = (atom " =") in
+        ([makeList ~postSpace:true [prepend; r]], None)
+    in
+      (*
+        The first element of the tuple represents constructor arguments,
+        the second an optional formatted gadt.
+
+        Case 1: No constructor arguments, neither a gadt
+          type attr = ..;
+          type attr += | Str
+
+        Case 2: No constructor arguments, is a gadt
+          type attr = ..;
+          type attr += | Str :attr
+
+        Case 3: Has Constructor args, not a gadt
+          type attr  = ..;
+          type attr += | Str(string);
+          type attr += | Point(int, int);
+
+        Case 4: Has Constructor args & is a gadt
+          type attr  = ..;
+          type attr += | Point(int, int) :attr;
+      *)
+    let everything = match resolved with
+      | ([], None) -> add_bar sourceMappedName pext_attributes None
+      | ([], Some gadt) -> add_bar sourceMappedName pext_attributes (Some gadt)
+      | (ctorArgs, None) -> add_bar sourceMappedName pext_attributes (Some (normalize ctorArgs))
+      | (ctorArgs, Some gadt) -> add_bar sourceMappedName pext_attributes (Some (normalize (ctorArgs@[gadt])))
+    in
+    source_map ~loc:pext_loc everything
+
+  (* shared by [Pstr_type,Psig_type]*)
+  method type_def_list (rf, l) =
+    (* As oposed to used in type substitution. *)
+    let formatOneTypeDefStandard prepend td =
+      let itm =
+        self#formatOneTypeDef
+          prepend
+          (atom ~loc:td.ptype_name.loc td.ptype_name.txt)
+          (atom "=")
+          td
+      in
+      let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true td.ptype_attributes in
+      let layout = self#attach_std_item_attrs stdAttrs itm in
+      self#attachDocAttrsToLayout
+        ~stdAttrs
+        ~docAttrs
+        ~loc:td.ptype_loc
+        ~layout
+        ()
+    in
+
+    match l with
+      | [] -> raise (NotPossible "asking for type list of nothing")
+      | hd::tl ->
+          let first =
+            match rf with
+            | Recursive -> formatOneTypeDefStandard (atom "type") hd
+            | Nonrecursive ->
+                formatOneTypeDefStandard (atom "type nonrec") hd
+          in
+          match tl with
+            (* Exactly one type *)
+            | [] -> first
+            | _::_ as typeList ->
+                let items = (hd.ptype_loc, first)::(List.map (fun ptyp ->
+                    (ptyp.ptype_loc, formatOneTypeDefStandard (atom "and") ptyp)
+                  ) typeList
+                ) in
+                makeList ~indent:0 ~inline:(true, true) ~break:Always_rec (
+                  groupAndPrint
+                    ~xf:snd
+                    ~getLoc:fst
+                    ~comments:self#comments
+                    items
+                )
+
+  method type_variant_leaf ?opt_ampersand:(a=false) ?polymorphic:(p=false) = self#type_variant_leaf1 a p true
+  method type_variant_leaf_nobar ?opt_ampersand:(a=false) ?polymorphic:(p=false) = self#type_variant_leaf1 a p false
+
+  (* TODOATTRIBUTES: Attributes on the entire variant leaf are likely
+   * not parsed or printed correctly. *)
+  method type_variant_leaf1 opt_ampersand polymorphic print_bar x =
+    let {pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes} = x in
+    let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true pcd_attributes in
+    let ampersand_helper i arg =
+      let ct = self#core_type arg in
+      let ct = match arg.ptyp_desc with
+        | Ptyp_tuple _ -> ct
+        | _ -> makeTup [ct]
+      in
+      if i == 0 && not opt_ampersand then
+        ct
+      else
+        label (atom "&") ct
+    in
+    let args = match pcd_args with
+      | Pcstr_record r -> [self#record_declaration r]
+      | Pcstr_tuple [] -> []
+      | Pcstr_tuple l when polymorphic -> List.mapi ampersand_helper l
+      (* Here's why this works. With the new syntax, all the args, are already inside of
+        a safely guarded place like Constructor(here, andHere). Compare that to the
+        previous syntax Constructor here andHere. In the previous syntax, we needed to
+        require that we print "non-arrowed" types for here, and andHere to avoid
+        something like Constructor a=>b c=>d. In the new syntax, we don't care if here
+        and andHere have unguarded arrow types like a=>b because they're safely
+        separated by commas.
+       *)
+      | Pcstr_tuple l -> [makeTup (List.map self#core_type l)]
+    in
+    let gadtRes = match pcd_res with
+      | None -> None
+      | Some x -> Some (
+          formatJustTheTypeConstraint (self#core_type x)
+        )
+    in
+    let normalize lst = match lst with
+      | [] -> raise (NotPossible "should not be called")
+      | [hd] -> hd
+      | _::_ -> makeList ~inline:(true, true) ~break:IfNeed ~postSpace:true lst
+    in
+    let add_bar constructor =
+      makeList ~postSpace:true (if print_bar then [atom "|"; constructor] else [constructor])
+    in
+    (* In some cases (e.g. inline records) we want the label with bar & the gadt resolution
+     * as a list.
+     *   | If {
+     *       pred: expr bool,
+     *       true_branch: expr 'a,
+     *       false_branch: expr 'a
+     *     }                           ==> end of label
+     *     :expr 'a;                   ==> gadt res
+     * The label & the gadt res form two separate units combined into a list.
+     * This is necessary to properly align the closing '}' on the same height as the 'If'.
+     *)
+    let add_bar_2 ?gadt name args =
+      let lbl = label name args in
+      let fullLbl = match gadt with
+        | Some g -> makeList ~inline:(true, true) ~break:IfNeed [lbl; g]
+        | None -> lbl
+      in
+      add_bar fullLbl
+    in
+
+    let prefix = if polymorphic then "`" else "" in
+    let sourceMappedName = atom ~loc:pcd_name.loc (prefix ^ pcd_name.txt) in
+    let sourceMappedNameWithAttributes =
+      let layout = match stdAttrs with
+      | [] -> sourceMappedName
+      | stdAttrs ->
+        formatAttributed sourceMappedName (self#attributes stdAttrs)
+      in
+      match docAttrs with
+      | [] -> layout
+      | docAttrs ->
+        makeList ~break:Always ~inline:(true, true) [
+          makeList (self#attributes docAttrs);
+          layout
+        ]
+    in
+    let constructorName = makeList ~postSpace:true [sourceMappedNameWithAttributes] in
+    let everything = match (args, gadtRes) with
+      | ([], None) -> add_bar sourceMappedNameWithAttributes
+      | ([], Some gadt) -> add_bar_2 sourceMappedNameWithAttributes gadt
+      | (_::_, None) -> add_bar_2 constructorName (normalize args)
+      | (_::_, Some gadt) ->
+          (match pcd_args with
+            | Pcstr_record _ -> add_bar_2 ~gadt constructorName (normalize args)
+            | _ -> add_bar_2 constructorName ~gadt (normalize args))
+    in
+    source_map ~loc:pcd_loc everything
+
+  method record_declaration ?assumeRecordLoc lbls =
+    let recordRow pld =
+      let hasPunning = recordRowIsPunned pld in
+      let name =
+        if hasPunning
+        then [atom pld.pld_name.txt]
+        else [atom pld.pld_name.txt; atom ":"]
+      in
+      let name = source_map ~loc:pld.pld_name.loc (makeList name) in
+      let withMutable =
+        match pld.pld_mutable with
+        | Immutable -> name
+        | Mutable -> makeList ~postSpace:true [atom "mutable"; name]
+      in
+      let recordRow = if hasPunning then
+          label withMutable (atom "")
+        else
+          label ~space:true withMutable (self#core_type pld.pld_type)
+      in
+      let recordRow = match pld.pld_attributes with
+      | [] -> recordRow
+      | attrs ->
+          let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true attrs in
+        let stdAttrsLayout =
+          makeList ~inline:(true, true) ~postSpace:true (self#attributes stdAttrs)
+        in
+        let docAttrsLayout = makeList ~inline:(true, true) (self#attributes docAttrs) in
+        let children = match (docAttrs, stdAttrs) with
+        | [], [] -> [recordRow]
+        | _, [] -> [docAttrsLayout; recordRow]
+        | [], _ -> [stdAttrsLayout; recordRow]
+        | _, _ ->
+            [docAttrsLayout; stdAttrsLayout; recordRow]
+        in
+        makeList ~inline:(true, true) ~break:Always_rec children
+      in
+      source_map ~loc:pld.pld_loc recordRow
+    in
+    let rows = List.map recordRow lbls in
+    (* if a record has more than 2 rows, always break *)
+    let break =
+      if List.length rows >= 2
+      then Layout.Always_rec
+      else Layout.IfNeed
+    in
+    source_map ?loc:assumeRecordLoc
+      (makeList ~wrap:("{", "}") ~sep:commaTrail ~postSpace:true ~break rows)
+
+  (* Returns the type declaration partitioned into three segments - one
+     suitable for appending to a label, the actual type manifest
+     and the list of constraints. *)
+  method type_declaration_binding_segments x =
+    (* Segments of the type binding (occuring after the type keyword) that
+       should begin with "=". Zero to two total sections.
+       This is just a straightforward reverse mapping from the original parser:
+        type_kind:
+            /*empty*/
+              { (Ptype_abstract, Public, None) }
+          | EQUAL core_type
+              { (Ptype_abstract, Public, Some $2) }
+          | EQUAL PRIVATE core_type
+              { (Ptype_abstract, Private, Some $3) }
+          | EQUAL constructor_declarations
+              { (Ptype_variant(List.rev $2), Public, None) }
+          | EQUAL PRIVATE constructor_declarations
+              { (Ptype_variant(List.rev $3), Private, None) }
+          | EQUAL private_flag BAR constructor_declarations
+              { (Ptype_variant(List.rev $4), $2, None) }
+          | EQUAL DOTDOT
+              { (Ptype_open, Public, None) }
+          | EQUAL private_flag LBRACE label_declarations opt_comma RBRACE
+              { (Ptype_record(List.rev $4), $2, None) }
+          | EQUAL core_type EQUAL private_flag opt_bar constructor_declarations
+              { (Ptype_variant(List.rev $6), $4, Some $2) }
+          | EQUAL core_type EQUAL DOTDOT
+              { (Ptype_open, Public, Some $2) }
+          | EQUAL core_type EQUAL private_flag LBRACE label_declarations opt_comma RBRACE
+              { (Ptype_record(List.rev $6), $4, Some $2) }
+    *)
+    let privateAtom = (atom "pri") in
+    let privatize scope lst = match scope with
+      | Public -> lst
+      | Private -> privateAtom::lst in
+
+    let estimateRecordOpenBracePoint () =
+      match x.ptype_params with
+        | [] -> x.ptype_name.loc.loc_end
+        | _ ->
+          (fst (List.nth x.ptype_params (List.length x.ptype_params - 1))).ptyp_loc.loc_end
+    in
+
+    let equalInitiatedSegments = match (x.ptype_kind, x.ptype_private, x.ptype_manifest) with
+      (* /*empty*/ {(Ptype_abstract, Public, None)} *)
+      | (Ptype_abstract, Public, None) -> [
+
+        ]
+      (* EQUAL core_type {(Ptype_abstract, Public, Some _)} *)
+      | (Ptype_abstract, Public, Some y) -> [
+          [self#core_type y]
+        ]
+      (* EQUAL PRIVATE core_type {(Ptype_abstract, Private, Some $3)} *)
+      | (Ptype_abstract, Private, Some y) -> [
+          [privateAtom; self#core_type y]
+        ]
+      (* EQUAL constructor_declarations {(Ptype_variant _., Public, None)} *)
+      (* This case is redundant *)
+      (* | (Ptype_variant lst, Public, None) -> [ *)
+      (*     [makeSpacedBreakableInlineList (List.map type_variant_leaf lst)] *)
+      (*   ] *)
+      (* EQUAL PRIVATE constructor_declarations {(Ptype_variant _, Private, None)} *)
+      | (Ptype_variant lst, Private, None) -> [
+          [privateAtom; makeList ~break:IfNeed ~postSpace:true ~inline:(true, true) (List.map self#type_variant_leaf lst)]
+        ]
+      (* EQUAL private_flag BAR constructor_declarations {(Ptype_variant _, $2, None)} *)
+      | (Ptype_variant lst, scope, None) ->  [
+          privatize scope [makeList ~break:Always_rec ~postSpace:true ~inline:(true, true) (List.map self#type_variant_leaf lst)]
+        ]
+      (* EQUAL DOTDOT {(Ptype_open, Public, None)} *)
+      | (Ptype_open, Public, None) -> [
+          [atom ".."]
+        ]
+      (* Super confusing how record/variants' manifest is not actually the
+         description of the structure. What's in the manifest in that case is
+         the *second* EQUALS asignment. *)
+
+      (* EQUAL private_flag LBRACE label_declarations opt_comma RBRACE {(Ptype_record _, $2, None)} *)
+      | (Ptype_record lst, scope, None) ->
+          let assumeRecordLoc = {loc_start = estimateRecordOpenBracePoint(); loc_end = x.ptype_loc.loc_end; loc_ghost = false} in
+          [privatize scope [self#record_declaration ~assumeRecordLoc lst]]
+      (* And now all of the forms involving *TWO* equals *)
+      (* Again, super confusing how manifests of variants/records represent the
+         structure after the second equals. *)
+      (* ================================================*)
+
+
+      (* EQUAL core_type EQUAL private_flag opt_bar constructor_declarations {
+         (Ptype_variant _, _, Some _)} *)
+      | (Ptype_variant lst, scope, Some mani) -> [
+          [self#core_type mani];
+          let variant = makeList ~break:IfNeed ~postSpace:true ~inline:(true, true) (List.map self#type_variant_leaf lst) in
+          privatize scope [variant];
+        ]
+
+      (* EQUAL core_type EQUAL DOTDOT {(Ptype_open, Public, Some $2)} *)
+      | (Ptype_open, Public, Some mani) -> [
+          [self#core_type mani];
+          [atom ".."];
+        ]
+      (* EQUAL core_type EQUAL private_flag LBRACE label_declarations opt_comma RBRACE
+           {(Ptype_record _, $4, Some $2)} *)
+      | (Ptype_record lst, scope, Some mani) ->
+          let declaration = self#record_declaration lst in
+          let record = match scope with
+            | Public -> [declaration]
+            | Private -> [label ~space:true privateAtom declaration]
+          in
+          [ [self#core_type mani]; record ]
+
+      (* Everything else is impossible *)
+      (* ================================================*)
+
+      | (_, _, _ ) ->  raise (NotPossible "Encountered impossible type specification")
+    in
+
+    let makeConstraint (ct1, ct2, _) =
+      let constraintEq = makeList ~postSpace:true [
+        atom "constraint";
+        self#core_type ct1;
+        atom "=";
+      ] in
+      label ~space:true constraintEq (self#core_type ct2) in
+    let constraints = List.map makeConstraint x.ptype_cstrs in
+    (equalInitiatedSegments, constraints)
+
+  (* "non-arrowed" means "a type where all arrows are inside at least one level of parens"
+
+    z => z: not a "non-arrowed" type.
+    (a, b): a "non-arrowed" type.
+    (z=>z): a "non-arrowed" type because the arrows are guarded by parens.
+
+    A "non arrowed, non simple" type would be one that is not-arrowed, and also
+    not "simple". Simple means it is "clearly one unit" like (a, b), identifier,
+    "hello", None.
+  *)
+  method non_arrowed_non_simple_core_type x =
+    let {stdAttrs} = partitionAttributes x.ptyp_attributes in
+    if stdAttrs != [] then
+      formatAttributed
+        (self#non_arrowed_simple_core_type {x with ptyp_attributes=[]})
+        (self#attributes stdAttrs)
+    else
+      match x.ptyp_desc with
+      (* This significantly differs from the standard OCaml printer/parser:
+         Type constructors are no longer simple *)
+      | _ -> self#non_arrowed_simple_core_type x
+
+  method type_param_list_element = function
+    | {ptyp_attributes = []; ptyp_desc = Ptyp_package(lid,cstrs)} ->
+        self#typ_package ~mod_prefix:true lid cstrs
+    | t -> self#core_type t
+
+  method non_arrowed_simple_core_type x =
+    let {stdAttrs} = partitionAttributes x.ptyp_attributes in
+    if stdAttrs != [] then
+      formatSimpleAttributed
+        (self#non_arrowed_simple_core_type {x with ptyp_attributes=[]})
+        (self#attributes stdAttrs)
+    else
+      let result =
+        match x.ptyp_desc with
+        (*   LPAREN core_type_comma_list RPAREN %prec below_NEWDOT *)
+        (*       { match $2 with *)
+        (*         | [] -> raise Parse_error *)
+        (*         | one::[] -> one *)
+        (*         | moreThanOne -> mktyp(Ptyp_tuple(List.rev moreThanOne)) } *)
+        | Ptyp_tuple l -> makeTup (List.map self#type_param_list_element l)
+        | Ptyp_object (l, o) -> self#unparseObject l o
+        | Ptyp_package (lid, cstrs) ->
+            self#typ_package ~protect:true ~mod_prefix:true lid cstrs
+        (*   | QUOTE ident *)
+        (*       { mktyp(Ptyp_var $2) } *)
+        | Ptyp_var s -> ensureSingleTokenSticksToLabel (self#tyvar s)
+        (*   | UNDERSCORE *)
+        (*       { mktyp(Ptyp_any) } *)
+        | Ptyp_any -> ensureSingleTokenSticksToLabel (atom "_")
+        (*   | type_longident *)
+        (*       { mktyp(Ptyp_constr(mkrhs $1 1, [])) } *)
+        | Ptyp_constr (li, []) ->
+          (* [ensureSingleTokenSticksToLabel] loses location information which is important
+               when you are embedded inside a list and comments are to be interleaved around you.
+               Therefore, we wrap the result in the correct [SourceMap].  *)
+          source_map ~loc:li.loc
+            (ensureSingleTokenSticksToLabel (self#longident_loc li))
+        | Ptyp_constr (li, l) ->
+            (match l with
+            | [{ptyp_desc = Ptyp_object (_::_ as l, o) }] when isJsDotTLongIdent li.txt ->
+                (* should have one or more rows, Js.t({..}) should print as Js.t({..})
+                 * {..} has a totally different meaning than Js.t({..}) *)
+                self#unparseObject ~withStringKeys:true l o
+            | [{ptyp_desc = Ptyp_object (l, o) }] when not (isJsDotTLongIdent li.txt) ->
+                label (self#longident_loc li)
+                  (self#unparseObject ~wrap:("(",")") l o)
+            | [{ptyp_desc = Ptyp_constr(lii, [{ ptyp_desc = Ptyp_object (_::_ as ll, o)}])}]
+              when isJsDotTLongIdent lii.txt ->
+              label (self#longident_loc li)
+                (self#unparseObject ~withStringKeys:true ~wrap:("(",")") ll o)
+            | _ ->
+              (* small guidance: in `type foo = bar`, we're now at the `bar` part *)
+
+              (* The single identifier has to be wrapped in a [ensureSingleTokenSticksToLabel] to
+                 avoid (@see @avoidSingleTokenWrapping): *)
+              label
+                (self#longident_loc li)
+                (makeTup (
+                  List.map self#type_param_list_element l
+                ))
+            )
+        | Ptyp_variant (l, closed, low) ->
+          let pcd_loc = x.ptyp_loc in
+          let pcd_attributes = x.ptyp_attributes in
+          let pcd_res = None in
+          let variant_helper i rf =
+            match rf with
+              | Rtag (label, attrs, opt_ampersand, ctl) ->
+                let pcd_name = {
+                  txt = label;
+                  loc = pcd_loc;
+                } in
+                let pcd_args = Pcstr_tuple ctl in
+                let all_attrs = List.concat [pcd_attributes; attrs] in
+                self#type_variant_leaf ~opt_ampersand ~polymorphic:true {pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes = all_attrs}
+              | Rinherit ct ->
+                (* '| type' is required if the Rinherit is not the first
+                  row_field in the list
+                 *)
+                if i = 0 then
+                  self#core_type ct
+                else
+                  makeList ~postSpace:true [atom "|"; self#core_type ct] in
+          let (designator, tl) =
+            match (closed,low) with
+              | (Closed,None) -> ("", [])
+              | (Closed,Some tl) -> ("<", tl)
+              | (Open,_) -> (">", []) in
+          let node_list = List.mapi variant_helper l in
+          let ll = (List.map (fun t -> atom ("`" ^ t)) tl) in
+          let tag_list = makeList ~postSpace:true ~break:IfNeed ((atom ">")::ll) in
+          let type_list = if tl != [] then node_list@[tag_list] else node_list in
+          makeList ~wrap:("[" ^ designator,"]") ~pad:(true, false) ~postSpace:true ~break:IfNeed type_list
+        | Ptyp_class (li, []) -> makeList [atom "#"; self#longident_loc li]
+        | Ptyp_class (li, l) ->
+          label
+            (makeList [atom "#"; self#longident_loc li])
+            (makeTup (List.map self#core_type l))
+        | Ptyp_extension e -> self#extension e
+        | Ptyp_arrow (_, _, _)
+        | Ptyp_alias (_, _)
+        | Ptyp_poly (_, _) ->
+            makeList ~wrap:("(",")") ~break:IfNeed [self#core_type x]
+      in
+      source_map ~loc:x.ptyp_loc result
+  (* TODO: ensure that we have a form of desugaring that protects *)
+  (* when final argument of curried pattern is a type constraint: *)
+  (* | COLON non_arrowed_core_type EQUALGREATER expr
+      { mkexp_constraint $4 (Some $2, None) }         *)
+  (*                         \----/   \--/
+                             constraint coerce
+
+                             Creates a ghost expression:
+                             mkexp_constraint | Some t, None -> ghexp(Pexp_constraint(e, t))
+  *)
+
+  method pattern_list_split_cons acc = function
+    | {
+      ppat_desc = Ppat_construct (
+        { txt = Lident("::")},
+        Some {ppat_desc = Ppat_tuple ([pat1; pat2])}
+      ) } ->
+        self#pattern_list_split_cons (pat1::acc) pat2
+    | p -> (List.rev acc), p
+
+  (*
+   * Adds parens to the right sub-tree when it is not a single node:
+   *
+   * A | B                   is formatted as    A | B
+   * A | (B | C)             is formatted as    A | (B | C)
+   *
+   * Also, adds parens to both sub-trees when both of them
+   * are not a single node:
+   * (A | B) | (C | D)       is formatted as    A | B | (C | D)
+   * A | B | (C | D)         is formatted as    A | B | (C | D)
+   * (A | B) | C             is formatted as    A | B | C
+   * A | B | C               is formatted as    A | B | C
+   *
+   *)
+  method or_pattern p1 p2 =
+    let (p1_raw, p2_raw) = (self#pattern p1, self#pattern p2) in
+    let (left, right) =
+      match p2.ppat_desc with
+        | Ppat_or _ -> (p1_raw, formatPrecedence p2_raw)
+        | _ -> (p1_raw, p2_raw)
+    in
+    makeList
+      ~break:IfNeed
+      ~inline:(true, true)
+      ~sep:(Sep "|")
+      ~postSpace:true
+      ~preSpace:true
+      [left; right]
+
+  method pattern_without_or x =
+    (* TODOATTRIBUTES: Handle the stdAttrs here *)
+    let {arityAttrs} = partitionAttributes x.ppat_attributes in
+    match x.ppat_desc with
+      | Ppat_alias (p, s) ->
+          let raw_pattern = (self#pattern p) in
+          let pattern_with_precedence = match p.ppat_desc with
+            | Ppat_or (p1, p2) -> formatPrecedence (self#or_pattern p1 p2)
+            | _ -> raw_pattern
+          in
+          label ~space:true
+            (source_map ~loc:p.ppat_loc pattern_with_precedence)
+            (makeList ~postSpace:true [
+              atom "as";
+              (source_map ~loc:s.loc (protectIdentifier s.txt))
+            ]) (* RA*)
+      | Ppat_variant (l, Some p) ->
+          if arityAttrs != [] then
+            raise (NotPossible "Should never see embedded attributes on poly variant")
+          else
+            source_map ~loc:x.ppat_loc
+              (self#constructor_pattern (atom ("`" ^ l)) p
+                 ~polyVariant:true ~arityIsClear:true)
+      | Ppat_lazy p -> label ~space:true (atom "lazy") (self#simple_pattern p)
+      | Ppat_construct (({txt} as li), po) when not (txt = Lident "::")-> (* FIXME The third field always false *)
+          let formattedConstruction = match po with
+            (* TODO: Check the explicit_arity field on the pattern/constructor
+               attributes to determine if should desugar to an *actual* tuple. *)
+            (* | Some ({ *)
+            (*   ppat_desc=Ppat_tuple l; *)
+            (*   ppat_attributes=[{txt="explicit_arity"; loc}] *)
+            (* }) -> *)
+            (*   label ~space:true (self#longident_loc li) (makeSpacedBreakableInlineList (List.map self#simple_pattern l)) *)
+            | Some pattern ->
+                let arityIsClear = isArityClear arityAttrs in
+                self#constructor_pattern ~arityIsClear (self#longident_loc li) pattern
+            | None ->
+                self#longident_loc li
+          in
+          source_map ~loc:x.ppat_loc formattedConstruction
+      | _ -> self#simple_pattern x
+
+  method pattern x =
+    let {arityAttrs; stdAttrs} = partitionAttributes x.ppat_attributes in
+    if stdAttrs != [] then
+      formatAttributed
+        (* Doesn't need to be simple_pattern because attributes are parse as
+         * appyling to the entire "function application style" syntax preceeding them *)
+        (self#pattern {x with ppat_attributes=arityAttrs})
+        (self#attributes stdAttrs)
+    else match x.ppat_desc with
+      | Ppat_or (p1, p2) ->
+        self#or_pattern p1 p2
+      | _ -> self#pattern_without_or x
+
+  method patternList ?(wrap=("","")) pat =
+    let pat_list, pat_last = self#pattern_list_split_cons [] pat in
+    let pat_list = List.map self#pattern pat_list in
+    match pat_last with
+    | {ppat_desc = Ppat_construct ({txt=Lident "[]"},_)} -> (* [x,y,z] *)
+      let (lwrap, rwrap) = wrap in
+      makeList pat_list
+        ~break:Layout.IfNeed ~sep:commaTrail ~postSpace:true
+        ~wrap:(lwrap ^ "[", "]" ^ rwrap)
+    | _ -> (* x::y *)
+      makeES6List pat_list (self#pattern pat_last) ~wrap
+
+  (* In some contexts the Ptyp_package needs to be protected by parens, or
+   * the `module` keyword needs to be added.
+   * Example: let f = (module Add: S.Z, x) => Add.add(x);
+   *  It's clear that `S.Z` is a module because it constraints the
+   *  `module Add` pattern. No need to add "module" before `S.Z`.
+   *
+   * Example2:
+   *   type t = (module Console);
+   *   In this case the "module" keyword needs to be printed to indicate
+   *   usage of a first-class-module.
+   *)
+  method typ_package ?(protect=false) ?(mod_prefix=true) lid cstrs =
+    let packageIdent =
+      let packageIdent = self#longident_loc lid in
+      if mod_prefix then
+        makeList ~postSpace:true [atom "module"; packageIdent]
+      else packageIdent
+    in
+    let unwrapped_layout = match cstrs with
+    | [] -> packageIdent
+    | cstrs ->
+        label ~space:true
+          (makeList ~postSpace:true [packageIdent; atom "with"])
+          (makeList
+            ~inline:(true, true)
+            ~break:IfNeed
+            ~sep:(Sep " and ")
+            (List.map (fun (s, ct) ->
+              label ~space:true
+                (makeList
+                  ~break:IfNeed ~postSpace:true
+                  [atom "type"; self#longident_loc s; atom "="])
+                (self#core_type ct)
+            ) cstrs))
+    in
+    if protect then
+      makeList ~postSpace:true ~wrap:("(", ")") [unwrapped_layout ]
+    else unwrapped_layout
+
+  method constrained_pattern x = match x.ppat_desc with
+    | Ppat_constraint (p, ct) ->
+        let (pat, typ) = begin match (p, ct) with
+        | (
+            {ppat_desc = Ppat_unpack(unpack)},
+            {ptyp_desc = Ptyp_package (lid, cstrs)}
+          ) ->
+            (makeList ~postSpace:true [atom "module"; atom unpack.txt],
+             self#typ_package ~mod_prefix:false lid cstrs)
+        | _ ->
+          (self#pattern p, self#core_type ct)
+        end in
+        formatTypeConstraint pat typ
+    | _  -> self#pattern x
+
+  method simple_pattern x =
+    let {arityAttrs; stdAttrs} = partitionAttributes x.ppat_attributes in
+    if stdAttrs != [] then
+      formatSimpleAttributed
+        (self#simple_pattern {x with ppat_attributes=arityAttrs})
+        (self#attributes stdAttrs)
+    else
+      let itm =
+        match x.ppat_desc with
+          | Ppat_construct (({loc; txt=Lident ("()"|"[]" as x)}), _) ->
+              (* Patterns' locations might include a leading bar depending on the
+               * context it was parsed in. Therefore, we need to include further
+               * information about the contents of the pattern such as tokens etc,
+               * in order to get comments to be distributed correctly.*)
+            atom ~loc x
+          | Ppat_construct (({txt=Lident "::"}), _) ->
+            self#patternList x (* LIST PATTERN *)
+          | Ppat_construct (li, None) ->
+            source_map ~loc:x.ppat_loc (self#longident_loc li)
+          | Ppat_any -> atom "_"
+          | Ppat_var ({loc; txt = txt}) ->
+            (*
+               To prevent this:
+
+                 let oneArgShouldWrapToAlignWith
+                   theFunctionNameBinding => theFunctionNameBinding;
+
+               And instead do:
+
+                 let oneArgShouldWrapToAlignWith
+                     theFunctionNameBinding => theFunctionNameBinding;
+
+               We have to do something to the non "listy" patterns. Non listy
+               patterns don't indent the same amount as listy patterns when docked
+               to a label.
+
+               If wrapping the non-listy pattern in [ensureSingleTokenSticksToLabel]
+               you'll get the following (even though it should wrap)
+
+                 let oneArgShouldWrapToAlignWith theFunctionNameBinding => theFunctionNameBinding;
+
+             *)
+            source_map ~loc (protectIdentifier txt)
+          | Ppat_array l ->
+              self#patternArray l
+          | Ppat_unpack s ->
+              makeList ~wrap:("(", ")") ~break:IfNeed ~postSpace:true [atom "module"; atom s.txt]
+          | Ppat_open (lid, pat) ->
+            (* let someFn Qualified.{ record } = ... *)
+            let needsParens = match pat.ppat_desc with
+              | Ppat_exception _ -> true
+              | _ -> false
+            in
+            let pat = self#simple_pattern pat in
+            label
+              (label (self#longident_loc lid) (atom (".")))
+              (if needsParens then formatPrecedence pat else pat)
+          | Ppat_type li ->
+              makeList [atom "#"; self#longident_loc li]
+          | Ppat_record (l, closed) ->
+             self#patternRecord l closed
+          | Ppat_tuple l ->
+             self#patternTuple l
+          | Ppat_constant c ->
+            let raw_literal, _ = extract_raw_literal x.ppat_attributes in
+            (self#constant ?raw_literal c)
+          | Ppat_interval (c1, c2) ->
+            makeList [self#constant c1; atom ".."; self#constant c2]
+          | Ppat_variant (l, None) -> makeList[atom "`"; atom l]
+          | Ppat_constraint (p, ct) ->
+              formatPrecedence (formatTypeConstraint (self#pattern p) (self#core_type ct))
+          | Ppat_lazy p ->formatPrecedence (label ~space:true (atom "lazy") (self#simple_pattern p))
+          | Ppat_extension e -> self#extension e
+          | Ppat_exception p ->
+              (*
+                An exception pattern with an alias should be wrapped in (...)
+                The rules for what goes to the right of the exception are a little (too) nuanced.
+                It accepts "non simple" parameters, except in the case of `as`.
+                Here we consistently apply "simplification" to the exception argument.
+                Example:
+                  | exception (Sys_error _ as exc) => raise exc
+                 parses correctly while
+                  | Sys_error _ as exc => raise exc
+                 results in incorrect parsing with type error otherwise.
+              *)
+               (makeList ~postSpace:true [atom "exception"; self#simple_pattern p])
+          | _ -> formatPrecedence (self#pattern x) (* May have a redundant sourcemap *)
+        in
+        source_map ~loc:x.ppat_loc itm
+
+  method label_exp lbl opt pat =
+    let term = self#constrained_pattern pat in
+    let param = match lbl with
+      | Nolabel -> term
+      | Labelled lbl | Optional lbl when is_punned_labelled_pattern pat lbl ->
+        makeList [atom namedArgSym; term]
+      | Labelled lbl | Optional lbl ->
+        let lblLayout=
+          makeList ~sep:(Sep " ") ~break:Layout.Never
+            [atom (namedArgSym ^ lbl); atom "as"]
+        in
+        label lblLayout ~space:true term
+    in
+    match opt, lbl with
+    | None, Optional _ -> makeList [param; atom "=?"]
+    | None, _ -> param
+    | Some o, _ -> makeList [param; atom "="; (self#unparseProtectedExpr ~forceParens:true o)]
+
+  method access op cls e1 e2 = makeList [
+    (* Important that this be not breaking - at least to preserve same
+       behavior as stock desugarer. It might even be required (double check
+       in parser.mly) *)
+    e1;
+    atom op;
+    e2;
+    atom cls;
+  ]
+
+
+  method simple_get_application x =
+    let {stdAttrs; jsxAttrs} = partitionAttributes x.pexp_attributes in
+    match (x.pexp_desc, stdAttrs, jsxAttrs) with
+    | (_, _::_, []) -> None (* Has some printed attributes - not simple *)
+    | (Pexp_apply ({pexp_desc=Pexp_ident loc}, l), [], _jsx::_) -> (
+      (* TODO: Soon, we will allow the final argument to be an identifier which
+         represents the entire list. This would be written as
+         `<tag>...list</tag>`. If you imagine there being an implicit [] inside
+         the tag, then it would be consistent with array spread:
+         [...list] evaluates to the thing as list.
+      *)
+      let hasLabelledChildrenLiteral = List.exists (function
+        | (Labelled "children", _) -> true
+        | _ -> false
+      ) l in
+      let rec hasSingleNonLabelledUnitAndIsAtTheEnd l = match l with
+      | [] -> false
+      | (Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, _)}) :: [] -> true
+      | (Nolabel, _) :: _ -> false
+      | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
+      in
+      if hasLabelledChildrenLiteral && hasSingleNonLabelledUnitAndIsAtTheEnd l then
+        let moduleNameList = List.rev (List.tl (List.rev (Longident.flatten loc.txt))) in
+        if moduleNameList != [] then
+          if Longident.last loc.txt = "createElement" then
+            Some (self#formatJSXComponent (String.concat "." moduleNameList) l)
+          else None
+        else Some (self#formatJSXComponent (Longident.last loc.txt) l)
+      else None
+    )
+    | (Pexp_apply (
+        {pexp_desc=
+          Pexp_letmodule(_,
+            ({pmod_desc=Pmod_apply _} as app),
+            {pexp_desc=Pexp_ident loc}
+          )}, l), [], _jsx::_) -> (
+      (* TODO: Soon, we will allow the final argument to be an identifier which
+         represents the entire list. This would be written as
+         `<tag>...list</tag>`. If you imagine there being an implicit [] inside
+         the tag, then it would be consistent with array spread:
+         [...list] evaluates to the thing as list.
+      *)
+      let rec extract_apps args = function
+        | { pmod_desc = Pmod_apply (m1, {pmod_desc=Pmod_ident loc}) } ->
+          let arg = String.concat "." (Longident.flatten loc.txt) in
+          extract_apps (arg :: args) m1
+        | { pmod_desc=Pmod_ident loc } -> (String.concat "." (Longident.flatten loc.txt))::args
+        | _ -> failwith "Functors in JSX tags support only module names as parameters" in
+      let hasLabelledChildrenLiteral = List.exists (function
+        | (Labelled "children", _) -> true
+        | _ -> false
+      ) l in
+      let rec hasSingleNonLabelledUnitAndIsAtTheEnd l = match l with
+      | [] -> false
+      | (Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, _)}) :: [] -> true
+      | (Nolabel, _) :: _ -> false
+      | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
+      in
+      if hasLabelledChildrenLiteral && hasSingleNonLabelledUnitAndIsAtTheEnd l then
+        if List.length (Longident.flatten loc.txt) > 1 then
+          if Longident.last loc.txt = "createElement" then
+            begin match extract_apps [] app with
+              | ftor::args ->
+                let applied = ftor ^ "(" ^ String.concat ", " args ^ ")" in
+                Some (self#formatJSXComponent ~closeComponentName:ftor applied l)
+              | _ -> None
+            end
+          else None
+        else Some (self#formatJSXComponent (Longident.last loc.txt) l)
+      else None
+    )
+    | _ -> None
+
+  (** Detects "sugar expressions" (sugar for array/string setters) and returns their separate
+      parts.  *)
+  method sugar_set_expr_parts e =
+    if e.pexp_attributes != [] then None
+    (* should also check attributes underneath *)
+    else match e.pexp_desc with
+      | Pexp_apply ({pexp_desc=Pexp_ident{txt=Ldot (Lident ("Array"), "set")}}, [(_,e1);(_,e2);(_,e3)]) ->
+        let prec = Custom "prec_lbracket" in
+        let lhs = self#unparseResolvedRule (
+            self#ensureExpression ~reducesOnToken:prec e1
+          ) in
+        Some (self#access "[" "]" lhs (self#unparseExpr e2), e3)
+      | Pexp_apply ({pexp_desc=Pexp_ident {txt=Ldot (Lident "String", "set")}}, [(_,e1);(_,e2);(_,e3)]) ->
+        let prec = Custom "prec_lbracket" in
+        let lhs = self#unparseResolvedRule (
+            self#ensureExpression ~reducesOnToken:prec e1
+          ) in
+        Some ((self#access ".[" "]" lhs (self#unparseExpr e2)), e3)
+      | Pexp_apply (
+        {pexp_desc=Pexp_ident {txt = Ldot (Ldot (Lident "Bigarray", array), "set")}},
+        label_exprs
+      ) -> (
+        match array with
+          | "Genarray" -> (
+            match label_exprs with
+            | [(_,a);(_,{pexp_desc=Pexp_array ls});(_,c)] ->
+              let formattedList = List.map self#unparseExpr ls in
+              let lhs = makeList [self#simple_enough_to_be_lhs_dot_send a; atom "."] in
+              let rhs = makeList ~break:IfNeed ~postSpace:true ~sep:commaSep ~wrap:("{", "}") formattedList
+              in
+              Some (label lhs rhs, c)
+            | _ -> None
+          )
+          | ("Array1"|"Array2"|"Array3") -> (
+            match label_exprs with
+            | (_,a)::rest -> (
+              match List.rev rest with
+              | (_,v)::rest ->
+                let args = List.map snd (List.rev rest) in
+                let formattedList = List.map self#unparseExpr args in
+                let lhs = makeList [self#simple_enough_to_be_lhs_dot_send a; atom "."] in
+                let rhs = makeList ~break:IfNeed ~postSpace:true ~sep:commaSep ~wrap:("{", "}") formattedList in
+                Some (label lhs rhs, v)
+              | _ -> assert false
+            )
+            | _ -> assert false
+          )
+          | _ -> None
+        )
+      | _ -> None
+
+  (*
+
+     How would we know not to print the sequence without { }; protecting the let a?
+
+                            let a
+                             |
+                           sequence
+                          /        \
+                    let a           print a
+                    alert a
+     let res = {
+       let a = something();
+       {                     \
+         alert(a);           | portion to be parsed as a sequence()
+         let a = 20;         | The final ; print(a) causes the entire
+         alert(a);           | portion to be parsed as a sequence()
+       };                    |
+       print (a);            /
+     }
+
+     ******************************************************************
+     Any time the First expression of a sequence is another sequence, or (as in
+     this case) a let, wrapping the first sequence expression in { } is
+     required.
+     ******************************************************************
+  *)
+
+  (**
+     TODO: Configure the optional ability to print the *minimum* number of
+     parens. It's simply a matter of changing [higherPrecedenceThan] to
+     [higherOrEqualPrecedenceThan].
+   *)
+
+  (* The point of the function is to ensure that ~reducesAfterRight:rightExpr will reduce
+     at the proper time when it is reparsed, possibly wrapping it
+     in parenthesis if needed. It ensures a rule doesn't reduce
+     until *after* `reducesAfterRight` gets a chance to reduce.
+     Example: The addition rule which has precedence of rightmost
+     token "+", in `x + a * b` should not reduce until after the a * b gets
+     a chance to reduce. This function would determine the minimum parens to
+     ensure that. *)
+  method ensureContainingRule ~withPrecedence ~reducesAfterRight () =
+    match self#unparseExprRecurse reducesAfterRight with
+    | SpecificInfixPrecedence ({shiftPrecedence}, rightRecurse) ->
+      if higherPrecedenceThan shiftPrecedence withPrecedence then rightRecurse
+      else if (higherPrecedenceThan withPrecedence shiftPrecedence) then
+        LayoutNode (formatPrecedence ~loc:reducesAfterRight.pexp_loc (self#unparseResolvedRule rightRecurse))
+      else (
+        if isRightAssociative ~prec:withPrecedence then
+         rightRecurse
+        else
+          LayoutNode (formatPrecedence ~loc:reducesAfterRight.pexp_loc (self#unparseResolvedRule rightRecurse))
+      )
+    | FunctionApplication itms ->
+      let funApplExpr = formatAttachmentApplication applicationFinalWrapping None (itms, Some reducesAfterRight.pexp_loc)
+      in
+      (* Little hack: need to print parens for the `bar` application in e.g.
+         `foo->other##(bar(baz))` or `foo->other->(bar(baz))`. *)
+      if higherPrecedenceThan withPrecedence (Custom "prec_functionAppl")
+      then LayoutNode (formatPrecedence ~loc:reducesAfterRight.pexp_loc funApplExpr)
+      else LayoutNode funApplExpr
+    | PotentiallyLowPrecedence itm -> LayoutNode (formatPrecedence ~loc:reducesAfterRight.pexp_loc itm)
+    | Simple itm -> LayoutNode itm
+
+  method ensureExpression ~reducesOnToken expr =
+    match self#unparseExprRecurse expr with
+    | SpecificInfixPrecedence ({reducePrecedence}, leftRecurse) ->
+      if higherPrecedenceThan reducePrecedence reducesOnToken then leftRecurse
+      else if higherPrecedenceThan reducesOnToken reducePrecedence then
+        LayoutNode (formatPrecedence ~loc:expr.pexp_loc (self#unparseResolvedRule leftRecurse))
+      else (
+        if isLeftAssociative ~prec:reducesOnToken then
+          leftRecurse
+        else
+          LayoutNode (formatPrecedence ~loc:expr.pexp_loc (self#unparseResolvedRule leftRecurse))
+      )
+    | FunctionApplication itms -> LayoutNode (formatAttachmentApplication applicationFinalWrapping None (itms, Some expr.pexp_loc))
+    | PotentiallyLowPrecedence itm -> LayoutNode (formatPrecedence ~loc:expr.pexp_loc itm)
+    | Simple itm -> LayoutNode itm
+
+  (** Attempts to unparse: The beginning of a more general printing algorithm,
+      that determines how to print based on precedence of tokens and rules.
+      The end goal is that this should be completely auto-generated from the
+      Menhir parsing tables. We could move more and more into this function.
+
+      You could always just call self#expression, but `unparseExpr` will render
+      infix/prefix/unary/terary fixities in their beautiful forms while
+      minimizing parenthesis.
+  *)
+  method unparseExpr x =
+    match self#unparseExprRecurse x with
+    | SpecificInfixPrecedence (_, resolvedRule) ->
+        self#unparseResolvedRule resolvedRule
+    | FunctionApplication itms ->
+        formatAttachmentApplication applicationFinalWrapping None (itms, Some x.pexp_loc)
+    | PotentiallyLowPrecedence itm -> itm
+    | Simple itm -> itm
+
+  (* This method may not even be needed *)
+  method unparseUnattributedExpr x =
+    match partitionAttributes x.pexp_attributes with
+    | {docAttrs = []; stdAttrs = []} -> self#unparseExpr x
+    | _ -> makeList ~wrap:("(",")") [self#unparseExpr x]
+
+  (* ensureExpr ensures that the expression is wrapped in parens
+   * e.g. is necessary in cases like:
+   * let display = (:message=("hello": string)) => 1;
+   * but not in cases like:
+   * let f = (a: bool) => 1;
+   * TODO: in the future we should probably use the type ruleCategory
+   * to 'automatically' ensure the validity of a constraint expr with parens...
+   *)
+  method unparseProtectedExpr ?(forceParens=false) e =
+    let itm =
+      match e with
+      | { pexp_attributes = []; pexp_desc = Pexp_constraint (x, ct)} ->
+        let x = self#unparseExpr x in
+        let children = [x; label ~space:true (atom ":") (self#core_type ct)] in
+        if forceParens then
+          makeList ~wrap:("(", ")") children
+        else makeList children
+      | { pexp_attributes; pexp_desc = Pexp_constant c } ->
+        (* When we have Some(-1) or someFunction(-1, -2), the arguments -1 and -2
+         * pass through this case. In this context they don't need to be wrapped in extra parens
+         * Some((-1)) should be printed as Some(-1). This is in contrast with
+         * 1 + (-1) where we print the parens for readability. *)
+          let raw_literal, pexp_attributes =
+            extract_raw_literal pexp_attributes
+          in
+          let constant = self#constant ?raw_literal ~parens:forceParens c in
+          begin match pexp_attributes with
+          | [] -> constant
+          | attrs ->
+              let formattedAttrs = makeSpacedBreakableInlineList (List.map self#item_attribute attrs) in
+               makeSpacedBreakableInlineList [formattedAttrs; constant]
+          end
+      | {pexp_desc = Pexp_fun _ } -> self#formatPexpFun e
+      | x -> self#unparseExpr x
+    in
+    source_map ~loc:e.pexp_loc itm
+
+  method simplifyUnparseExpr ?(inline=false) ?(wrap=("(", ")")) x =
+    match self#unparseExprRecurse x with
+    | SpecificInfixPrecedence (_, itm) ->
+        formatPrecedence
+          ~inline
+          ~wrap
+          ~loc:x.pexp_loc
+          (self#unparseResolvedRule itm)
+    | FunctionApplication itms ->
+      formatPrecedence
+        ~inline
+        ~wrap
+        ~loc:x.pexp_loc
+        (formatAttachmentApplication applicationFinalWrapping None (itms, Some x.pexp_loc))
+    | PotentiallyLowPrecedence itm ->
+        formatPrecedence
+          ~inline
+          ~wrap
+          ~loc:x.pexp_loc
+          itm
+    | Simple itm -> itm
+
+
+  method unparseResolvedRule  = function
+    | LayoutNode layoutNode -> layoutNode
+    | InfixTree _ as infixTree ->
+      formatComputedInfixChain (computeInfixChain infixTree)
+
+  method unparseExprApplicationItems x =
+    match self#unparseExprRecurse x with
+    | SpecificInfixPrecedence (_, wrappedRule) ->
+        let itm = self#unparseResolvedRule wrappedRule in
+        ([itm], Some x.pexp_loc)
+    | FunctionApplication itms -> (itms, Some x.pexp_loc)
+    | PotentiallyLowPrecedence itm -> ([itm], Some x.pexp_loc)
+    | Simple itm -> ([itm], Some x.pexp_loc)
+
+
+  (* Provides beautiful printing for pipe first sugar:
+   * foo
+   * ->f(a, b)
+   * ->g(c, d)
+   *)
+  method formatPipeFirst e =
+    let module PipeFirstTree = struct
+      type exp = Parsetree.expression
+
+      type flatNode =
+        | Exp of exp
+        | ExpU of exp (* uncurried *)
+        | Args of (Asttypes.arg_label * exp) list
+      type flatT = flatNode list
+
+      type node = {
+        exp: exp;
+        args: (Asttypes.arg_label *exp) list;
+        uncurried: bool;
+      }
+      type t = node list
+
+      let formatNode ?prefix ?(first=false) {exp; args; uncurried} =
+        let formatLayout expr =
+          let formatted = if first then
+            self#ensureExpression ~reducesOnToken:(Token pipeFirstToken) expr
+          else
+            match expr with
+            (* a->foo(x, _) and a->(foo(x, _)) are equivalent under pipe first
+             * (a->foo)(x, _) is unnatural and desugars to
+             *    (__x) => (a |. foo)(x, __x)
+             * Under `->`, it makes more sense to desugar into
+             *  a |. (__x => foo(x, __x))
+             *
+             * Hence we don't need parens in this case.
+             *)
+            | expr when Reason_heuristics.isUnderscoreApplication expr ->
+                LayoutNode (self#unparseExpr expr)
+            | _ ->
+              self#ensureContainingRule
+                ~withPrecedence:(Token pipeFirstToken) ~reducesAfterRight:expr ()
+          in
+          self#unparseResolvedRule formatted
+        in
+        let parens = match (exp.pexp_desc) with
+        | Pexp_apply (e,_) -> printedStringAndFixityExpr e = UnaryPostfix "^"
+        | _ -> false
+        in
+        let layout = match args with
+        | [] ->
+          let e = formatLayout exp in
+          (match prefix with
+          | Some l -> makeList [l; e]
+          | None -> e)
+        | args ->
+            let fakeApplExp =
+              let loc_end = match List.rev args with
+                | (_, e)::_ -> e.pexp_loc.loc_end
+                | _ -> exp.pexp_loc.loc_end
+              in
+              {exp with pexp_loc = { exp.pexp_loc with loc_end = loc_end } }
+            in
+            makeList (
+              self#formatFunAppl
+                ?prefix
+                ~jsxAttrs:[]
+                ~args
+                ~funExpr:exp
+                ~applicationExpr:fakeApplExp
+                ~uncurried
+                ()
+            )
+        in
+        if parens then
+          formatPrecedence layout
+        else layout
+    end in
+    (* Imagine: foo->f(a, b)->g(c,d)
+     * The corresponding parsetree looks more like:
+     *   (((foo->f)(a,b))->g)(c, d)
+     * The extra Pexp_apply nodes, e.g. (foo->f), result into a
+     * nested/recursive ast which is pretty inconvenient in terms of printing.
+     * For printing purposes we actually want something more like:
+     *  foo->|f(a,b)|->|g(c, d)|
+     * in order to provide to following printing:
+     *  foo
+     *  ->f(a, b)
+     *  ->g(c, d)
+     * The job of "flatten" is to turn the inconvenient, nested ast
+     *  (((foo->f)(a,b))->g)(c, d)
+     * into
+     *  [Exp foo; Exp f; Args [a; b]; Exp g; Args [c; d]]
+     * which can be processed for printing purposes.
+     *)
+    let rec flatten ?(uncurried=false) acc = function
+      | {pexp_desc = Pexp_apply(
+          {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+          [Nolabel, arg1; Nolabel, arg2]
+         )} ->
+          flatten ((PipeFirstTree.Exp arg2)::acc) arg1
+      | {pexp_attributes;
+         pexp_desc = Pexp_apply(
+          {pexp_desc = Pexp_apply(
+           {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})},
+             [Nolabel, arg1; Nolabel, arg2]
+           )},
+           args
+         )} as e ->
+          let args = PipeFirstTree.Args args in
+          begin match pexp_attributes with
+          | [{txt = "bs"}, PStr []] ->
+            flatten ((PipeFirstTree.ExpU arg2)::args::acc) arg1
+          | [] ->
+              (* the uncurried attribute might sit on the Pstr_eval
+               * enclosing the Pexp_apply*)
+              if uncurried then
+                flatten ((PipeFirstTree.ExpU arg2)::args::acc) arg1
+              else
+                flatten ((PipeFirstTree.Exp arg2)::args::acc) arg1
+          | _ ->
+            (PipeFirstTree.Exp e)::acc
+          end
+      | {pexp_desc = Pexp_ident({txt = Longident.Lident("|.")})} -> acc
+      | arg -> ((PipeFirstTree.Exp arg)::acc)
+    in
+    (* Given: foo->f(a, b)->g(c, d)
+     * We get the following PipeFirstTree.flatNode list:
+     *   [Exp foo; Exp f; Args [a; b]; Exp g; Args [c; d]]
+     * The job of `parse` is to turn the "flat representation"
+     * (a.k.a. PipeFirstTree.flastNode list) into a more convenient structure
+     * that allows us to express the segments: "foo" "f(a, b)" "g(c, d)".
+     * PipeFirstTree.t expresses those segments.
+     *  [{exp = foo; args = []}; {exp = f; args = [a; b]}; {exp = g; args = [c; d]}]
+     *)
+    let rec parse acc = function
+    | (PipeFirstTree.Exp e)::(PipeFirstTree.Args args)::xs ->
+        parse ((PipeFirstTree.{exp = e; args; uncurried = false})::acc) xs
+    | (PipeFirstTree.ExpU e)::(PipeFirstTree.Args args)::xs ->
+        parse ((PipeFirstTree.{exp = e; args; uncurried = true})::acc) xs
+    | (PipeFirstTree.Exp e)::xs ->
+        parse ((PipeFirstTree.{exp = e; args = []; uncurried = false})::acc) xs
+    | _ -> List.rev acc
+    in
+    (* Given: foo->f(. a,b);
+     * The uncurried attribute doesn't sit on the Pexp_apply, but sits on
+     * the top level Pstr_eval. We don't have access to top-level context here,
+     * hence the lookup in the global uncurriedTable to correctly determine
+     * if we need to print uncurried. *)
+    let uncurried = try Hashtbl.find uncurriedTable e.pexp_loc with
+      | Not_found -> false
+    in
+    (* Turn
+     *  foo->f(a, b)->g(c, d)
+     * into
+     *  [Exp foo; Exp f; Args [a; b]; Exp g; Args [c; d]]
+     *)
+    let (flatNodes : PipeFirstTree.flatT) = flatten ~uncurried [] e in
+    (* Turn
+     *  [Exp foo; Exp f; Args [a; b]; Exp g; Args [c; d]]
+     * into
+     *  [{exp = foo; args = []}; {exp = f; args = [a; b]}; {exp = g; args = [c; d]}]
+     *)
+    let (pipetree : PipeFirstTree.t) = parse [] flatNodes in
+    (* Turn
+     *  [{exp = foo; args = []}; {exp = f; args = [a; b]}; {exp = g; args = [c; d]}]
+     * into
+     *  [foo; ->f(a, b); ->g(c, d)]
+     *)
+    let pipeSegments = match pipetree with
+    (* Special case printing of
+     * foo->bar(
+     *  aa,
+     *  bb,
+     * )
+     *
+     *  We don't want
+     *  foo
+     *  ->bar(
+     *      aa,
+     *      bb
+     *    )
+     *
+     *  Notice how `foo->bar` shouldn't break, it wastes space and is
+     *  inconsistent with
+     *  foo.bar(
+     *    aa,
+     *    bb,
+     *  )
+     *)
+    | [({exp = {pexp_desc = Pexp_ident _ }} as hd); last] ->
+        let prefix = Some (
+          makeList [PipeFirstTree.formatNode ~first:true hd; atom "->"]
+        ) in
+        [PipeFirstTree.formatNode ?prefix last]
+    | hd::tl ->
+        let hd = PipeFirstTree.formatNode ~first:true hd in
+        let tl = List.map (fun node ->
+          makeList [atom "->"; PipeFirstTree.formatNode node]
+        ) tl in
+        hd::tl
+    | [] -> []
+    in
+    (* Provide nice breaking for: [foo; ->f(a, b); ->g(c, d)]
+     * foo
+     * ->f(a, b)
+     * ->g(c, d)
+     *)
+    makeList ~break:IfNeed ~inline:(true, true) pipeSegments
+
+  (*
+   * Replace (__x) => foo(__x) with foo(_)
+   *)
+  method process_underscore_application x =
+    let process_application expr =
+      let process_arg (l,e) = match e.pexp_desc with
+        | Pexp_ident ({ txt = Lident "__x"} as id) ->
+          let pexp_desc = Pexp_ident {id with txt = Lident "_"} in
+          (l, {e with pexp_desc})
+        | _ ->
+          (l,e) in
+      match expr.pexp_desc with
+      | Pexp_apply (e_fun, args) ->
+        let pexp_desc = Pexp_apply (e_fun, List.map process_arg args) in
+        {expr with pexp_desc}
+      | _ ->
+        expr in
+    match x.pexp_desc with
+    | Pexp_fun (Nolabel, None, {ppat_desc = Ppat_var {txt="__x"}},
+        ({pexp_desc = Pexp_apply _} as e)) ->
+      process_application e
+    | Pexp_fun (l, eo, p, e) ->
+       let e_processed = self#process_underscore_application e in
+       if e == e_processed then
+         x
+       else
+         {x with pexp_desc = Pexp_fun (l, eo, p, e_processed)}
+    | _ ->
+      x
+
+  method unparseExprRecurse x =
+    let x = self#process_underscore_application x in
+    (* If there are any attributes, render unary like `(~-) x [@ppx]`, and infix like `(+) x y [@attr]` *)
+
+    let {arityAttrs; stdAttrs; jsxAttrs; stylisticAttrs; uncurried} =
+      partitionAttributes ~allowUncurry:(Reason_heuristics.bsExprCanBeUncurried x) x.pexp_attributes
+    in
+    let stylisticAttrs = Reason_attributes.maybe_remove_stylistic_attrs stylisticAttrs preserve_braces in
+    let () = if uncurried then Hashtbl.add uncurriedTable x.pexp_loc true in
+    let x = {x with pexp_attributes = (stylisticAttrs @ arityAttrs @ stdAttrs @ jsxAttrs) } in
+    (* If there's any attributes, recurse without them, then apply them to
+       the ends of functions, or simplify infix printings then append. *)
+    if stdAttrs != [] then
+      let withoutVisibleAttrs = {x with pexp_attributes=(stylisticAttrs @ arityAttrs @ jsxAttrs)} in
+      let attributesAsList = (List.map self#attribute stdAttrs) in
+      let itms = match self#unparseExprRecurse withoutVisibleAttrs with
+        | SpecificInfixPrecedence ({reducePrecedence}, wrappedRule) ->
+            let itm = self#unparseResolvedRule wrappedRule in
+            (match reducePrecedence with
+             (* doesn't need wrapping; we know how to parse *)
+             | Custom "prec_lbracket" | Token "." -> [itm]
+             | _ -> [formatPrecedence ~loc:x.pexp_loc itm])
+        | FunctionApplication itms -> itms
+        | PotentiallyLowPrecedence itm -> [formatPrecedence ~loc:x.pexp_loc itm]
+        | Simple itm -> [itm]
+      in
+      FunctionApplication [
+        makeList
+          ~break:IfNeed
+          ~inline:(true, true)
+          ~indent:0
+          ~postSpace:true
+          (List.concat [attributesAsList; itms])
+      ]
+    else
+    match self#simplest_expression x with
+    | Some se -> Simple se
+    | None ->
+    match x.pexp_desc with
+    | Pexp_apply (e, ls) -> (
+      let ls = List.map (fun (l,expr) -> (l, self#process_underscore_application expr)) ls in
+      match (e, ls) with
+      | (e, _) when Reason_heuristics.isPipeFirst e ->
+        let prec = Token pipeFirstToken in
+          SpecificInfixPrecedence
+            ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode (self#formatPipeFirst x))
+      | ({pexp_desc = Pexp_ident {txt = Ldot (Lident ("Array"),"get")}}, [(_,e1);(_,e2)]) ->
+        begin match e1.pexp_desc with
+          | Pexp_ident ({txt = Lident "_"}) ->
+            let k = atom "Array.get" in
+            let v = makeList ~postSpace:true ~sep:(Layout.Sep ",") ~wrap:("(", ")")
+                [atom "_"; self#unparseExpr e2]
+            in
+            Simple (label k v)
+          | _ ->
+            let prec = Custom "prec_lbracket" in
+            let lhs = self#unparseResolvedRule (
+              self#ensureExpression ~reducesOnToken:prec e1
+            ) in
+            let rhs = self#unparseExpr e2 in
+            SpecificInfixPrecedence
+              ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode (self#access "[" "]" lhs rhs))
+        end
+      | ({pexp_desc = Pexp_ident {txt = Ldot (Lident ("String"),"get")}}, [(_,e1);(_,e2)]) ->
+        if Reason_heuristics.isUnderscoreIdent e1 then
+          let k = atom "String.get" in
+          let v = makeList ~postSpace:true ~sep:(Layout.Sep ",") ~wrap:("(", ")")
+              [atom "_"; self#unparseExpr e2]
+          in
+          Simple (label k v)
+        else
+          let prec = Custom "prec_lbracket" in
+            let lhs = self#unparseResolvedRule (
+              self#ensureExpression ~reducesOnToken:prec e1
+            ) in
+            let rhs = self#unparseExpr e2 in
+          SpecificInfixPrecedence
+            ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode (self#access ".[" "]" lhs rhs))
+      | (
+        {pexp_desc= Pexp_ident {txt=Ldot (Ldot (Lident "Bigarray", "Genarray" ), "get")}},
+        [(_,e1); (_,({pexp_desc=Pexp_array ls} as e2))]
+      ) ->
+        if (Reason_heuristics.isUnderscoreIdent e1) then
+          let k = atom "Bigarray.Genarray.get" in
+          let v = makeList ~postSpace:true ~sep:(Layout.Sep ",") ~wrap:("(", ")")
+              [atom "_"; self#unparseExpr e2]
+          in
+          Simple (label k v)
+        else
+          let formattedList = List.map self#unparseExpr ls in
+          let lhs = makeList [(self#simple_enough_to_be_lhs_dot_send e1); atom "."] in
+          let rhs = makeList ~break:IfNeed ~postSpace:true ~sep:commaSep ~wrap:("{", "}") formattedList in
+          let prec = Custom "prec_lbracket" in
+          SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode (label lhs rhs))
+      | (
+        {pexp_desc= Pexp_ident {txt=
+                                  Ldot (Ldot (Lident "Bigarray", (("Array1"|"Array2"|"Array3") as arrayIdent)), "get")}
+        },
+        (_,e1)::rest
+      ) ->
+        if Reason_heuristics.isUnderscoreIdent e1 then
+          let k = atom("Bigarray." ^ arrayIdent ^ ".get") in
+          let v = makeList ~postSpace:true ~sep:(Layout.Sep ",") ~wrap:("(", ")")
+              ((atom "_")::(List.map (fun (_, e) -> self#unparseExpr e) rest))
+          in
+          Simple (label k v)
+        else
+          let formattedList = List.map self#unparseExpr (List.map snd rest) in
+          let lhs = makeList [(self#simple_enough_to_be_lhs_dot_send e1); atom "."] in
+          let rhs = makeList ~break:IfNeed ~postSpace:true ~sep:commaSep ~wrap:("{", "}") formattedList in
+          let prec = Custom "prec_lbracket" in
+          SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode (label lhs rhs))
+      | _ -> (
+
+          match (self#sugar_set_expr_parts x) with
+      (* Returns None if there's attributes - would render as regular function *)
+      (* Format as if it were an infix function application with identifier "=" *)
+      | Some (simplyFormatedLeftItm, rightExpr) -> (
+        let tokenPrec = Token updateToken in
+        let rightItm = self#ensureContainingRule ~withPrecedence:tokenPrec ~reducesAfterRight:rightExpr () in
+        let leftWithOp = makeList ~postSpace:true [simplyFormatedLeftItm; atom updateToken] in
+        let expr = label ~space:true leftWithOp (self#unparseResolvedRule rightItm) in
+        SpecificInfixPrecedence ({reducePrecedence=tokenPrec; shiftPrecedence=tokenPrec}, LayoutNode expr)
+      )
+      | None -> (
+        match (printedStringAndFixityExpr e, ls) with
+       (* We must take care not to print two subsequent prefix operators without
+         spaces between them (`! !` could become `!!` which is totally
+         different).  *)
+        | (AlmostSimplePrefix prefixStr, [(Nolabel, rightExpr)]) ->
+        let forceSpace = match rightExpr.pexp_desc with
+          | Pexp_apply (ee, _) ->
+            (match printedStringAndFixityExpr ee with | AlmostSimplePrefix _ -> true | _ -> false)
+          | _ -> false
+        in
+        let prec = Token prefixStr in
+        let rightItm = self#unparseResolvedRule (
+          self#ensureContainingRule ~withPrecedence:prec ~reducesAfterRight:rightExpr ()
+        ) in
+        SpecificInfixPrecedence
+          ({reducePrecedence=prec; shiftPrecedence = prec}, LayoutNode (label ~space:forceSpace (atom prefixStr) rightItm))
+        | (UnaryPostfix postfixStr, [(Nolabel, leftExpr)]) ->
+          let forceSpace = match leftExpr.pexp_desc with
+            | Pexp_apply (ee, _) ->
+              (match printedStringAndFixityExpr ee with
+               | UnaryPostfix "^" | AlmostSimplePrefix _ -> true
+               | _ -> false)
+            | _ -> false
+          in
+          let leftItm = (match leftExpr.pexp_desc with
+            | Pexp_apply (e,_) ->
+              (match printedStringAndFixityExpr e with
+               | Infix printedIdent
+                 when requireNoSpaceFor printedIdent ||
+                      Reason_heuristics.isPipeFirst e ->
+                 self#unparseExpr leftExpr
+               | _ -> self#simplifyUnparseExpr leftExpr)
+            | Pexp_field _ -> self#unparseExpr leftExpr
+            | _ -> self#simplifyUnparseExpr leftExpr
+          )
+          in
+          Simple (label ~space:forceSpace leftItm (atom postfixStr))
+        | (Infix printedIdent, [(Nolabel, leftExpr); (Nolabel, rightExpr)]) ->
+          let infixToken = Token printedIdent in
+          let rightItm = self#ensureContainingRule ~withPrecedence:infixToken ~reducesAfterRight:rightExpr () in
+          let leftItm = self#ensureExpression ~reducesOnToken:infixToken leftExpr in
+          (* Left exprs of infix tokens which we don't print spaces for (e.g. `##`)
+             need to be wrapped in parens in the case of postfix `^`. Otherwise,
+             printing will be ambiguous as `^` is also a valid start of an infix
+             operator. *)
+          let formattedLeftItm = (match leftItm with
+            | LayoutNode x -> begin match leftExpr.pexp_desc with
+                | Pexp_apply (e,_) ->
+                  (match printedStringAndFixityExpr e with
+                   | UnaryPostfix "^" when requireNoSpaceFor printedIdent ->
+                     LayoutNode (formatPrecedence ~loc:leftExpr.pexp_loc x)
+                   | _ -> leftItm)
+                | _ -> leftItm
+              end
+            | InfixTree _ -> leftItm
+          ) in
+          let infixTree = InfixTree (printedIdent, formattedLeftItm, rightItm) in
+          SpecificInfixPrecedence ({reducePrecedence=infixToken; shiftPrecedence=infixToken}, infixTree)
+        (* Will be rendered as `(+) a b c` which is parsed with higher precedence than all
+           the other forms unparsed here.*)
+        | (UnaryPlusPrefix printedIdent, [(Nolabel, rightExpr)]) ->
+          let prec = Custom "prec_unary" in
+          let rightItm = self#unparseResolvedRule (
+            self#ensureContainingRule ~withPrecedence:prec ~reducesAfterRight:rightExpr ()
+          ) in
+          let expr = label ~space:true (atom printedIdent) rightItm in
+          SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=Token printedIdent}, LayoutNode expr)
+        | (UnaryMinusPrefix printedIdent as x, [(Nolabel, rightExpr)])
+        | (UnaryNotPrefix printedIdent as x, [(Nolabel, rightExpr)]) ->
+          let forceSpace = (match x with
+              | UnaryMinusPrefix _ -> true
+              | _ -> begin match rightExpr.pexp_desc with
+                  | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident s}}, _) ->
+                    isSimplePrefixToken s
+                  | _ -> false
+                end) in
+          let prec = Custom "prec_unary" in
+          let rightItm = self#unparseResolvedRule (
+            self#ensureContainingRule ~withPrecedence:prec ~reducesAfterRight:rightExpr ()
+          ) in
+          let expr = label ~space:forceSpace (atom printedIdent) rightItm in
+          SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=Token printedIdent}, LayoutNode expr)
+        (* Will need to be rendered in self#expression as (~-) x y z. *)
+        | (_, _) ->
+        (* This case will happen when there is something like
+
+             Bar.createElement a::1 b::2 [] [@bla] [@JSX]
+
+           At this point the bla will be stripped (because it's a visible
+           attribute) but the JSX will still be there.
+         *)
+
+        (* this case also happens when we have something like:
+         * List.map((a) => a + 1, numbers);
+         * We got two "List.map" as Pexp_ident & a list of arguments:
+         * [`(a) => a + 1`; `numbers`]
+         *
+         * Another possible case is:
+         * describe("App", () =>
+         *   test("math", () =>
+         *     Expect.expect(1 + 2) |> toBe(3)));
+         *)
+        let uncurried = try Hashtbl.find uncurriedTable x.pexp_loc with | Not_found -> false in
+        FunctionApplication (
+          self#formatFunAppl
+            ~uncurried
+            ~jsxAttrs
+            ~args:ls
+            ~applicationExpr:x
+            ~funExpr:e
+            ()
+          )
+        )
+      )
+    )
+    | Pexp_field (e, li) ->
+        let prec = Token "." in
+        let leftItm = self#unparseResolvedRule (
+          self#ensureExpression ~reducesOnToken:prec e
+        ) in
+        let {stdAttrs} = partitionAttributes e.pexp_attributes in
+        let formattedLeftItm = if stdAttrs == [] then
+            leftItm
+          else
+            formatPrecedence ~loc:e.pexp_loc leftItm
+        in
+        let layout = label (makeList [formattedLeftItm; atom "."]) (self#longident_loc li) in
+        SpecificInfixPrecedence ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode layout)
+    | Pexp_construct (li, Some eo) when not (is_simple_construct (view_expr x)) -> (
+        match view_expr x with
+        (* TODO: Explicit arity *)
+        | `normal ->
+            let arityIsClear = isArityClear arityAttrs in
+            FunctionApplication [self#constructor_expression ~arityIsClear stdAttrs (self#longident_loc li) eo]
+        | _ -> assert false
+      )
+    | Pexp_variant (l, Some eo) ->
+        if arityAttrs != [] then
+          raise (NotPossible "Should never see embedded attributes on poly variant")
+        else
+          FunctionApplication [self#constructor_expression ~polyVariant:true ~arityIsClear:true stdAttrs (atom ("`" ^ l)) eo]
+    (* TODO: Should protect this identifier *)
+    | Pexp_setinstvar (s, rightExpr) ->
+      let rightItm = self#unparseResolvedRule (
+        self#ensureContainingRule ~withPrecedence:(Token updateToken) ~reducesAfterRight:rightExpr ()
+      ) in
+      let expr = label ~space:true (makeList ~postSpace:true [(protectIdentifier s.txt); atom updateToken]) rightItm in
+      SpecificInfixPrecedence ({reducePrecedence=(Token updateToken); shiftPrecedence=(Token updateToken)}, LayoutNode expr)
+    | Pexp_setfield (leftExpr, li, rightExpr) ->
+      let rightItm = self#unparseResolvedRule (
+        self#ensureContainingRule ~withPrecedence:(Token updateToken) ~reducesAfterRight:rightExpr ()
+      ) in
+      let leftItm = self#unparseResolvedRule (
+        self#ensureExpression ~reducesOnToken:(Token ".") leftExpr
+      ) in
+      let leftLbl =
+        label
+          (makeList [leftItm; atom "."])
+          (self#longident_loc li) in
+      let expr = label ~space:true (makeList ~postSpace:true [leftLbl; atom updateToken]) rightItm in
+      SpecificInfixPrecedence ({reducePrecedence=(Token updateToken); shiftPrecedence=(Token updateToken)}, LayoutNode expr)
+    | Pexp_match (e, l) when detectTernary l != None -> (
+      match detectTernary l with
+      | None -> raise (Invalid_argument "Impossible")
+      | Some (tt, ff) ->
+        let ifTrue = self#unparseExpr tt in
+        let testItem = self#unparseResolvedRule (
+          self#ensureExpression e ~reducesOnToken:(Token "?")
+        ) in
+        let ifFalse = self#unparseResolvedRule (
+          self#ensureContainingRule ~withPrecedence:(Token ":") ~reducesAfterRight:ff ()
+        ) in
+        let trueBranch = label ~space:true ~break:`Never (atom "?") ifTrue
+        in
+        let falseBranch = label ~space:true ~break:`Never (atom ":") ifFalse
+        in
+        let expr = label ~space:true testItem (makeList ~break:IfNeed ~sep:(Sep " ") ~inline:(true, true) [trueBranch; falseBranch])
+        in
+        SpecificInfixPrecedence ({reducePrecedence=Token ":"; shiftPrecedence=Token "?"}, LayoutNode expr)
+      )
+    | _ -> (
+      match self#expression_requiring_parens_in_infix x with
+      | Some e -> e
+      | None -> raise (Invalid_argument "No match for unparsing expression")
+    )
+
+  method formatNonSequencyExpression e =
+    (*
+     * Instead of printing:
+     *   let result =  { open Fmt; strf(foo);}
+     *
+     * We format as:
+     *   let result = Fmt.(strf(foo))
+     *
+     * (Also see https://github.com/facebook/Reason/issues/114)
+     *)
+    match e.pexp_attributes, e.pexp_desc with
+    | [], Pexp_record _ (* syntax sugar for M.{x:1} *)
+    | [], Pexp_tuple _ (* syntax sugar for M.(a, b) *)
+    | [], Pexp_object {pcstr_fields = []} (* syntax sugar for M.{} *)
+    | [], Pexp_construct ( {txt= Lident"::"},Some _)
+    | [], Pexp_construct ( {txt= Lident"[]"},_)
+    | [], Pexp_extension ( {txt = "bs.obj"}, _ ) ->
+      self#simplifyUnparseExpr e (* syntax sugar for M.[x,y] *)
+    (* syntax sugar for the rest, wrap with parens to avoid ambiguity.
+     * E.g., avoid M.(M2.v) being printed as M.M2.v
+     * Or ReasonReact.(<> {string("Test")} </>);
+     *)
+    | _ -> makeList ~wrap:("(",")") ~break:IfNeed [self#unparseExpr e]
+
+  (*
+     It's not enough to only check if precedence of an infix left/right is
+     greater than the infix itself. We also should likely pay attention to
+     left/right associativity. So how do we render the minimum number of
+     parenthesis?
+
+     The intuition is that sequential right associative operators will
+     naturally build up deep trees on the right side (left builds up left-deep
+     trees). So by default, we add parens to model the tree structure that
+     we're rendering except when the parser will *naturally* parse the tree
+     structure that the parens assert.
+
+     Sequential identical infix operators:
+     ------------------------------------
+     So if we see a nested infix operator of precedence Y, as one side of
+     another infix operator that has the same precedence (Y), that is S
+     associative on the S side of the function application, we don't need to
+     wrap in parens. In more detail:
+
+     -Add parens around infix binary function application
+       Exception 1: Unless we are a left-assoc operator of precedence X in the left branch of an operator w/ precedence X.
+       Exception 2: Unless we are a right-assoc operator of precedence X in the right branch of an operator w/ precedence X.
+       Exception 3: Unless we are a _any_-assoc X operator in the _any_ branch of an Y operator where X has greater precedence than Y.
+
+     Note that the exceptions do not specify any special cases for mixing
+     left/right associativity. Precedence is what determines necessity of
+     parens for operators with non-identical precedences. Associativity
+     only determines necessity of parens for identically precedented operators.
+
+     PLUS is left assoc:
+     - So this one *shouldn't* expand into two consecutive infix +:
+
+
+            [Pexp_apply]
+              /      \
+         first +   [Pexp_apply]
+                      /   \
+                  second + third
+
+
+     - This one *should*:
+
+                    [Pexp_apply]
+                      /      \
+           [  Pexp_apply  ] + third
+              /     \
+           first +  second
+
+
+
+     COLONCOLON is right assoc, so
+     - This one *should* expand into two consecutive infix ::  :
+
+            [Pexp_apply]
+              /      \
+         first ::   [Pexp_apply]
+                      /   \
+                  second :: third
+
+
+     - This one *shouldn't*:
+
+                    [Pexp_apply]
+                      /      \
+           [  Pexp_apply  ] :: third
+              /     \
+           first ::  second
+
+
+
+
+     Sequential differing infix operators:
+     ------------------------------------
+
+     Neither of the following require paren grouping because of rule 3.
+
+
+            [Pexp_apply]
+              /      \
+         first  +  [Pexp_apply]
+                      /   \
+                  second * third
+
+
+                    [Pexp_apply]
+                      /      \
+            [Pexp_apply  +  third
+              /     \
+           first *  second
+
+      The previous has nothing to do with the fact that + and * have the same
+      associativity. Exception 3 applies to the following where :: is right assoc
+      and + is left. + has higher precedence than ::
+
+      - so parens aren't required to group + when it is in a branch of a
+        lower precedence ::
+
+            [Pexp_apply]
+              /      \
+         first ::   [Pexp_apply]
+                      /   \
+                  second + third
+
+
+      - Whereas there is no Exception that applies in this case (Exception 3
+        doesn't apply) so parens are required around the :: in this case.
+
+                    [Pexp_apply]
+                      /      \
+           [  Pexp_apply  ] + third
+              /     \
+           first ::  second
+
+  *)
+
+  method classExpressionToFormattedApplicationItems = function
+    | { pcl_desc = Pcl_apply (ce, l) } ->
+      [label (self#simple_class_expr ce) (self#label_x_expression_params l)]
+    | x -> [self#class_expr x]
+
+
+  (**
+        How JSX is formatted/wrapped. We want the attributes to wrap independently
+        of children.
+
+        <xxx
+          attr1=blah
+          attr2=foo>
+          child
+          child
+          child
+        </x>
+
+      +-------------------------------+
+      |  left   right (list of attrs) |
+      |   / \   /   \                 |
+      |   <tag                        |
+      |     attr1=blah                |
+      |     attr2=foo                 |
+      +-------------------------------+
+       |
+       |
+       |
+       |      left       right  list of children with
+       |   /       \    /  \     open,close = > </tag>
+       |  +---------+
+       +--|         |    >
+          +---------+
+
+          </tag>           *)
+  method formatJSXComponent componentName ?closeComponentName args =
+    let rec processArguments arguments processedAttrs children =
+      match arguments with
+      | (Labelled "children", {pexp_desc = Pexp_construct (_, None)}) :: tail ->
+        processArguments tail processedAttrs None
+      | (Labelled "children", {pexp_desc = Pexp_construct ({txt = Lident"::"}, Some {pexp_desc = Pexp_tuple components} )}) :: tail ->
+        processArguments tail processedAttrs (self#formatChildren components [])
+      | (Labelled "children", expr) :: tail ->
+          let dotdotdotChild = match expr with
+            | {pexp_desc = Pexp_apply (funExpr, args)}
+              when printedStringAndFixityExpr funExpr == Normal &&
+                   Reason_attributes.without_stylistic_attrs expr.pexp_attributes == [] ->
+              begin match (self#formatFunAppl ~prefix:(atom "...") ~wrap:("{", "}") ~jsxAttrs:[] ~args ~funExpr ~applicationExpr:expr ()) with
+              | [x] -> x
+              | xs -> makeList xs
+              end
+            | {pexp_desc = Pexp_fun _ } ->
+                self#formatPexpFun ~prefix:(atom "...") ~wrap:("{", "}") expr
+            | _ ->
+              let childLayout = self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{", "}") expr in
+              makeList ~break:Never [atom "..."; childLayout]
+          in
+          processArguments tail processedAttrs (Some [dotdotdotChild])
+      | (Optional lbl, expression) :: tail ->
+        let nextAttr =
+          match expression.pexp_desc with
+          | Pexp_ident ident when isPunnedJsxArg lbl ident ->
+              makeList ~break:Layout.Never [atom "?"; atom lbl]
+          | _ ->
+              label
+                (makeList ~break:Layout.Never [atom lbl; atom "=?"])
+                (self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{","}") expression) in
+        processArguments tail (nextAttr :: processedAttrs) children
+
+      | (Labelled lbl, expression) :: tail ->
+         let nextAttr =
+           match expression.pexp_desc with
+           | Pexp_ident ident when isPunnedJsxArg lbl ident -> atom lbl
+           | _ when isJSXComponent expression  ->
+               label (atom (lbl ^ "="))
+                     (makeList ~break:IfNeed ~wrap:("{", "}")
+                       [self#dont_preserve_braces#simplifyUnparseExpr expression])
+           | Pexp_open (_, lid, e)
+             when self#isSeriesOfOpensFollowedByNonSequencyExpression expression ->
+             label (makeList [atom lbl;
+                              atom "=";
+                              (label (self#longident_loc lid) (atom "."))])
+                   (self#formatNonSequencyExpression e)
+           | Pexp_apply ({pexp_desc = Pexp_ident _} as funExpr, args)
+                when printedStringAndFixityExpr funExpr == Normal &&
+                     Reason_attributes.without_stylistic_attrs expression.pexp_attributes == [] ->
+             let lhs = makeList [atom lbl; atom "="] in
+             begin match (
+               self#formatFunAppl
+                ~prefix:lhs
+                ~wrap:("{", "}")
+                ~jsxAttrs:[]
+                ~args
+                ~funExpr
+                ~applicationExpr:expression
+                ())
+             with
+             | [x] -> x
+             | xs -> makeList xs
+             end
+           | Pexp_apply (eFun, _) ->
+             let lhs = makeList [atom lbl; atom "="] in
+             let rhs = (match printedStringAndFixityExpr eFun with
+                 | Infix str when requireNoSpaceFor str -> self#unparseExpr expression
+                 | _ -> self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{","}") expression)
+             in label lhs rhs
+           | Pexp_record _
+           | Pexp_construct _
+           | Pexp_array _
+           | Pexp_tuple _
+           | Pexp_match _
+           | Pexp_extension _
+           | Pexp_function _ ->
+               label
+                (makeList [atom lbl; atom "="])
+                (self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{","}") expression)
+           | Pexp_fun _ ->
+               let propName = makeList [atom lbl; atom "="] in
+               self#formatPexpFun ~wrap:("{", "}") ~prefix:propName expression
+           | _ -> makeList [
+                    atom lbl;
+                    atom "=";
+                    self#dont_preserve_braces#simplifyUnparseExpr ~wrap:("{","}") expression
+                  ]
+         in
+         processArguments tail (nextAttr :: processedAttrs) children
+      | [] -> (processedAttrs, children)
+      | _ :: tail -> processArguments tail processedAttrs children
+    in
+    let (reversedAttributes, children) = processArguments args [] None in
+    match children with
+    | None ->
+      makeList
+        ~break:IfNeed
+        ~wrap:("<" ^ componentName, "/>")
+        ~pad:(true, true)
+        ~inline:(false, false)
+        ~postSpace:true
+        (List.rev reversedAttributes)
+    | Some renderedChildren ->
+      let openTagAndAttrs =
+        match reversedAttributes with
+        | [] -> (atom ("<" ^ componentName ^ ">"))
+        | revAttrHd::revAttrTl ->
+          let finalAttrList = (List.rev (makeList ~break:Layout.Never [revAttrHd; atom ">"] :: revAttrTl)) in
+          let renderedAttrList = (makeList ~inline:(true, true) ~break:IfNeed ~pad:(false, false) ~preSpace:true finalAttrList) in
+          label
+            ~space:true
+            (atom ("<" ^ componentName))
+            renderedAttrList
+      in
+      label
+        openTagAndAttrs
+        (makeList
+          ~wrap:("", "</" ^ (match closeComponentName with None -> componentName | Some close -> close) ^ ">")
+          ~inline:(true, false)
+          ~break:IfNeed
+          ~pad:(true, true)
+          ~postSpace:true
+          renderedChildren)
+
+  (*
+   * Format Pexp_fun expression: (a, b) => a + b;
+   * Example: the `onClick` prop with Pexp_fun in
+   *  <div
+   *    onClick={(event) => {
+   *      Js.log(event);
+   *      handleChange(event);
+   *    }}
+   *  />;
+   *
+   *  The arguments of the callback (Pexp_fun) should be inlined as much as
+   *  possible on the same line as `onClick={`.
+   *  Also notice the brace-hugging `}}` at the end.
+   *
+   *  ~prefix -> prefixes the Pexp_fun layout, example `onClick=`
+   *  ~wrap -> wraps the `Pexp_fun` in the tuple passed to wrap, e.g. `{` and
+   *  `}` for jsx
+   *)
+  method formatPexpFun ?(prefix=(atom "")) ?(wrap=("","")) expression =
+    let (lwrap, rwrap) = wrap in
+    let {stdAttrs; uncurried} = partitionAttributes expression.pexp_attributes in
+    if uncurried then Hashtbl.add uncurriedTable expression.pexp_loc true;
+
+    let (args, ret) =
+      (* omit attributes here, we're formatting them manually *)
+      self#curriedPatternsAndReturnVal {expression with pexp_attributes = [] }
+    in
+    (* Format `onClick={` *)
+    let propName = makeList ~wrap:("", lwrap) [prefix] in
+    let argsList =
+      let args = match args with
+      | [argsList] -> argsList
+      | args -> makeList args
+      in
+      match stdAttrs with
+      | [] -> args
+      | attrs ->
+          (* attach attributes to the args of the Pexp_fun: `[@attr] (event)` *)
+          let attrList =
+            makeList ~inline:(true, true) ~break:IfNeed ~postSpace:true
+              (List.map self#attribute attrs)
+          in
+          let all = [attrList; args] in
+          makeList ~break:IfNeed ~inline:(true, true) ~postSpace:true all
+    in
+    (* Format `onClick={(event)` *)
+    let propNameWithArgs = label propName argsList in
+    (* Pick constraints: (a, b) :string => ...
+     * :string is the constraint here *)
+    let (return, optConstr) = match ret.pexp_desc with
+      | Pexp_constraint (e, ct) -> (e, Some (self#non_arrowed_core_type ct))
+      | _ -> (ret, None)
+    in
+    let returnExpr = match (self#letList return) with
+    | [x] ->
+      (* Format `handleChange(event)}` or
+       *  handleChange(event)
+       * }
+       *
+       * If the closing rwrap is empty, we need it to be inline, otherwise
+       * we get a empty newline when the layout breaks:
+       * ```
+       *  handleChange(event)
+       *
+       * ```
+       * (Notice to nonsense newline)
+       *)
+       let inlineClosing = rwrap = "" in
+       makeList ~break:IfNeed ~inline:(true, inlineClosing) ~wrap:("", rwrap) [x]
+    | xs ->
+      (* Format `Js.log(event)` and `handleChange(event)` as
+       * {
+       *   Js.log(event);
+       *   handleChange(event);
+       * }}
+       *)
+        makeList
+          ~break:Always_rec ~sep:(SepFinal (";", ";")) ~wrap:("{", "}" ^ rwrap)
+          xs
+    in
+    match optConstr with
+    | Some typeConstraint ->
+      let upToConstraint =
+        label ~space:true
+          (makeList ~wrap:("", ":") [propNameWithArgs])
+          typeConstraint
+      in
+      label ~space:true
+        (makeList ~wrap:("", " =>") [upToConstraint])
+        returnExpr
+    | None ->
+      label ~space:true
+        (makeList ~wrap:("", " =>") [propNameWithArgs])
+        returnExpr
+
+  (* Creates a list of simple module expressions corresponding to module
+     expression or functor application. *)
+  method moduleExpressionToFormattedApplicationItems ?(prefix="") x =
+    match x with
+    (* are we formatting a functor application with a module structure as arg?
+     * YourLib.Make({
+     *   type t = int;
+     *   type s = string;
+     * });
+     *
+     * We should "hug" the parens here: ({ & }) should stick together.
+     *)
+    | { pmod_desc = Pmod_apply (
+            ({pmod_desc = Pmod_ident _} as m1),
+            ({pmod_desc = Pmod_structure _} as m2)
+         )
+      } ->
+        let modIdent = source_map ~loc:m1.pmod_loc (self#simple_module_expr m1) in
+        let name = if prefix <> "" then
+          makeList ~postSpace:true[atom prefix; modIdent]
+          else modIdent
+        in
+        let arg = source_map ~loc:m2.pmod_loc (self#simple_module_expr ~hug:true m2) in
+        label name arg
+    | _ ->
+      let rec extract_apps args = function
+        | { pmod_desc = Pmod_apply (me1, me2) } ->
+          let arg = source_map ~loc:me2.pmod_loc (self#simple_module_expr me2) in
+          extract_apps (arg :: args) me1
+        | me ->
+          let head = source_map ~loc:me.pmod_loc (self#module_expr me) in
+          if args == [] then head else label head (makeTup args)
+      in
+      let functor_application = extract_apps [] x in
+      if prefix <> "" then
+        makeList ~postSpace:true [atom prefix; functor_application]
+      else
+        functor_application
+
+  (*
+
+     Watch out, if you see something like below (sixteenTuple getting put on a
+     newline), yet a paren-wrapped list wouldn't have had an extra newlin, you
+     might need to wrap the single token (sixteenTuple) in [ensureSingleTokenSticksToLabel].
+     let (
+        axx,
+        oxx,
+        pxx
+      ):
+        sixteenTuple = echoTuple (
+        0,
+        0,
+        0
+      );
+  *)
+
+  method formatSimplePatternBinding labelOpener layoutPattern typeConstraint appTerms =
+    let letPattern = label ~break:`Never ~space:true (atom labelOpener) layoutPattern in
+    let upUntilEqual =
+      match typeConstraint with
+        | None -> letPattern
+        | Some tc -> formatTypeConstraint letPattern tc
+    in
+    let includingEqual = makeList ~postSpace:true [upUntilEqual; atom "="] in
+    formatAttachmentApplication applicationFinalWrapping (Some (true, includingEqual)) appTerms
+
+  (*
+     The [bindingLabel] is either the function name (if let binding) or first
+     arg (if lambda).
+
+     For defining layout of the following form:
+
+         lbl one
+             two
+             constraint => {
+           ...
+         }
+
+     If using "=" as the arrow, can also be used for:
+
+         met private
+             myMethod
+             constraint = fun ...
+
+   *)
+  method wrapCurriedFunctionBinding
+         ?attachTo
+         ~arrow
+         ?(sweet=false)
+         ?(spaceBeforeArrow=true)
+         prefixText
+         bindingLabel
+         patternList
+         returnedAppTerms =
+    let allPatterns = bindingLabel::patternList in
+    let partitioning = curriedFunctionFinalWrapping allPatterns in
+    let everythingButReturnVal =
+      (*
+         Because align_closing is set to false, you get:
+
+         (Brackets[] inserted to show boundaries between open/close of pattern list)
+         let[firstThing
+             secondThing
+             thirdThing]
+
+         It only wraps to indent four by coincidence: If the "opening" token was
+         longer, you'd get:
+
+         letReallyLong[firstThing
+                       secondThing
+                       thirdThing]
+
+         For curried let bindings, we stick the arrow in the *last* pattern:
+         let[firstThing
+             secondThing
+             thirdThing =>]
+
+         But it could have just as easily been the "closing" token corresponding to
+         "let". This works because we have [align_closing = false]. The benefit of
+         shoving it in the last pattern, is that we can turn [align_closing = true]
+         and still have the arrow stuck to the last pattern (which is usually what we
+         want) (See modeTwo below).
+      *)
+      match partitioning with
+        | None when sweet ->
+          makeList
+            ~pad:(false, spaceBeforeArrow)
+            ~wrap:("", arrow)
+            ~indent:(settings.space * settings.indentWrappedPatternArgs)
+            ~postSpace:true
+            ~inline:(true, true)
+            ~break:IfNeed
+            allPatterns
+        | None ->
+            (* We want the binding label to break *with* the arguments. Again,
+               there's no apparent way to add additional indenting for the
+               args with this setting. *)
+
+            (*
+               Formats lambdas by treating the first pattern as the
+               "bindingLabel" which is kind of strange in some cases (when
+               you only have one arg that wraps)...
+
+                  echoTheEchoer (
+                    fun (
+                          a,
+                          p
+                        ) => (
+                      a,
+                      b
+                    )
+
+               But it makes sense in others (where you have multiple args):
+
+                  echoTheEchoer (
+                    fun (
+                          a,
+                          p
+                        )
+                        mySecondArg
+                        myThirdArg => (
+                      a,
+                      b
+                    )
+
+               Try any other convention for wrapping that first arg and it
+               won't look as balanced when adding multiple args.
+
+            *)
+          makeList
+            ~pad:(true, spaceBeforeArrow)
+            ~wrap:(prefixText, arrow)
+            ~indent:(settings.space * settings.indentWrappedPatternArgs)
+            ~postSpace:true
+            ~inline:(true, true)
+            ~break:IfNeed
+            allPatterns
+        | Some (attachedList, wrappedListy) ->
+            (* To get *only* the final argument to "break", while not
+               necessarily breaking the prior arguments, we dock everything
+               but the last item to a created label *)
+          label
+            ~space:true
+            (
+              makeList
+                ~pad:(true, spaceBeforeArrow)
+                ~wrap:(prefixText, arrow)
+                ~indent:(settings.space * settings.indentWrappedPatternArgs)
+                ~postSpace:true
+                ~inline:(true, true)
+                ~break:IfNeed
+                attachedList
+            )
+            wrappedListy
+    in
+
+    let everythingButAppTerms = match attachTo with
+      | None -> everythingButReturnVal
+      | Some toThis -> label ~space:true toThis everythingButReturnVal
+    in
+    formatAttachmentApplication
+      applicationFinalWrapping
+      (Some (true, everythingButAppTerms))
+      returnedAppTerms
+
+  method leadingCurriedAbstractTypes x =
+    let rec argsAndReturn xx =
+      match xx.pexp_desc with
+        | Pexp_newtype (str,e) ->
+            let (nextArgs, return) = argsAndReturn e in
+            (str::nextArgs, return)
+        | _ -> ([], xx.pexp_desc)
+    in argsAndReturn x
+
+  method curriedConstructorPatternsAndReturnVal cl =
+    let rec argsAndReturn args = function
+      | { pcl_desc = Pcl_fun (label, eo, p, e); pcl_attributes = [] } ->
+        let arg = source_map ~loc:p.ppat_loc (self#label_exp label eo p) in
+        argsAndReturn (arg :: args) e
+      | xx ->
+        if args == [] then (None, xx) else (Some (makeTup (List.rev args)), xx)
+    in
+    argsAndReturn [] cl
+
+
+
+  (*
+    Returns the arguments list (if any, that occur before the =>), and the
+    final expression (that is either returned from the function (after =>) or
+    that is bound to the value (if there are no arguments, and this is just a
+    let pattern binding)).
+  *)
+  method curriedPatternsAndReturnVal x =
+    let uncurried = try Hashtbl.find uncurriedTable x.pexp_loc with | Not_found -> false in
+    let rec extract_args xx =
+      let {stdAttrs} = partitionAttributes ~allowUncurry:false xx.pexp_attributes in
+      if stdAttrs != [] then
+        ([], xx)
+      else match xx.pexp_desc with
+        (* label * expression option * pattern * expression *)
+        | Pexp_fun (l, eo, p, e) ->
+          let args, ret = extract_args e in
+          (`Value (l,eo,p) :: args, ret)
+        | Pexp_newtype (newtype,e) ->
+          let args, ret = extract_args e in
+          (`Type newtype :: args, ret)
+        | Pexp_constraint _ -> ([], xx)
+        | _ -> ([], xx)
+    in
+    let prepare_arg = function
+      | `Value (l,eo,p) -> source_map ~loc:p.ppat_loc (self#label_exp l eo p)
+      | `Type nt -> atom ("type " ^ nt)
+    in
+    let single_argument_no_parens p ret =
+      if uncurried then false
+      else
+        let isUnitPat = is_unit_pattern p in
+        let isAnyPat = is_any_pattern p in
+        begin match ret.pexp_desc with
+        (* (event) :ReasonReact.event => {...}
+         * The above Pexp_fun with constraint ReasonReact.event requires parens
+         * surrounding the single argument `event`.*)
+        | Pexp_constraint _ when not isUnitPat && not isAnyPat -> false
+        | _ -> isUnitPat || isAnyPat || is_ident_pattern p
+      end
+    in
+    match extract_args x with
+    | ([], ret) -> ([], ret)
+    | ([`Value (Nolabel, None, p) ], ret) when is_unit_pattern p && uncurried ->
+        ( [atom "(.)"], ret)
+    | ([`Value (Nolabel, None, p) as arg], ret) when single_argument_no_parens p ret ->
+      ([prepare_arg arg], ret)
+    | (args, ret) ->
+        ([makeTup ~uncurried (List.map prepare_arg args)], ret)
+
+  (* Returns the (curriedModule, returnStructure) for a functor *)
+  method curriedFunctorPatternsAndReturnStruct = function
+    (* string loc * module_type option * module_expr *)
+    | { pmod_desc = Pmod_functor(s, mt, me2) } ->
+        let firstOne =
+          match mt with
+            | None -> atom "()"
+            | Some mt' -> self#module_type (makeList [atom s.txt; atom ":"]) mt'
+        in
+        let (functorArgsRecurse, returnStructure) = (self#curriedFunctorPatternsAndReturnStruct me2) in
+        (firstOne::functorArgsRecurse, returnStructure)
+    | me -> ([], me)
+
+  method isRenderableAsPolymorphicAbstractTypes
+         typeVars
+         polyType
+         leadingAbstractVars
+         nonVarifiedType =
+      same_ast_modulo_varification_and_extensions polyType nonVarifiedType &&
+      for_all2' string_equal typeVars leadingAbstractVars
+
+  (* Reinterpret this as a pattern constraint since we don't currently have a
+     way to disambiguate. There is currently a way to disambiguate a parsing
+     from Ppat_constraint vs.  Pexp_constraint. Currently (and consistent with
+     OCaml standard parser):
+
+       let (x: typ) = blah;
+         Becomes Ppat_constraint
+       let x:poly . type = blah;
+         Becomes Ppat_constraint
+       let x:typ = blah;
+         Becomes Pexp_constraint(ghost)
+       let x = (blah:typ);
+         Becomes Pexp_constraint(ghost)
+
+     How are double constraints represented?
+     let (x:typ) = (blah:typ);
+     If currently both constraints are parsed into a single Pexp_constraint,
+     then something must be lost, and how could you fail type checking on:
+     let x:int = (10:string) ?? Answer: It probably parses into a nested
+     Pexp_constraint.
+
+     Proposal:
+
+       let (x: typ) = blah;
+         Becomes Ppat_constraint   (still)
+       let x:poly . type = blah;
+         Becomes Ppat_constraint   (still)
+       let x:typ = blah;
+         Becomes Ppat_constraint
+       let x = blah:typ;
+         Becomes Pexp_constraint
+
+
+     Reasoning: Allows parsing of any of the currently valid ML forms, but
+     combines the two most similar into one form. The only lossyness is the
+     unnecessary parens, which there is already precedence for dropping in
+     expressions. In the existing approach, preserving a paren-constrained
+     expression is *impossible* because it becomes pretty printed as
+     let x:t =.... In the proposal, it is not impossible - it is only
+     impossible to preserve unnecessary parenthesis around the let binding.
+
+     The one downside is that integrating with existing code that uses [let x =
+     (blah:typ)] in standard OCaml will be parsed as a Pexp_constraint. There
+     might be some lossiness (beyond parens) that occurs in the original OCaml
+     parser.
+  *)
+
+  method locallyAbstractPolymorphicFunctionBinding prefixText layoutPattern funWithNewTypes absVars bodyType =
+    let appTerms = self#unparseExprApplicationItems funWithNewTypes in
+    let locallyAbstractTypes = (List.map atom absVars) in
+    let typeLayout =
+      source_map ~loc:bodyType.ptyp_loc (self#core_type bodyType)
+    in
+    let polyType =
+      label
+        ~space:true
+        (* TODO: This isn't a correct use of sep! It ruins how
+         * comments are interleaved. *)
+        (makeList [makeList ~sep:(Sep " ") (atom "type"::locallyAbstractTypes); atom "."])
+        typeLayout
+      in
+    self#formatSimplePatternBinding
+      prefixText
+      layoutPattern
+      (Some polyType)
+      appTerms
+
+  (**
+      Intelligently switches between:
+      Curried function binding w/ constraint on return expr:
+         lbl patt
+             pattAux
+             arg
+             :constraint => {
+           ...
+         }
+
+      Constrained:
+         lbl patt
+             pattAux...
+             :constraint = {
+           ...
+         }
+   *)
+  method wrappedBinding prefixText ~arrow pattern patternAux expr =
+    let expr = self#process_underscore_application expr in
+    let (argsList, return) = self#curriedPatternsAndReturnVal expr in
+    let patternList = match patternAux with
+      | [] -> pattern
+      | _::_ -> makeList ~postSpace:true ~inline:(true, true) ~break:IfNeed (pattern::patternAux)
+    in
+    match (argsList, return.pexp_desc) with
+      | ([], Pexp_constraint (e, ct)) ->
+          let typeLayout =
+            source_map ~loc:ct.ptyp_loc
+              begin match ct.ptyp_desc with
+              | Ptyp_package (li, cstrs) ->
+                self#typ_package li cstrs
+              | _ ->
+                self#core_type ct
+              end
+          in
+          let appTerms = self#unparseExprApplicationItems e in
+          self#formatSimplePatternBinding prefixText patternList (Some typeLayout) appTerms
+      | ([], _) ->
+          (* simple let binding, e.g. `let number = 5` *)
+          (* let f = (. a, b) => a + b; *)
+          let appTerms = self#unparseExprApplicationItems expr in
+          self#formatSimplePatternBinding prefixText patternList None appTerms
+      | (_::_, _) ->
+          let (argsWithConstraint, actualReturn) = self#normalizeFunctionArgsConstraint argsList return in
+          let fauxArgs =
+            List.concat [patternAux; argsWithConstraint] in
+          let returnedAppTerms = self#unparseExprApplicationItems actualReturn in
+           (* Attaches the `=` to `f` to recreate javascript function syntax in
+            * let f = (a, b) => a + b; *)
+          let lbl = makeList ~sep:(Sep " ") ~break:Layout.Never [pattern; atom "="] in
+          self#wrapCurriedFunctionBinding prefixText ~arrow lbl fauxArgs returnedAppTerms
+
+  (* Similar to the above method. *)
+  method wrappedClassBinding prefixText pattern patternAux expr =
+    let (args, return) = self#curriedConstructorPatternsAndReturnVal expr in
+    let patternList =
+      match patternAux with
+        | [] -> pattern
+        | _::_ -> makeList ~postSpace:true ~inline:(true, true) ~break:IfNeed (pattern::patternAux)
+    in
+    match (args, return.pcl_desc) with
+      | (None, Pcl_constraint (e, ct)) ->
+          let typeLayout = source_map ~loc:ct.pcty_loc (self#class_constructor_type ct) in
+          self#formatSimplePatternBinding prefixText patternList (Some typeLayout)
+            (self#classExpressionToFormattedApplicationItems e, None)
+      | (None, _) ->
+          self#formatSimplePatternBinding prefixText patternList None
+            (self#classExpressionToFormattedApplicationItems expr, None)
+      | (Some args, _) ->
+          let (argsWithConstraint, actualReturn) =
+            self#normalizeConstructorArgsConstraint [args] return in
+          let fauxArgs =
+            List.concat [patternAux; argsWithConstraint] in
+          self#wrapCurriedFunctionBinding prefixText ~arrow:"=" pattern fauxArgs
+            (self#classExpressionToFormattedApplicationItems actualReturn, None)
+
+  (* Attaches doc comments to a layout, with whitespace preserved
+   * Example:
+   * /** Doc comment */
+   *
+   * /* another random comment */
+   * let a = 1;
+   *)
+  method attachDocAttrsToLayout
+    (* all std attributes attached on the ast node backing the layout *)
+    ~stdAttrs:(stdAttrs : Ast_404.Parsetree.attributes)
+    (* all doc comments attached on the ast node backing the layout *)
+    ~docAttrs:(docAttrs : Ast_404.Parsetree.attributes)
+    (* location of the layout *)
+    ~loc
+    (* layout to attach the doc comments to *)
+    ~layout () =
+    (*
+     * compute the correct location of layout
+     * Example:
+     * 1| /** doc-comment */
+     * 2|
+     * 3| [@attribute]
+     * 4| let a = 1;
+     *
+     * The location might indicate a start of line 4 for the ast-node
+     * representing `let a = 1`. The reality is that `[@attribute]` should be
+     * included (start of line 3), to represent the correct start location
+     * of the whole layout.
+     *)
+    let loc = match stdAttrs with
+    | (astLoc, _)::_ -> astLoc.loc
+    | [] -> loc
+    in
+    let rec aux prevLoc layout = function
+      | ((x, _) as attr : Ast_404.Parsetree.attribute)::xs ->
+        let newLayout =
+          let range = Range.makeRangeBetween x.loc prevLoc in
+          let layout =
+            if Range.containsWhitespace ~range ~comments:self#comments () then
+              let region = WhitespaceRegion.make ~range ~newlines:1 () in
+              Layout.Whitespace(region, layout)
+            else layout
+          in
+          makeList ~inline:(true, true) ~break:Always [
+            self#attribute attr;
+            layout
+          ]
+        in aux x.loc newLayout xs
+      | [] -> layout
+    in
+    aux loc layout (List.rev docAttrs)
+
+  method binding prefixText x = (* TODO: print attributes *)
+    let body = match x.pvb_pat.ppat_desc with
+      | (Ppat_var _) ->
+        self#wrappedBinding prefixText ~arrow:"=>"
+          (source_map ~loc:x.pvb_pat.ppat_loc (self#simple_pattern x.pvb_pat))
+          [] x.pvb_expr
+      (*
+         Ppat_constraint is used in bindings of the form
+
+            let (inParenVar:typ) = ...
+
+         And in the case of let bindings for explicitly polymorphic type
+         annotations (see parser for more details).
+
+         See reason_parser.mly for explanation of how we encode the two primary
+         forms of explicit polymorphic annotations in the parse tree, and how
+         we must recover them here.
+       *)
+      | (Ppat_constraint(p, ty)) -> (
+          (* Locally abstract forall types are *seriously* mangled by the parsing
+             stage, and we have to be very smart about how to recover it.
+
+              let df_locallyAbstractFuncAnnotated:
+                type a b.
+                  a =>
+                  b =>
+                  (inputEchoRecord a, inputEchoRecord b) =
+                fun (input: a) (input2: b) => (
+                  {inputIs: input},
+                  {inputIs: input2}
+                );
+
+             becomes:
+
+               let df_locallyAbstractFuncAnnotatedTwo:
+                 'a 'b .
+                 'a => 'b => (inputEchoRecord 'a, inputEchoRecord 'b)
+                =
+                 fun (type a) (type b) => (
+                   fun (input: a) (input2: b) => ({inputIs: input}, {inputIs:input2}):
+                     a => b => (inputEchoRecord a, inputEchoRecord b)
+                 );
+          *)
+          let layoutPattern =
+            source_map ~loc:x.pvb_pat.ppat_loc (self#simple_pattern p)
+          in
+          let leadingAbsTypesAndExpr = self#leadingCurriedAbstractTypes x.pvb_expr in
+          match (p.ppat_desc, ty.ptyp_desc, leadingAbsTypesAndExpr) with
+            | (Ppat_var _,
+               Ptyp_poly (typeVars, varifiedPolyType),
+               (_::_ as absVars, Pexp_constraint(funWithNewTypes, nonVarifiedExprType)))
+              when self#isRenderableAsPolymorphicAbstractTypes
+                  typeVars
+                  (* If even artificially varified - don't know until returns*)
+                  varifiedPolyType
+                  absVars
+                  nonVarifiedExprType ->
+              (*
+                 We assume was the case whenever we see this pattern in the
+                 AST, it was because the parser parsed the polymorphic locally
+                 abstract type sugar.
+
+                 Ppat_var..Ptyp_poly...Pexp_constraint:
+
+                    let x: 'a 'b . 'a => 'b => 'b =
+                      fun (type a) (type b) =>
+                         (fun aVal bVal => bVal : a => b => b);
+
+                 We need to be careful not to accidentally detect similar
+                 forms, that cannot be printed as sugar.
+
+                    let x: 'a 'b . 'a => 'b => 'b =
+                      fun (type a) (type b) =>
+                         (fun aVal bVal => bVal : int => int => int);
+
+                 Should *NOT* be formatted as:
+
+                    let x: type a b. int => int => int = fun aVal bVal => bVal;
+
+                 The helper function
+                 [same_ast_modulo_varification_and_extensions] was created to
+                 help compare the varified constraint pattern body, and the
+                 non-varified expression constraint type.
+
+                 The second requirement that we check before assuming that the
+                 sugar form is correct, is to make sure the list of type vars
+                 corresponds to a leading prefix of the Pexp_newtype variables.
+              *)
+              self#locallyAbstractPolymorphicFunctionBinding
+                prefixText
+                layoutPattern
+                funWithNewTypes
+                absVars
+                nonVarifiedExprType
+            | _ ->
+              let typeLayout = source_map ~loc:ty.ptyp_loc (self#core_type ty) in
+              let appTerms = self#unparseExprApplicationItems x.pvb_expr in
+              self#formatSimplePatternBinding
+                prefixText
+                layoutPattern
+                (Some typeLayout)
+                appTerms
+        )
+      | _ ->
+        let layoutPattern =
+          source_map ~loc:x.pvb_pat.ppat_loc (self#pattern x.pvb_pat)
+        in
+        let appTerms = self#unparseExprApplicationItems x.pvb_expr in
+        self#formatSimplePatternBinding prefixText layoutPattern None appTerms
+    in
+    let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true x.pvb_attributes in
+
+    let body = makeList ~inline:(true, true) [body] in
+    let layout = self#attach_std_item_attrs stdAttrs (source_map ~loc:x.pvb_loc body) in
+    self#attachDocAttrsToLayout
+      ~stdAttrs
+      ~docAttrs
+      ~loc:x.pvb_pat.ppat_loc
+      ~layout
+      ()
+
+  (* Ensures that the constraint is formatted properly for sake of function
+     binding (formatted without arrows)
+     let x y z : no_unguarded_arrows_allowed_here => ret;
+   *)
+  method normalizeFunctionArgsConstraint argsList return =
+    match return.pexp_desc with
+      | Pexp_constraint (e, ct) ->
+        let typeLayout =
+          source_map ~loc:ct.ptyp_loc
+            (self#non_arrowed_non_simple_core_type ct)
+        in
+        ([makeList
+           ~break:IfNeed
+           ~inline:(true, true)
+           (argsList@[formatJustTheTypeConstraint typeLayout])], e)
+      | _ -> (argsList, return)
+
+  method normalizeConstructorArgsConstraint argsList return =
+    match return.pcl_desc with
+      | Pcl_constraint (e, ct) when return.pcl_attributes == [] ->
+        let typeLayout =
+          source_map ~loc:ct.pcty_loc
+            (self#non_arrowed_class_constructor_type ct)
+        in
+        (argsList@[formatJustTheTypeConstraint typeLayout], e)
+      | _ -> (argsList, return)
+
+  method bindingsLocationRange ?extension l =
+    let len = List.length l in
+    let fstLoc = match extension with
+    | Some ({pexp_loc = {loc_ghost = false}} as ext) -> ext.pexp_loc
+    | _ -> (List.nth l 0).pvb_loc
+    in
+    let lstLoc = (List.nth l (len - 1)).pvb_loc in
+    {
+      loc_start = fstLoc.loc_start;
+      loc_end = lstLoc.loc_end;
+      loc_ghost = false
+    }
+
+  method bindings ?extension (rf, l) =
+    let label = add_extension_sugar "let" extension in
+    let label = match rf with
+      | Nonrecursive -> label
+      | Recursive -> label ^ " rec"
+    in
+    match l with
+    | [x] -> self#binding label x
+    | l ->
+      let items = List.mapi (fun i x ->
+        let loc = extractLocValBinding x in
+        let layout = self#binding (if i == 0 then label else "and") x in
+        (loc, layout)
+      ) l
+      in
+      let itemsLayout = groupAndPrint
+        ~xf:(fun (_, layout) -> layout)
+        ~getLoc:(fun (loc, _) -> loc)
+        ~comments:self#comments
+        items
+      in
+      makeList
+        ~postSpace:true
+        ~break:Always
+        ~indent:0
+        ~inline:(true, true)
+        itemsLayout
+
+  method letList expr =
+    (* Recursively transform a nested ast of "let-items", into a flat
+     * list containing the location indicating start/end of the "let-item" and
+     * its layout. *)
+    let rec processLetList acc expr =
+      let {stdAttrs; arityAttrs; jsxAttrs} = partitionAttributes ~allowUncurry:false expr.pexp_attributes in
+      match (stdAttrs, expr.pexp_desc) with
+        | ([], Pexp_let (rf, l, e)) ->
+          (* For "letList" bindings, the start/end isn't as simple as with
+           * module value bindings. For "let lists", the sequences were formed
+           * within braces {}. The parser relocates the first let binding to the
+           * first brace. *)
+           let bindingsLayout = self#bindings (rf, l) in
+           let bindingsLoc = self#bindingsLocationRange l in
+           let layout = source_map ~loc:bindingsLoc bindingsLayout in
+           processLetList ((bindingsLoc, layout)::acc) e
+        | (attrs, Pexp_open (ovf, lid, e))
+            (* Add this when check to make sure these are handled as regular "simple expressions" *)
+            when not (self#isSeriesOfOpensFollowedByNonSequencyExpression {expr with pexp_attributes = []}) ->
+          let overrideStr = match ovf with | Override -> "!" | Fresh -> "" in
+          let openLayout = label ~space:true
+            (atom ("open" ^ overrideStr))
+            (self#longident_loc lid)
+          in
+          let attrsOnOpen =
+            makeList ~inline:(true, true) ~postSpace:true ~break:Always
+            ((self#attributes attrs)@[openLayout])
+          in
+          (* Just like the bindings, have to synthesize a location since the
+           * Pexp location is parsed (potentially) beginning with the open
+           * brace {} in the let sequence. *)
+          let layout = source_map ~loc:lid.loc attrsOnOpen in
+          let loc = {
+            lid.loc with
+            loc_start = {
+              lid.loc.loc_start with
+              pos_lnum = expr.pexp_loc.loc_start.pos_lnum
+            }
+          } in
+          processLetList ((loc, layout)::acc) e
+        | ([], Pexp_letmodule (s, me, e)) ->
+            let prefixText = "module" in
+            let bindingName = atom ~loc:s.loc s.txt in
+            let moduleExpr = me in
+            let letModuleLayout =
+              (self#let_module_binding prefixText bindingName moduleExpr) in
+            let letModuleLoc = {
+              loc_start = s.loc.loc_start;
+              loc_end = me.pmod_loc.loc_end;
+              loc_ghost = false
+            } in
+            (* Just like the bindings, have to synthesize a location since the
+             * Pexp location is parsed (potentially) beginning with the open
+             * brace {} in the let sequence. *)
+          let layout = source_map ~loc:letModuleLoc letModuleLayout in
+        let (_, return) = self#curriedFunctorPatternsAndReturnStruct moduleExpr in
+          let loc = {
+            letModuleLoc with
+            loc_end = return.pmod_loc.loc_end
+          } in
+           processLetList ((loc, layout)::acc) e
+        | ([], Pexp_letexception (extensionConstructor, expr)) ->
+            let exc = self#exception_declaration extensionConstructor in
+            let layout = source_map ~loc:extensionConstructor.pext_loc exc in
+            processLetList ((extensionConstructor.pext_loc, layout)::acc) expr
+        | ([], Pexp_sequence (({pexp_desc=Pexp_sequence _ }) as e1, e2))
+        | ([], Pexp_sequence (({pexp_desc=Pexp_let _      }) as e1, e2))
+        | ([], Pexp_sequence (({pexp_desc=Pexp_open _     }) as e1, e2))
+        | ([], Pexp_sequence (({pexp_desc=Pexp_letmodule _}) as e1, e2))
+        | ([], Pexp_sequence (e1, e2)) ->
+            let e1Layout = match expression_not_immediate_extension_sugar e1 with
+              | Some (extension, e) ->
+                    self#attach_std_item_attrs ~extension []
+                      (self#unparseExpr e)
+              | None ->
+                  self#unparseExpr e1
+            in
+            let loc = e1.pexp_loc in
+            let layout = source_map ~loc e1Layout in
+            processLetList ((loc, layout)::acc) e2
+        | _ ->
+          let expr = { expr with pexp_attributes = (arityAttrs @ stdAttrs @ jsxAttrs) }
+          in
+          match expression_not_immediate_extension_sugar expr with
+          | Some (extension, {pexp_attributes = []; pexp_desc = Pexp_let (rf, l, e)}) ->
+            let bindingsLayout = self#bindings ~extension (rf, l) in
+            let bindingsLoc = self#bindingsLocationRange ~extension:expr l in
+            let layout = source_map ~loc:bindingsLoc bindingsLayout in
+            processLetList ((extractLocationFromValBindList expr l, layout)::acc) e
+          | Some (extension, e) ->
+            let layout = self#attach_std_item_attrs ~extension [] (self#unparseExpr e) in
+            (expr.pexp_loc, layout)::acc
+          | None ->
+            (* Should really do something to prevent infinite loops here. Never
+               allowing a top level call into letList to recurse back to
+               self#unparseExpr- top level calls into letList *must* be one of the
+               special forms above whereas lower level recursive calls may be of
+               any form. *)
+            let layout = source_map ~loc:expr.pexp_loc (self#unparseExpr expr) in
+            (expr.pexp_loc, layout)::acc
+    in
+    let es = processLetList [] expr in
+    (* Interleave whitespace between the "let-items" when appropriate *)
+    groupAndPrint
+      ~xf:(fun (_, layout) -> layout)
+      ~getLoc:(fun (loc, _) -> loc)
+      ~comments:self#comments
+      (List.rev es)
+
+  method constructor_expression ?(polyVariant=false) ~arityIsClear stdAttrs ctor eo =
+    let (implicit_arity, arguments) =
+      match eo.pexp_desc with
+      | Pexp_construct ( {txt= Lident "()"},_) ->
+        (* `foo() is a polymorphic variant that contains a single unit construct as expression
+         * This requires special formatting: `foo(()) -> `foo() *)
+        (false, atom "()")
+      (* special printing: MyConstructor(()) -> MyConstructor() *)
+      | Pexp_tuple l when is_single_unit_construct l ->
+          (false, atom "()")
+      | Pexp_tuple l when polyVariant == true ->
+          (false, self#unparseSequence ~wrap:("(", ")") ~construct:`Tuple l)
+      | Pexp_tuple l ->
+        (* There is no ambiguity when the number of tuple components is 1.
+             We don't need put implicit_arity in that case *)
+        (match l with
+        | exprList when isSingleArgParenApplication exprList ->
+            (false, self#singleArgParenApplication exprList)
+        | _ ->
+            (not arityIsClear, makeTup (List.map self#unparseProtectedExpr l)))
+      | _ when isSingleArgParenApplication [eo] ->
+          (false, self#singleArgParenApplication [eo])
+      | _ ->
+          (false, makeTup [self#unparseProtectedExpr eo])
+    in
+    let arguments = source_map ~loc:eo.pexp_loc arguments in
+    let construction =
+      label ctor (if isSequencey arguments
+                  then arguments
+                  else (ensureSingleTokenSticksToLabel arguments))
+    in
+    let attrs =
+      if implicit_arity && (not polyVariant) then
+        ({txt="implicit_arity"; loc=eo.pexp_loc}, PStr []) :: stdAttrs
+      else
+        stdAttrs
+    in
+    match attrs with
+      | [] -> construction
+      | _::_ -> formatAttributed construction (self#attributes attrs)
+
+  (* TODOATTRIBUTES: Handle stdAttrs here (merge with implicit_arity) *)
+  method constructor_pattern ?(polyVariant=false) ~arityIsClear ctor po =
+    let (implicit_arity, arguments) =
+      match po.ppat_desc with
+      (* There is no ambiguity when the number of tuple components is 1.
+           We don't need put implicit_arity in that case *)
+      | Ppat_tuple (([] | _::[]) as l) ->
+        (false, l)
+      | Ppat_tuple l ->
+        (not arityIsClear, l)
+
+      | _ -> (false, [po])
+    in
+    let space, arguments = match arguments with
+      | [x] when is_direct_pattern x -> (true, self#simple_pattern x)
+      | xs when isSingleArgParenPattern xs -> (false, self#singleArgParenPattern xs)
+      (* Optimize the case when it's a variant holding a shot variable - avoid trailing*)
+      | [{ppat_desc=Ppat_constant (Pconst_string (s, None))} as x]
+      | [{ppat_desc=Ppat_construct (({txt=Lident s}), None)} as x]
+      | [{ppat_desc=Ppat_var ({txt = s})} as x]
+        when Reason_heuristics.singleTokenPatternOmmitTrail s ->
+        let layout = makeTup ~trailComma:false [self#pattern x] in
+        (false, source_map ~loc:po.ppat_loc layout)
+      | [{ppat_desc=Ppat_any} as x]
+      | [{ppat_desc=Ppat_constant (Pconst_char _)} as x]
+      | [{ppat_desc=Ppat_constant (Pconst_integer _)} as x] ->
+        let layout = makeTup ~trailComma:false [self#pattern x] in
+        (false, source_map ~loc:po.ppat_loc layout)
+      | xs ->
+        let layout = makeTup (List.map self#pattern xs) in
+        (false, source_map ~loc:po.ppat_loc layout)
+    in
+    let construction = label ~space ctor arguments in
+    if implicit_arity && (not polyVariant) then
+      formatAttributed construction
+        (self#attributes [({txt="implicit_arity"; loc=po.ppat_loc}, PStr [])])
+    else
+      construction
+
+  (*
+   * Provides special printing for constructor arguments:
+   * iff there's one argument & they have some kind of wrapping,
+   * they're wrapping need to 'hug' the surrounding parens.
+   * Example:
+   *  switch x {
+   *  | Some({
+   *      a,
+   *      b,
+   *    }) => ()
+   *  }
+   *
+   *  Notice how ({ and }) hug.
+   *  This applies for records, arrays, tuples & lists.
+   *  Also see `isSingleArgParenPattern` to determine if this kind of wrapping applies.
+   *)
+  method singleArgParenPattern = function
+    | [{ppat_desc = Ppat_record (l, closed); ppat_loc = loc}] ->
+      source_map ~loc (self#patternRecord ~wrap:("(", ")") l closed)
+    | [{ppat_desc = Ppat_array l; ppat_loc = loc}] ->
+      source_map ~loc (self#patternArray ~wrap:("(", ")") l)
+    | [{ppat_desc = Ppat_tuple l; ppat_loc = loc}] ->
+      source_map ~loc (self#patternTuple ~wrap:("(", ")") l)
+    | [{ppat_desc = Ppat_construct (({txt=Lident "::"}), _); ppat_loc} as listPattern]  ->
+      source_map ~loc:ppat_loc (self#patternList ~wrap:("(", ")")  listPattern)
+    | _ -> assert false
+
+  method patternArray ?(wrap=("","")) l =
+    let (left, right) = wrap in
+    let wrap = (left ^ "[|", "|]" ^ right) in
+    makeList ~wrap ~break:IfNeed ~postSpace:true ~sep:commaTrail (List.map self#pattern l)
+
+  method patternTuple ?(wrap=("","")) l =
+    let (left, right) = wrap in
+    let wrap = (left ^ "(", ")" ^ right) in
+    makeList ~wrap ~sep:commaTrail ~postSpace:true ~break:IfNeed (List.map self#constrained_pattern l)
+
+  method patternRecord ?(wrap=("","")) l closed =
+    let longident_x_pattern (li, p) =
+      match (li, p.ppat_desc) with
+        | ({txt = ident}, Ppat_var {txt}) when Longident.last ident = txt ->
+          (* record field punning when destructuring. {x: x, y: y} becomes {x, y} *)
+          (* works with module prefix too: {MyModule.x: x, y: y} becomes {MyModule.x, y} *)
+            self#longident_loc li
+        | ({txt = ident},
+           Ppat_alias ({ppat_desc = (Ppat_var {txt = ident2}) }, {txt = aliasIdent}))
+           when Longident.last ident = ident2 ->
+          (* record field punning when destructuring with renaming. {state: state as prevState} becomes {state as prevState *)
+          (* works with module prefix too: {ReasonReact.state: state as prevState} becomes {ReasonReact.state as prevState *)
+            makeList ~sep:(Sep " ") [self#longident_loc li; atom "as"; atom aliasIdent]
+        | _ ->
+            label ~space:true (makeList [self#longident_loc li; atom ":"]) (self#pattern p)
+    in
+    let rows = (List.map longident_x_pattern l)@(
+      match closed with
+        | Closed -> []
+        | _ -> [atom "_"]
+    ) in
+    let (left, right) = wrap in
+    let wrap = (left ^ "{", "}" ^ right) in
+    makeList
+      ~wrap
+      ~break:IfNeed
+      ~sep:commaTrail
+      ~postSpace:true
+      rows
+
+  method patternFunction ?extension loc l =
+    let estimatedFunLocation = {
+        loc_start = loc.loc_start;
+        loc_end = {loc.loc_start with pos_cnum = loc.loc_start.Lexing.pos_cnum + 3};
+        loc_ghost = false;
+    } in
+    makeList
+      ~postSpace:true
+      ~break:IfNeed
+      ~inline:(true, true)
+      ~pad:(false, false)
+      ((atom ~loc:estimatedFunLocation (add_extension_sugar funToken extension)) :: (self#case_list l))
+
+  method parenthesized_expr ?break expr =
+    let result = self#unparseExpr expr in
+    match expr.pexp_attributes, expr.pexp_desc with
+    | [], (Pexp_tuple _ | Pexp_construct ({txt=Lident "()"}, None)) -> result
+    | _ -> makeList ~wrap:("(",")") ?break [self#unparseExpr expr]
+
+  (* Expressions requiring parens, in most contexts such as separated by infix *)
+  method expression_requiring_parens_in_infix x =
+    let {stdAttrs} = partitionAttributes x.pexp_attributes in
+    assert (stdAttrs == []);
+    (* keep the incoming expression around, an expr with
+     * immediate extension sugar might contain less than perfect location
+     * info in its children (used for comment interleaving), the expression passed to
+     * 'expression_requiring_parens_in_infix' contains the correct location *)
+    let originalExpr = x in
+    let extension, x = expression_immediate_extension_sugar x in
+    match x.pexp_desc with
+      (* The only reason Pexp_fun must also be wrapped in parens when under
+         pipe, is that its => token will be confused with the match token.
+         Simple expression will also invoke `#reset`. *)
+      | Pexp_function _ when pipe || semi -> None (* Would be rendered as simplest_expression  *)
+      (* Pexp_function, on the other hand, doesn't need wrapping in parens in
+         most cases anymore, since `fun` is not ambiguous anymore (we print Pexp_fun
+         as ES6 functions). *)
+      | Pexp_function l ->
+        let prec = Custom funToken in
+        let expr = self#patternFunction ?extension x.pexp_loc l in
+        Some (SpecificInfixPrecedence
+                ({reducePrecedence=prec; shiftPrecedence=prec}, LayoutNode expr))
+      | _ ->
+        (* The Pexp_function cases above don't use location because comment printing
+          breaks for them. *)
+        let itm = match x.pexp_desc with
+          | Pexp_fun _
+          | Pexp_newtype _ ->
+            (* let uncurried =  *)
+            let (args, ret) = self#curriedPatternsAndReturnVal x in
+            (match args with
+              | [] -> raise (NotPossible ("no arrow args in unparse "))
+              | firstArg::tl ->
+                (* Suboptimal printing of parens:
+
+                      something >>= fun x => x + 1;
+
+                   Will be printed as:
+
+                      something >>= (fun x => x + 1);
+
+                   Because the arrow has lower precedence than >>=, but it wasn't
+                   needed because
+
+                      (something >>= fun x) => x + 1;
+
+                   Is not a valid parse. Parens around the `=>` weren't needed to
+                   prevent reducing instead of shifting. To optimize this part, we need
+                   a much deeper encoding of the parse rules to print parens only when
+                   needed, testing which rules will be reduced. It really should be
+                   integrated deeply with Menhir.
+
+                   One question is, if it's this difficult to describe when parens are
+                   needed, should we even print them with the minimum amount?  We can
+                   instead model everything as "infix" with ranked precedences.  *)
+                let retValUnparsed = self#unparseExprApplicationItems ret in
+                Some (self#wrapCurriedFunctionBinding
+                        ~sweet:(extension = None)
+                        (add_extension_sugar funToken extension)
+                        ~arrow:"=>" firstArg tl retValUnparsed)
+            )
+          | Pexp_try (e, l) ->
+            let estimatedBracePoint = {
+              loc_start = e.pexp_loc.loc_end;
+              loc_end = x.pexp_loc.loc_end;
+              loc_ghost = false;
+            }
+            in
+            let cases = (self#case_list ~allowUnguardedSequenceBodies:true l) in
+            let switchWith = label ~space:true
+                (atom (add_extension_sugar "try" extension))
+                (self#parenthesized_expr ~break:IfNeed e)
+            in
+            Some (
+              label
+                ~space:true
+                switchWith
+                (source_map ~loc:estimatedBracePoint
+                   (makeList ~indent:settings.trySwitchIndent ~wrap:("{", "}")
+                      ~break:Always_rec ~postSpace:true cases))
+            )
+          (* These should have already been handled and we should never havgotten this far. *)
+          | Pexp_setinstvar _ -> raise (Invalid_argument "Cannot handle setinstvar here - call unparseExpr")
+          | Pexp_setfield (_, _, _) -> raise (Invalid_argument "Cannot handle setfield here - call unparseExpr")
+          | Pexp_apply _ -> raise (Invalid_argument "Cannot handle apply here - call unparseExpr")
+          | Pexp_match (e, l) ->
+             let estimatedBracePoint = {
+               loc_start = e.pexp_loc.loc_end;
+               (* See originalExpr binding, for more info.
+                * It contains the correct location under immediate extension sugar *)
+               loc_end = originalExpr.pexp_loc.loc_end;
+               loc_ghost = false;
+             }
+             in
+             let cases = (self#case_list ~allowUnguardedSequenceBodies:true l) in
+             let switchWith =
+               label ~space:true (atom (add_extension_sugar "switch" extension))
+                 (self#parenthesized_expr ~break:IfNeed e)
+             in
+             let lbl =
+               label
+                 ~space:true
+                 switchWith
+                 (source_map ~loc:estimatedBracePoint
+                    (makeList ~indent:settings.trySwitchIndent ~wrap:("{", "}")
+                       ~break:Always_rec ~postSpace:true cases))
+             in
+             Some lbl
+          | Pexp_ifthenelse (e1, e2, eo) ->
+            let (blocks, finalExpression) = sequentialIfBlocks eo in
+            let rec singleExpression exp =
+              match exp.pexp_desc with
+              | Pexp_ident _ -> true
+              | Pexp_constant _ -> true
+              | Pexp_construct (_, arg) ->
+                (match arg with
+                | None -> true
+                | Some x -> singleExpression x)
+              | _ -> false
+            in
+            let singleLineIf =
+              (singleExpression e1) &&
+              (singleExpression e2) &&
+              (match eo with
+               | Some expr -> singleExpression expr
+               | None -> true
+              )
+            in
+            let makeLetSequence =
+              if singleLineIf then
+                makeLetSequenceSingleLine
+              else
+                makeLetSequence
+            in
+            let rec sequence soFar remaining = (
+              match (remaining, finalExpression) with
+                | ([], None) -> soFar
+                | ([], Some e) ->
+                  let soFarWithElseAppended = makeList ~postSpace:true [soFar; atom "else"] in
+                  label ~space:true soFarWithElseAppended
+                    (source_map ~loc:e.pexp_loc (makeLetSequence (self#letList e)))
+                | (hd::tl, _) ->
+                  let (e1, e2) = hd in
+                  let soFarWithElseIfAppended =
+                    label
+                      ~space:true
+                      (makeList ~postSpace:true [soFar; atom "else if"])
+                      (makeList ~wrap:("(",")") [self#unparseExpr e1])
+                  in
+                  let nextSoFar =
+                    label ~space:true soFarWithElseIfAppended
+                      (source_map ~loc:e2.pexp_loc (makeLetSequence (self#letList e2)))
+                  in
+                  sequence nextSoFar tl
+            ) in
+            let init =
+              let if_ = atom (add_extension_sugar "if" extension) in
+              let cond = self#parenthesized_expr e1 in
+              label ~space:true
+                (source_map ~loc:e1.pexp_loc (label ~space:true if_ cond))
+                (source_map ~loc:e2.pexp_loc (makeLetSequence (self#letList e2)))
+            in
+            Some (sequence init blocks)
+          | Pexp_while (e1, e2) ->
+            let lbl =
+              let while_ = atom (add_extension_sugar "while" extension) in
+              let cond = self#parenthesized_expr e1 in
+              label ~space:true
+                (label ~space:true while_ cond)
+                (source_map ~loc:e2.pexp_loc (makeLetSequence (self#letList e2)))
+            in
+            Some lbl
+          | Pexp_for (s, e1, e2, df, e3) ->
+            (*
+             *  for longIdentifier in
+             *      (longInit expr) to
+             *      (longEnd expr) {
+             *    print_int longIdentifier;
+             *  };
+             *)
+            let identifierIn = (makeList ~postSpace:true [self#pattern s; atom "in";]) in
+            let dockedToFor = makeList
+                ~break:IfNeed
+                ~postSpace:true
+                ~inline:(true, true)
+                ~wrap:("(",")")
+                [
+                  identifierIn;
+                  makeList ~postSpace:true [self#unparseExpr e1; self#direction_flag df];
+                  (self#unparseExpr e2);
+                ]
+            in
+            let upToBody = makeList ~inline:(true, true) ~postSpace:true
+                [atom (add_extension_sugar "for" extension); dockedToFor]
+            in
+            Some (label ~space:true upToBody
+                    (source_map ~loc:e3.pexp_loc (makeLetSequence (self#letList e3))))
+          | Pexp_new li ->
+            Some (label ~space:true (atom "new") (self#longident_class_or_type_loc li))
+          | Pexp_assert e ->
+            Some (
+              label
+                (atom "assert")
+                (makeTup [(self#unparseExpr e)]);
+            )
+          | Pexp_lazy e ->
+              Some (label ~space:true (atom "lazy") (self#simplifyUnparseExpr e))
+          | Pexp_poly _ ->
+            failwith (
+              "This version of the pretty printer assumes it is impossible to " ^
+              "construct a Pexp_poly outside of a method definition - yet it sees one."
+            )
+          | _ -> None
+        in
+        match itm with
+          | None -> None
+          | Some i -> Some (PotentiallyLowPrecedence (source_map ~loc:x.pexp_loc i))
+
+  method potentiallyConstrainedExpr x =
+    match x.pexp_desc with
+      | Pexp_constraint (e, ct) ->
+          formatTypeConstraint (self#unparseExpr e) (self#core_type ct)
+      | _ -> self#unparseExpr x
+
+
+  (*
+   * Because the rule BANG simple_expr was given %prec below_DOT_AND_SHARP,
+   * !x.y.z will parse as !(x.y.z) and not (!x).y.z.
+   *
+   *     !x.y.z == !((x.y).z)
+   *     !x#y#z == !((x#y)#z)
+   *
+   * So the intuition is: In general, any simple expression can exist to the
+   * left of a `.`, except `BANG simple_expr`, which has special precedence,
+   * and must be guarded in this one case.
+   *
+   * TODO: Instead of special casing this here, we should continue to extend
+   * unparseExpr to also unparse simple expressions, (by encoding the
+   * rules precedence below_DOT_AND_SHARP).
+   *
+   * TODO:
+   *  Some would even have the prefix application be parsed with lower
+   *  precedence function *application*. In the case of !, where ! means not,
+   *  it makes a lot of sense because (!identifier)(arg) would be meaningless.
+   *
+   *  !callTheFunction(1, 2, 3)(andEvenCurriedArgs)
+   *
+   * Only problem is that it could then not appear anywhere simple expressions
+   * would appear.
+   *
+   * We could make a special case for ! followed by one simple expression, and
+   * consider the result simple.
+   *
+   * Alternatively, we can figure out a way to not require simple expressions
+   * in the most common locations such as if/while tests. This is really hard
+   * (impossible w/ grammars Menhir supports?)
+   *
+   * if ! myFunc argOne argTwo {
+   *
+   * } else {
+   *
+   * };
+   *
+   *)
+  method simple_enough_to_be_lhs_dot_send x =
+    match x.pexp_desc with
+    | (Pexp_apply (eFun, _)) -> (
+        match printedStringAndFixityExpr eFun with
+        | AlmostSimplePrefix _
+        | UnaryPlusPrefix _
+        | UnaryMinusPrefix _
+        | UnaryNotPrefix _
+        | UnaryPostfix _
+        | Infix _ -> self#simplifyUnparseExpr x
+        | Normal ->
+          if x.pexp_attributes == [] then
+            (* `let a = foo().bar` instead of `let a = (foo()).bar *)
+            (* same for foo()##bar, foo()#=bar, etc. *)
+            self#unparseExpr x
+          else
+            self#simplifyUnparseExpr x
+      )
+    | _ -> self#simplifyUnparseExpr x
+
+  method unparseRecord
+    ?wrap:((lwrap, rwrap)=("", ""))
+    ?withStringKeys:(withStringKeys=false)
+    ?allowPunning:(allowPunning=true)
+    ?forceBreak:(forceBreak=false)
+    l eo =
+    (* forceBreak is a ref which can be set to always break the record rows.
+     * Example, when we have a row which contains a nested record,
+     * this ref can be set to true from inside the printing of that row,
+     * which forces breaks for the outer record structure. *)
+    let forceBreak = ref forceBreak in
+    let quote = (atom "\"") in
+    let maybeQuoteFirstElem fst rest =
+        if withStringKeys then (match fst.txt with
+          | Lident s -> quote::(atom s)::quote::rest
+          | Ldot _  | Lapply _ -> assert false
+          )
+        else
+          (self#longident_loc fst)::rest
+    in
+    let makeRow (li, e) shouldPun =
+      let totalRowLoc = {
+        loc_start = li.Asttypes.loc.loc_start;
+        loc_end = e.pexp_loc.loc_end;
+        loc_ghost = false;
+      } in
+      let theRow = match (e.pexp_desc, shouldPun, allowPunning) with
+        (* record value punning. Turns {foo: foo, bar: 1} into {foo, bar: 1} *)
+        (* also turns {Foo.bar: bar, baz: 1} into {Foo.bar, baz: 1} *)
+        (* don't turn {bar: Foo.bar, baz: 1} into {bar, baz: 1}, naturally *)
+        | (Pexp_ident {txt = Lident value}, true, true) when Longident.last li.txt = value ->
+          makeList (maybeQuoteFirstElem li [])
+
+          (* Force breaks for nested records or bs obj sugar
+           * Example:
+           *  let person = {name: {first: "Bob", last: "Zhmith"}, age: 32};
+           * is a lot less readable than
+           *  let person = {
+           *   "name": {
+           *     "first": "Bob",
+           *     "last": "Zhmith"
+           *   },
+           *  "age": 32
+           *  };
+           *)
+        | (Pexp_record (recordRows, optionalGadt), _, _) ->
+            forceBreak := true;
+            let keyWithColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
+            let value = self#unparseRecord ~forceBreak: true recordRows optionalGadt in
+            label ~space:true keyWithColon value
+        | (Pexp_extension (s, p), _, _) when s.txt = "bs.obj" ->
+            forceBreak := true;
+            let keyWithColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
+            let value = self#formatBsObjExtensionSugar ~forceBreak:true p in
+            label ~space:true keyWithColon value
+        | (Pexp_object classStructure, _, _) ->
+            forceBreak := true;
+            let keyWithColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
+            let value = self#classStructure ~forceBreak:true classStructure in
+            label ~space:true keyWithColon value
+        | _ ->
+          let (argsList, return) = self#curriedPatternsAndReturnVal e in
+          match argsList with
+          | [] ->
+            let appTerms = self#unparseExprApplicationItems e in
+            let upToColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
+            formatAttachmentApplication applicationFinalWrapping (Some (true, upToColon)) appTerms
+          | firstArg :: tl ->
+            let upToColon = makeList (maybeQuoteFirstElem li [atom ":"]) in
+            let returnedAppTerms = self#unparseExprApplicationItems return in
+            self#wrapCurriedFunctionBinding
+              ~sweet:true ~attachTo:upToColon funToken ~arrow:"=>"
+              firstArg tl returnedAppTerms
+      in (source_map ~loc:totalRowLoc theRow, totalRowLoc)
+    in
+    let rec getRows l =
+      match l with
+        | [] -> []
+        | hd::[] -> [makeRow hd true]
+        | hd::hd2::tl -> (makeRow hd true)::(getRows (hd2::tl))
+    in
+
+    let allRows = match eo with
+      | None -> (
+        match l with
+          (* No punning (or comma) for records with only a single field. It's ambiguous with an expression in a scope *)
+          (* See comment in parser.mly for lbl_expr_list_with_at_least_one_non_punned_field *)
+          | [hd] -> [makeRow hd false]
+          | _ -> getRows l
+        )
+      (* This case represents a "spread" being present -> {...x, a: 1, b: 2} *)
+      | Some withRecord ->
+        let firstRow =
+          let row = (
+            (* Unclear why "sugar_expr" was special cased hre. *)
+            let appTerms = self#unparseExprApplicationItems withRecord in
+            formatAttachmentApplication applicationFinalWrapping (Some (false, (atom "..."))) appTerms
+          )
+          in (
+            source_map ~loc:withRecord.pexp_loc row,
+            withRecord.pexp_loc
+          )
+        in
+        firstRow::(getRows l)
+    in
+    makeList
+      ~wrap:(lwrap ^ "{" ,"}" ^ rwrap)
+      ~break:(if !forceBreak then Layout.Always else Layout.IfNeed)
+      ~sep:commaTrail
+      ~postSpace:true
+      (groupAndPrint ~xf:fst ~getLoc:snd ~comments:self#comments allRows)
+
+  method isSeriesOfOpensFollowedByNonSequencyExpression expr =
+    match (expr.pexp_attributes, expr.pexp_desc) with
+        | ([], Pexp_let _) -> false
+        | ([], Pexp_sequence _) -> false
+        | ([], Pexp_letmodule _) -> false
+        | ([], Pexp_open (ovf, _, e)) ->
+          ovf == Fresh && self#isSeriesOfOpensFollowedByNonSequencyExpression e
+        | ([], Pexp_letexception _) -> false
+        | ([], Pexp_extension ({txt}, _)) -> txt = "bs.obj"
+        | _ -> true
+
+  method unparseObject ?wrap:((lwrap,rwrap)=("", "")) ?(withStringKeys=false) l o =
+    let core_field_type (s, attrs, ct) =
+      let l = extractStdAttrs attrs in
+      let row =
+         let rowKey = if withStringKeys then
+            (makeList ~wrap:("\"", "\"") [atom s])
+          else (atom s)
+          in
+          label ~space:true
+                (makeList ~break:Layout.Never [rowKey; (atom ":")])
+                (self#core_type ct)
+      in
+      (match l with
+       | [] -> row
+       | _::_ ->
+         makeList
+           ~postSpace:true
+           ~break:IfNeed
+           ~inline:(true, true)
+           (List.concat [self#attributes attrs; [row]]))
+    in
+    let rows = List.map core_field_type l in
+    let openness = match o with
+      | Closed -> atom "."
+      | Open -> atom ".."
+    in
+    (* if an object has more than 2 rows, always break for readability *)
+    let rows_layout = makeList
+        ~inline:(true, true) ~postSpace:true ~sep:commaTrail rows
+        ~break:(if List.length rows >= 2
+                then Layout.Always_rec
+                else Layout.IfNeed)
+    in
+    makeList
+      ~break:Layout.IfNeed
+      ~preSpace:(rows != [])
+      ~wrap:(lwrap ^ "{", "}" ^ rwrap)
+      (openness::[rows_layout])
+
+  method unparseSequence ?wrap:(wrap=("", "")) ~construct l =
+    match construct with
+    | `ES6List ->
+      let seq, ext = (match List.rev l with
+        | ext :: seq_rev -> (List.rev seq_rev, ext)
+        | [] -> assert false) in
+      makeES6List ~wrap (List.map self#unparseExpr seq) (self#unparseExpr ext)
+    | _ ->
+      let (left, right) = wrap in
+      let (xf, (leftDelim, rightDelim)) = (match construct with
+        | `List -> (self#unparseExpr, ("[", "]"))
+        | `Array -> (self#unparseExpr, ("[|", "|]"))
+        | `Tuple -> (self#potentiallyConstrainedExpr, ("(", ")"))
+        | `ES6List -> assert false)
+      in
+      let wrap = (left ^ leftDelim, rightDelim ^ right) in
+      makeList
+        ~wrap
+        ~sep:commaTrail
+        ~break:IfNeed
+        ~postSpace:true
+        (List.map xf l)
+
+
+  method formatBsObjExtensionSugar ?wrap:(wrap=("", "")) ?(forceBreak=false) payload =
+    match payload with
+    | PStr [itm] -> (
+      match itm with
+      | {pstr_desc = Pstr_eval ({ pexp_desc = Pexp_record (l, eo) }, []) } ->
+        self#unparseRecord ~forceBreak ~wrap ~withStringKeys:true ~allowPunning:false l eo
+      | {pstr_desc = Pstr_eval ({ pexp_desc = Pexp_extension ({txt = "bs.obj"}, payload) }, []) } ->
+        (* some folks write `[%bs.obj [%bs.obj {foo: bar}]]`. This looks improbable but
+          it happens often if you use the sugared version: `[%bs.obj {"foo": bar}]`.
+          We're gonna be lenient here and treat it as if they wanted to just write
+          `{"foo": bar}`. BuckleScript does the same relaxation when parsing bs.obj
+        *)
+        self#formatBsObjExtensionSugar ~wrap ~forceBreak payload
+      | _ -> raise (Invalid_argument "bs.obj only accepts a record. You've passed something else"))
+    | _ -> assert false
+
+  method should_preserve_requested_braces expr =
+    let {stylisticAttrs} = partitionAttributes expr.pexp_attributes in
+    match expr.pexp_desc with
+    | Pexp_ifthenelse _
+    | Pexp_try _ -> false
+    | _ ->
+        preserve_braces &&
+        Reason_attributes.has_preserve_braces_attrs stylisticAttrs
+
+  method simplest_expression x =
+    let {stdAttrs; jsxAttrs} = partitionAttributes x.pexp_attributes in
+    if stdAttrs != [] then
+      None
+    else if self#should_preserve_requested_braces x then
+      let layout =
+        makeList
+          ~break:(if inline_braces then Always else Always_rec)
+          ~inline:(true, inline_braces)
+          ~wrap:("{", "}")
+          ~postSpace:true
+          ~sep:(if inline_braces then NoSep else (SepFinal (";", ";")))
+          (self#letList x)
+      in
+      Some layout
+    else
+      let item =
+        match x.pexp_desc with
+        (* The only reason Pexp_fun must also be wrapped in parens is that its =>
+           token will be confused with the match token. *)
+        | Pexp_fun _ when pipe || semi -> Some (self#reset#simplifyUnparseExpr x)
+        | Pexp_function l when pipe || semi -> Some (formatPrecedence ~loc:x.pexp_loc (self#reset#patternFunction x.pexp_loc l))
+        | Pexp_apply _ -> (
+          match self#simple_get_application x with
+          (* If it's the simple form of application. *)
+          | Some simpleGet -> Some simpleGet
+          | None -> None
+        )
+        | Pexp_object cs -> Some (self#classStructure cs)
+        | Pexp_override l -> (* FIXME *)
+          let string_x_expression (s, e) =
+            label ~space:true (atom (s.txt ^ ":")) (self#unparseExpr e)
+          in
+          Some (
+            makeList
+              ~postSpace:true
+              ~wrap:("{<", ">}")
+              ~sep:(Sep ",")
+              (List.map string_x_expression l)
+          )
+        | Pexp_construct _  when is_simple_construct (view_expr x) ->
+            let hasJsxAttribute = jsxAttrs != [] in
+            Some (
+              match view_expr x with
+              | `nil -> if hasJsxAttribute then atom "<> </>" else atom "[]"
+              | `tuple -> atom "()"
+              | `list xs -> (* LIST EXPRESSION *)
+                if hasJsxAttribute then
+                  let actualChildren =
+                    match self#formatChildren xs [] with
+                    | None -> []
+                    | Some ch -> ch
+                  in
+                    makeList
+                      ~break:IfNeed
+                      ~inline:(false, false)
+                      ~postSpace:true
+                      ~wrap:("<>", "</>")
+                      ~pad:(true, true)
+                      actualChildren
+                else
+                  self#unparseSequence ~construct:`List xs
+              | `cons xs ->
+                  self#unparseSequence ~construct:`ES6List xs
+              | `simple x -> self#longident x
+              | _ -> assert false
+            )
+        | Pexp_ident li ->
+            (* Lone identifiers shouldn't break when to the right of a label *)
+            Some (ensureSingleTokenSticksToLabel (self#longident_loc li))
+        | Pexp_constant c ->
+            (* Constants shouldn't break when to the right of a label *)
+          let raw_literal, _ = extract_raw_literal x.pexp_attributes in
+            Some (ensureSingleTokenSticksToLabel
+                    (self#constant ?raw_literal c))
+        | Pexp_pack me ->
+          Some (
+            makeList
+              ~break:IfNeed
+              ~postSpace:true
+              ~wrap:("(", ")")
+              ~inline:(true, true)
+              [atom "module"; self#module_expr me;]
+          )
+        | Pexp_tuple l ->
+            (* TODO: These may be simple, non-simple, or type constrained
+               non-simple expressions *)
+          Some (self#unparseSequence ~construct:`Tuple l)
+        | Pexp_constraint (e, ct) ->
+          Some (
+            makeList
+              ~break:IfNeed
+              ~wrap:("(", ")")
+              [formatTypeConstraint (self#unparseExpr e) (self#core_type ct)]
+          )
+        | Pexp_coerce (e, cto1, ct) ->
+            let optFormattedType = match cto1 with
+              | None -> None
+              | Some typ -> Some (self#core_type typ) in
+            Some (
+              makeList
+                ~break:IfNeed
+                ~wrap:("(", ")")
+                [formatCoerce (self#unparseExpr e) optFormattedType (self#core_type ct)]
+            )
+        | Pexp_variant (l, None) ->
+            Some (ensureSingleTokenSticksToLabel (atom ("`" ^ l)))
+        | Pexp_record (l, eo) -> Some (self#unparseRecord l eo)
+        | Pexp_array l ->
+          Some (self#unparseSequence ~construct:`Array l)
+        | Pexp_let _ | Pexp_sequence _
+        | Pexp_letmodule _ | Pexp_letexception _ ->
+          Some (makeLetSequence (self#letList x))
+        | Pexp_extension e ->
+          begin match expression_immediate_extension_sugar x with
+            | (Some _, _) -> None
+            | (None, _) ->
+              match expression_extension_sugar x with
+              | None -> Some (self#extension e)
+              | Some (_, x') ->
+                match x'.pexp_desc with
+                | Pexp_let _ ->
+                  Some (makeLetSequence (self#letList x))
+                | _ -> Some (self#extension e)
+          end
+        | Pexp_open (_, lid, e) ->
+            if self#isSeriesOfOpensFollowedByNonSequencyExpression x then
+              Some (label (label (self#longident_loc lid) (atom (".")))
+                          (self#formatNonSequencyExpression e))
+          else
+            Some (makeLetSequence (self#letList x))
+        | Pexp_send (e, s) ->
+          let needparens = match e.pexp_desc with
+            | Pexp_apply (ee, _) ->
+              (match printedStringAndFixityExpr ee with
+               | UnaryPostfix "^" -> true
+               | _ -> false)
+            | _ -> false
+          in
+          let lhs = self#simple_enough_to_be_lhs_dot_send e in
+          let lhs = if needparens then makeList ~wrap:("(",")") [lhs] else lhs in
+          Some (label (makeList [lhs; atom "#";]) (atom s))
+        | _ -> None
+      in
+      match item with
+      | None -> None
+      | Some i -> Some (source_map ~loc:x.pexp_loc i)
+
+  method formatChildren children processedRev =
+    match children with
+    | {pexp_desc = Pexp_constant constant} as x :: remaining ->
+      let raw_literal, _ = extract_raw_literal x.pexp_attributes in
+      self#formatChildren remaining (self#constant ?raw_literal constant :: processedRev)
+    | {pexp_desc = Pexp_construct ({txt = Lident "::"}, Some {pexp_desc = Pexp_tuple children} )} as x :: remaining ->
+      let {jsxAttrs} = partitionAttributes x.pexp_attributes in
+      if jsxAttrs != [] then
+        match self#simplest_expression x with
+        | Some r -> self#formatChildren remaining (r :: processedRev)
+        | None -> self#formatChildren (remaining @ children) processedRev
+      else
+        self#formatChildren (remaining @ children) processedRev
+    | ({pexp_desc = Pexp_apply _} as e) :: remaining ->
+        let child =
+        (* Pipe first behaves differently according to the expression on the
+         * right. In example (1) below, it's a `SpecificInfixPrecedence`; in
+         * (2), however, it's `Simple` and doesn't need to be wrapped in parens.
+         *
+         * (1). <div> {items->Belt.Array.map(ReasonReact.string)->ReasonReact.array} </div>;
+         * (2). <Foo> (title === "" ? [1, 2, 3] : blocks)->Foo.toString </Foo>; *)
+        if Reason_heuristics.isPipeFirst e &&
+           not (Reason_heuristics.isPipeFirstWithNonSimpleJSXChild e)
+        then
+          self#formatPipeFirst e
+        else
+          self#inline_braces#simplifyUnparseExpr ~inline:true ~wrap:("{", "}") e
+        in
+        self#formatChildren remaining (child::processedRev)
+    | {pexp_desc = Pexp_ident li} :: remaining ->
+      self#formatChildren remaining (self#longident_loc li :: processedRev)
+    | {pexp_desc = Pexp_construct ({txt = Lident "[]"}, None)} :: remaining -> self#formatChildren remaining processedRev
+    | {pexp_desc = Pexp_match _ } as head :: remaining ->
+        self#formatChildren
+          remaining
+          (self#inline_braces#simplifyUnparseExpr ~inline:true ~wrap:("{", "}") head :: processedRev)
+    | head :: remaining ->
+        self#formatChildren
+          remaining
+          (self
+            #dont_preserve_braces (* the brace logic is handled here *)
+            #simplifyUnparseExpr ~inline:true ~wrap:("{", "}")
+            head
+           :: processedRev)
+    | [] -> match processedRev with
+        | [] -> None
+        | _::_ -> Some (List.rev processedRev)
+
+  method direction_flag = function
+    | Upto -> atom "to"
+    | Downto -> atom "downto"
+
+  method payload ppxToken ppxId e =
+    let wrap = ("[" ^ ppxToken ^ ppxId.txt, "]") in
+    let wrap_prefix str (x,y) = (x^str, y) in
+    let break = Layout.IfNeed in
+    let pad = (true, false) in
+    let postSpace = true in
+    match e with
+    | PStr [] -> atom ("[" ^ ppxToken  ^ ppxId.txt  ^ "]")
+    | PStr [itm] -> makeList ~break ~wrap ~pad [self#structure_item itm]
+    | PStr (_::_ as items) ->
+      let rows = List.map self#structure_item items in
+      makeList ~wrap ~break ~pad ~postSpace ~sep:(Layout.Sep ";") rows
+    | PTyp x ->
+      let wrap = wrap_prefix ":" wrap in
+      makeList ~wrap ~break ~pad [self#core_type x]
+    (* Signatures in attributes were added recently *)
+    | PSig [] -> atom ("[" ^ ppxToken ^ ppxId.txt ^":]")
+    | PSig [x] ->
+      let wrap = wrap_prefix ":" wrap in
+      makeList ~break ~wrap ~pad [self#signature_item x]
+    | PSig items ->
+      let wrap = wrap_prefix ":" wrap in
+      let rows = List.map self#signature_item items in
+      makeList ~wrap ~break ~pad ~postSpace ~sep:(Layout.Sep ";") rows
+    | PPat (x, None) ->
+      let wrap = wrap_prefix "?" wrap in
+      makeList ~wrap ~break ~pad [self#pattern x]
+    | PPat (x, Some e) ->
+      let wrap = wrap_prefix "?" wrap in
+      makeList ~wrap ~break ~pad ~postSpace [
+        self#pattern x;
+        label ~space:true (atom "when") (self#unparseExpr e)
+      ]
+
+  method extension (s, p) =
+    match s.txt with
+    (* We special case "bs.obj" for now to allow for a nicer interop with
+     * BuckleScript. We might be able to generalize to any kind of record
+     * looking thing with struct keys. *)
+    | "bs.obj" -> self#formatBsObjExtensionSugar p
+    | _ -> (self#payload "%" s p)
+
+  method item_extension (s, e) = (self#payload "%%" s e)
+
+
+  (* [@ ...] Simple attributes *)
+  method attribute = function
+    | { Location. txt = ("ocaml.doc" | "ocaml.text") },
+      PStr [{ pstr_desc = Pstr_eval ({ pexp_desc = Pexp_constant (Pconst_string(text, None)) } , _);
+              pstr_loc }] ->
+      let text = if text = "" then "/**/" else "/**" ^ text ^ "*/" in
+      makeList ~inline:(true, true) ~postSpace:true ~preSpace:true ~indent:0 ~break:IfNeed [atom ~loc:pstr_loc text]
+    | (s, e) -> self#payload "@" s e
+
+  (* [@@ ... ] Attributes that occur after a major item in a structure/class *)
+  method item_attribute = self#attribute
+
+  (* [@@ ...] Attributes that occur not *after* an item in some structure/class/sig, but
+     rather as their own standalone item. Note that syntactic distinction
+     between item_attribute and floating_attribute is no longer necessary with
+     Reason. Thank you semicolons. *)
+  method floating_attribute = self#item_attribute
+
+  method attributes l = List.map self#attribute l
+
+  method attach_std_attrs l toThis =
+    let l = extractStdAttrs l in
+    match l with
+      | [] -> toThis
+      | _::_ -> makeList ~postSpace:true (List.concat [self#attributes l; [toThis]])
+
+  method attach_std_item_attrs ?(allowUncurry=true) ?extension l toThis =
+    let l = (partitionAttributes ~allowUncurry l).stdAttrs in
+    match extension, l with
+    | None, [] -> toThis
+    | _, _ ->
+      let extension = match extension with
+        | None -> []
+        | Some id -> [atom ("%" ^ id.txt)]
+      in
+      makeList
+        ~postSpace:true ~indent:0 ~break:Layout.Always_rec ~inline:(true, true)
+        (extension @ List.map self#item_attribute l @ [toThis])
+
+  method exception_declaration ed =
+    let pcd_name = ed.pext_name in
+    let pcd_loc = ed.pext_loc in
+    let pcd_attributes = [] in
+    let exn_arg = match ed.pext_kind with
+      | Pext_decl (args, type_opt) ->
+          let pcd_args, pcd_res = args, type_opt in
+          [self#type_variant_leaf_nobar {pcd_name; pcd_args; pcd_res; pcd_loc; pcd_attributes}]
+      | Pext_rebind id ->
+          [atom pcd_name.txt; atom "="; (self#longident_loc id)] in
+    let {stdAttrs; docAttrs} =
+      partitionAttributes ~partDoc:true ed.pext_attributes
+    in
+    let layout =
+      self#attach_std_item_attrs
+        stdAttrs
+        (label ~space:true
+          (atom "exception")
+          (makeList ~postSpace:true ~inline:(true, true) exn_arg))
+    in
+    self#attachDocAttrsToLayout
+      ~stdAttrs
+      ~docAttrs
+      ~loc:ed.pext_loc
+      ~layout
+      ()
+
+  (*
+    Note: that override doesn't appear in class_sig_field, but does occur in
+    class/object expressions.
+    TODO: TODOATTRIBUTES
+   *)
+  method method_sig_flags_for s = function
+    | Virtual -> [atom "virtual"; atom s]
+    | Concrete ->  [atom s]
+
+  method value_type_flags_for s = function
+    | (Virtual, Mutable) -> [atom "virtual"; atom "mutable"; atom s]
+    | (Virtual, Immutable) -> [atom "virtual"; atom s]
+    | (Concrete, Mutable) -> [atom "mutable"; atom s]
+    | (Concrete, Immutable) -> [atom s]
+
+  method class_sig_field x =
+    match x.pctf_desc with
+    | Pctf_inherit ct ->
+      label ~space:true (atom "inherit") (self#class_constructor_type ct)
+    | Pctf_val (s, mf, vf, ct) ->
+      let valueFlags = self#value_type_flags_for (s ^ ":") (vf, mf) in
+      label
+        ~space:true
+        (
+          label ~space:true
+            (atom "val")
+            (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed valueFlags)
+        )
+        (self#core_type ct)
+    | Pctf_method (s, pf, vf, ct) ->
+      let methodFlags = self#method_sig_flags_for (s ^ ":") vf
+      in
+      let pubOrPrivate =
+        match pf with
+        | Private -> "pri"
+        | Public -> "pub"
+      in
+      let m = label
+        ~space:true
+        (label ~space:true
+            (atom pubOrPrivate)
+            (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed methodFlags)
+        )
+        (self#core_type ct)
+      in
+      (self#attach_std_item_attrs x.pctf_attributes m)
+    | Pctf_constraint (ct1, ct2) ->
+      label
+        ~space:true
+        (atom "constraint")
+        (label ~space:true
+            (makeList ~postSpace:true [self#core_type ct1; atom "="])
+            (self#core_type ct2)
+        )
+    | Pctf_attribute a -> self#floating_attribute a
+    | Pctf_extension e -> self#item_extension e
+
+  (*
+    /** doc comment */                                    (* formattedDocs *)
+    [@bs.val] [@bs.module "react-dom"]                    (* formattedAttrs *)
+    external render : reactElement => element => unit =   (* frstHalf *)
+      "render";                                           (* sndHalf *)
+
+    To improve the formatting with breaking & indentation:
+      * consider the part before the '=' as a label
+      * combine that label with '=' in a list
+      * consider the part after the '=' as a list
+      * combine both parts as a label
+      * format the doc comment with a ~postSpace:true (inline, not inline) list
+      * format the attributes with a ~postSpace:true (inline, inline) list
+      * format everything together in a ~postSpace:true (inline, inline) list
+        for nicer breaking
+  *)
+  method primitive_declaration vd =
+    let lblBefore =
+      label
+        ~space:true
+        (makeList
+           [(makeList ~postSpace:true [atom "external"; protectIdentifier vd.pval_name.txt]); (atom ":")])
+        (self#core_type vd.pval_type)
+    in
+    let frstHalf = makeList ~postSpace:true [lblBefore; atom "="] in
+    let sndHalf = makeSpacedBreakableInlineList (List.map self#constant_string vd.pval_prim) in
+    let primDecl = label ~space:true frstHalf sndHalf in
+    match vd.pval_attributes with
+    | [] -> primDecl
+    | attrs ->
+        let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true attrs in
+        let docs = List.map self#item_attribute docAttrs in
+        let formattedDocs = makeList ~postSpace:true docs in
+        let attrs = List.map self#item_attribute stdAttrs in
+        let formattedAttrs = makeSpacedBreakableInlineList attrs in
+        let layouts = match (docAttrs, stdAttrs) with
+        | ([], _) -> [formattedAttrs; primDecl]
+        | (_, []) -> [formattedDocs; primDecl]
+        | _ -> [formattedDocs; formattedAttrs; primDecl] in
+        makeSpacedBreakableInlineList layouts
+
+  method class_instance_type x =
+    match x.pcty_desc with
+    | Pcty_signature cs ->
+      let {pcsig_self = ct; pcsig_fields = l} = cs in
+      let instTypeFields = List.map self#class_sig_field l in
+      let allItems = match ct.ptyp_desc with
+        | Ptyp_any -> instTypeFields
+        | _ ->
+          label ~space:true (atom "as") (self#core_type ct) ::
+          instTypeFields
+      in
+      self#attach_std_item_attrs ~allowUncurry:false x.pcty_attributes (
+        makeList
+          ~wrap:("{", "}")
+          ~postSpace:true
+          ~break:Layout.Always_rec
+          (List.map semiTerminated allItems)
+      )
+    | Pcty_constr (li, l) ->
+      self#attach_std_attrs x.pcty_attributes (
+        match l with
+        | [] -> self#longident_loc li
+        | _::_ ->
+          label
+            (self#longident_loc li)
+            (makeList ~wrap:("(", ")") ~sep:commaTrail (List.map self#core_type l))
+      )
+    | Pcty_extension e ->
+      self#attach_std_item_attrs x.pcty_attributes (self#extension e)
+    | Pcty_arrow _ -> failwith "class_instance_type should not be printed with Pcty_arrow"
+
+  method class_declaration_list l =
+    let class_declaration ?(class_keyword=false)
+        ({pci_params=ls; pci_name={txt}; pci_virt; pci_loc} as x) =
+      let (firstToken, pattern, patternAux) = self#class_opening class_keyword txt pci_virt ls in
+      let classBinding = self#wrappedClassBinding firstToken pattern patternAux x.pci_expr in
+      source_map ~loc:pci_loc
+        (self#attach_std_item_attrs x.pci_attributes classBinding)
+    in
+    (match l with
+      | [] -> raise (NotPossible "Class definitions will have at least one item.")
+      | x::rest ->
+        makeNonIndentedBreakingList (
+          class_declaration ~class_keyword:true x ::
+          List.map class_declaration rest
+        )
+    )
+  (* For use with [class type a = class_instance_type]. Class type
+     declarations/definitions declare the types of instances generated by class
+     constructors.
+     We have to call self#class_instance_type because self#class_constructor_type
+     would add a "new" before the type.
+     TODO: TODOATTRIBUTES:
+  *)
+  method class_type_declaration_list l =
+    let class_type_declaration kwd ({pci_params=ls;pci_name;pci_attributes} as x) =
+      let opener = match x.pci_virt with
+        | Virtual -> kwd ^ " " ^ "virtual"
+        | Concrete -> kwd
+      in
+
+      let upToName =
+        if ls == [] then
+          label ~space:true (atom opener) (atom pci_name.txt)
+        else
+          label
+            ~space:true
+            (label ~space:true (atom opener) (atom pci_name.txt))
+            (self#class_params_def ls)
+      in
+      let includingEqual = makeList ~postSpace:true [upToName; atom "="] in
+      let {stdAttrs; docAttrs} =
+        partitionAttributes ~partDoc:true pci_attributes
+      in
+      let layout =
+        self#attach_std_item_attrs stdAttrs @@
+        label ~space:true includingEqual (self#class_instance_type x.pci_expr)
+      in
+      self#attachDocAttrsToLayout
+        ~stdAttrs
+        ~docAttrs
+        ~loc:pci_name.loc
+        ~layout
+        ()
+    in
+    match l with
+    | [] -> failwith "Should not call class_type_declaration with no classes"
+    | [x] -> class_type_declaration "class type" x
+    | x :: xs ->
+      makeList
+        ~break:Always_rec
+        ~indent:0
+        ~inline:(true, true)
+        (
+          (class_type_declaration "class type" x)::
+          List.map (class_type_declaration "and") xs
+        )
+
+  (*
+     Formerly the [class_type]
+     Notice how class_constructor_type doesn't have any type attributes -
+     class_instance_type does.
+     TODO: Divide into class_constructor_types that allow arrows and ones
+     that don't.
+   *)
+  method class_constructor_type x =
+    match x.pcty_desc with
+    | Pcty_arrow _ ->
+      let rec allArrowSegments acc = function
+        | { pcty_desc = Pcty_arrow (l, ct1, ct2); } ->
+            allArrowSegments (self#type_with_label (l, ct1, false) :: acc) ct2
+        (* This "new" is unfortunate. See reason_parser.mly for details. *)
+        | xx -> (List.rev acc, self#class_constructor_type xx)
+      in
+      let (params, return) = allArrowSegments [] x in
+      let normalized =
+        makeList ~break:IfNeed
+          ~sep:(Sep "=>")
+          ~preSpace:true ~postSpace:true ~inline:(true, true)
+        [makeCommaBreakableListSurround "(" ")" params; return]
+      in
+      source_map ~loc:x.pcty_loc normalized
+    | _ ->
+      (* Unfortunately, we have to have final components of a class_constructor_type
+         be prefixed with the `new` keyword.  Hopefully this is temporary. *)
+      self#class_instance_type x
+
+  method non_arrowed_class_constructor_type x =
+    match x.pcty_desc with
+    | Pcty_arrow _ ->
+      source_map ~loc:x.pcty_loc
+        (formatPrecedence (self#class_constructor_type x))
+    | _ -> self#class_instance_type x
+
+  method class_field x =
+    let itm =
+      match x.pcf_desc with
+      | Pcf_inherit (ovf, ce, so) ->
+        let inheritText = ("inherit" ^ override ovf) in
+        let inheritExp = self#class_expr ce in
+        label
+          ~space:true
+          (atom inheritText)
+          (
+            match so with
+            | None -> inheritExp;
+            | Some s -> label ~space:true inheritExp (atom ("as " ^ s))
+          )
+      | Pcf_val (s, mf, Cfk_concrete (ovf, e)) ->
+        let opening = match mf with
+          | Mutable ->
+            let mutableName = [atom "mutable"; atom s.txt] in
+            label
+              ~space:true
+              (atom ("val" ^ override ovf))
+              (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed mutableName)
+          | Immutable -> label ~space:true (atom ("val" ^ override ovf)) (atom s.txt)
+        in
+        let valExprAndConstraint = match e.pexp_desc with
+          | Pexp_constraint (ex, ct) ->
+            let openingWithTypeConstraint = formatTypeConstraint opening (self#core_type ct) in
+            label
+              ~space:true
+              (makeList ~postSpace:true [openingWithTypeConstraint; atom "="])
+              (self#unparseExpr ex)
+          | _ ->
+            label ~space:true (makeList ~postSpace:true [opening; atom "="]) (self#unparseExpr e)
+        in
+        valExprAndConstraint
+      | Pcf_val (s, mf, Cfk_virtual ct) ->
+        let opening = match mf with
+          | Mutable ->
+            let mutableVirtualName = [atom "mutable"; atom "virtual"; atom s.txt] in
+            let openingTokens =
+              (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed mutableVirtualName) in
+            label ~space:true (atom "val") openingTokens
+          | Immutable ->
+            let virtualName = [atom "virtual"; atom s.txt] in
+            let openingTokens =
+              (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed virtualName) in
+            label ~space:true (atom "val") openingTokens
+        in
+        formatTypeConstraint opening (self#core_type ct)
+      | Pcf_method (s, pf, Cfk_virtual ct) ->
+        let opening = match pf with
+          | Private ->
+            let privateVirtualName = [atom "virtual"; atom s.txt] in
+            let openingTokens =
+              (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed privateVirtualName) in
+            label ~space:true (atom "pri") openingTokens
+          | Public ->
+            let virtualName = [atom "virtual"; atom s.txt] in
+            let openingTokens =
+              (makeList ~postSpace:true ~inline:(false, true) ~break:IfNeed virtualName) in
+            label ~space:true (atom "pub") openingTokens
+        in
+        formatTypeConstraint opening (self#core_type ct)
+      | Pcf_method (s, pf, Cfk_concrete (ovf, e)) ->
+        let methodText =
+           let postFix = if ovf == Override then "!" else "" in
+           (
+           match pf with
+           | Private -> "pri" ^ postFix
+           | Public -> "pub" ^ postFix
+           ) in
+        (* Should refactor the binding logic so faking out the AST isn't needed,
+           currently, it includes a ton of nuanced logic around recovering explicitly
+           polymorphic type definitions, and that furthermore, that representation...
+           Actually, let's do it.
+
+           For some reason, concrete methods are only ever parsed as Pexp_poly.
+           If there *is* no polymorphic function for the method, then the return
+           value of the function is wrapped in a ghost Pexp_poly with [None] for
+           the type vars.*)
+        (match e.pexp_desc with
+          | (Pexp_poly
+              ({pexp_desc=Pexp_constraint (methodFunWithNewtypes, nonVarifiedExprType)},
+                Some ({ptyp_desc=Ptyp_poly (typeVars, varifiedPolyType)})
+              )
+            ) when (
+              let (leadingAbstractVars, _) =
+                self#leadingCurriedAbstractTypes methodFunWithNewtypes in
+              self#isRenderableAsPolymorphicAbstractTypes
+                typeVars
+                (* If even artificially varified. Don't know until this returns*)
+                varifiedPolyType
+                leadingAbstractVars
+                nonVarifiedExprType
+          ) ->
+            let (leadingAbstractVars, _) =
+              self#leadingCurriedAbstractTypes methodFunWithNewtypes in
+            self#locallyAbstractPolymorphicFunctionBinding
+              methodText
+              (atom s.txt)
+              methodFunWithNewtypes
+              leadingAbstractVars
+              nonVarifiedExprType
+          | Pexp_poly (e, Some ct) ->
+            self#formatSimplePatternBinding methodText (atom s.txt)
+              (Some (source_map ~loc:ct.ptyp_loc (self#core_type ct)))
+              (self#unparseExprApplicationItems e)
+          (* This form means that there is no type constraint - it's a strange node name.*)
+          | Pexp_poly (e, None) ->
+            self#wrappedBinding methodText ~arrow:"=>" (atom s.txt) [] e
+          | _ -> failwith "Concrete methods should only ever have Pexp_poly."
+        )
+      | Pcf_constraint (ct1, ct2) ->
+        label
+          ~space:true
+          (atom "constraint")
+          (
+            makeList ~postSpace:true ~inline:(true, false) [
+              makeList ~postSpace:true [self#core_type ct1; atom "="];
+              self#core_type ct2
+            ]
+          )
+      | Pcf_initializer e ->
+        label
+          ~space:true
+          (atom "initializer")
+          (self#simplifyUnparseExpr e)
+      | Pcf_attribute a -> self#floating_attribute a
+      | Pcf_extension e ->
+        (* And don't forget, we still need to print post_item_attributes even for
+           this case *)
+        self#item_extension e
+    in
+    source_map ~loc:x.pcf_loc itm
+
+  method class_self_pattern_and_structure {pcstr_self = p; pcstr_fields = l} =
+    let fields = List.map self#class_field l in
+    (* Recall that by default self is bound to "this" at parse time. You'd
+       have to go out of your way to bind it to "_". *)
+    match (p.ppat_attributes, p.ppat_desc) with
+      | ([], Ppat_var ({txt = "this"})) -> fields
+      | _ ->
+        let field = label ~space:true (atom "as") (self#pattern p) in
+        source_map ~loc:p.ppat_loc field :: fields
+
+  method simple_class_expr x =
+    let {stdAttrs} = partitionAttributes x.pcl_attributes in
+    if stdAttrs != [] then
+      formatSimpleAttributed
+        (self#simple_class_expr {x with pcl_attributes=[]})
+        (self#attributes stdAttrs)
+    else
+      let itm =
+        match x.pcl_desc with
+        | Pcl_constraint (ce, ct) ->
+          formatTypeConstraint (self#class_expr ce) (self#class_constructor_type ct)
+        (* In OCaml,
+          - In the most recent version of OCaml, when in the top level of a
+            module, let _ = ... is a PStr_eval.
+          - When in a function, it is a Pexp_let PPat_any
+          - When in class pre-member let bindings it is a Pcl_let PPat_any
+
+           Reason normalizes all of these to be simple imperative expressions
+           with trailing semicolons, *except* in the case of classes because it
+           will likely introduce a conflict with some proposed syntaxes for
+           objects.
+        *)
+        | Pcl_let _
+        | Pcl_structure _ ->
+          let rows = (self#classExprLetsAndRest x) in
+          makeList ~wrap:("{", "}") ~inline:(true, false) ~postSpace:true ~break:Always_rec (List.map semiTerminated rows)
+        | Pcl_extension e -> self#extension e
+        | _ -> formatPrecedence (self#class_expr x)
+     in source_map ~loc:x.pcl_loc itm
+
+  method classExprLetsAndRest x =
+    match x.pcl_desc with
+      | Pcl_structure cs -> self#class_self_pattern_and_structure cs
+      | Pcl_let (rf, l, ce) ->
+        (* For "letList" bindings, the start/end isn't as simple as with
+         * module value bindings. For "let lists", the sequences were formed
+         * within braces {}. The parser relocates the first let binding to the
+         * first brace. *)
+        let binding =
+          source_map ~loc:(self#bindingsLocationRange l)
+            (self#bindings (rf, l))
+        in
+        (binding :: self#classExprLetsAndRest ce)
+      | _ -> [self#class_expr x]
+
+  method class_expr x =
+    let {stdAttrs} = partitionAttributes x.pcl_attributes in
+    (* We cannot handle the attributes here. Must handle them in each item *)
+    if stdAttrs != [] then
+      (* Do not need a "simple" attributes precedence wrapper. *)
+      formatAttributed
+        (self#simple_class_expr {x with pcl_attributes=[]})
+        (self#attributes stdAttrs)
+    else
+      match x.pcl_desc with
+      | Pcl_fun _ ->
+        (match self#curriedConstructorPatternsAndReturnVal x with
+         | None, _ ->
+           (* x just matched Pcl_fun, there is at least one parameter *)
+           assert false
+         | Some args, e ->
+           label ~space:true
+             (makeList ~postSpace:true
+                [label ~space:true (atom funToken) args; atom "=>"])
+             (self#class_expr e))
+      | Pcl_apply _ ->
+        formatAttachmentApplication applicationFinalWrapping None
+         (self#classExpressionToFormattedApplicationItems x, None)
+      | Pcl_constr (li, []) ->
+        label ~space:true (atom "class") (self#longident_loc li)
+      | Pcl_constr (li, l) ->
+        label
+          (makeList ~postSpace:true [atom "class"; self#longident_loc li])
+          (makeTup (List.map self#non_arrowed_non_simple_core_type l))
+      | Pcl_constraint _
+      | Pcl_extension _
+      | Pcl_let _
+      | Pcl_structure _ -> self#simple_class_expr x;
+
+  method classStructure ?(forceBreak=false) ?(wrap=("", "")) cs =
+    let (left, right) = wrap in
+    makeList
+      ~sep:(Layout.Sep ";")
+      ~wrap:(left ^ "{", "}" ^ right)
+      ~break:(if forceBreak then Layout.Always else Layout.IfNeed)
+      ~postSpace:true
+      ~inline:(true, false)
+      (self#class_self_pattern_and_structure cs)
+
+  method signature signatureItems =
+    match signatureItems with
+    | [] -> atom ""
+    | first::_ as signatureItems ->
+      let last = match (List.rev signatureItems) with | last::_ -> last | [] -> assert false in
+      let loc_start = first.psig_loc.loc_start in
+      let loc_end = last.psig_loc.loc_end in
+      let items =
+        groupAndPrint
+          ~xf:self#signature_item
+          ~getLoc:(fun x -> x.psig_loc)
+          ~comments:self#comments
+          signatureItems
+      in
+      source_map ~loc:{loc_start; loc_end; loc_ghost=false}
+        (makeList
+           ~postSpace:true
+           ~break:Layout.Always_rec
+           ~indent:0
+           ~inline:(true, false)
+           ~sep:(SepFinal (";", ";"))
+           items)
+
+  method signature_item x : Layout.t =
+    let item: Layout.t =
+      match x.psig_desc with
+        | Psig_type (rf, l) ->
+            self#type_def_list (rf, l)
+        | Psig_value vd ->
+            if vd.pval_prim != [] then
+              self#primitive_declaration vd
+            else
+              let intro = atom "let" in
+              let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true vd.pval_attributes in
+              let layout = self#attach_std_item_attrs stdAttrs
+                (formatTypeConstraint
+                   (label ~space:true intro
+                      (source_map ~loc:vd.pval_name.loc
+                         (protectIdentifier vd.pval_name.txt)))
+                  (self#core_type vd.pval_type))
+              in
+              self#attachDocAttrsToLayout
+                ~stdAttrs
+                ~docAttrs
+                ~loc:vd.pval_loc
+                ~layout
+                ()
+
+        | Psig_typext te ->
+            self#type_extension te
+        | Psig_exception ed ->
+            self#exception_declaration ed
+        | Psig_class l ->
+            let class_description
+                ?(class_keyword=false)
+                ({pci_params=ls; pci_name={txt}; pci_loc} as x) =
+              let (firstToken, pattern, patternAux) = self#class_opening class_keyword txt x.pci_virt ls in
+              let withColon = self#wrapCurriedFunctionBinding
+                ~arrow:":"
+                ~spaceBeforeArrow:false
+                firstToken
+                pattern
+                patternAux
+                ([(self#class_constructor_type x.pci_expr)], None)
+              in
+              let {stdAttrs; docAttrs} = partitionAttributes ~partDoc:true x.pci_attributes in
+              let layout = self#attach_std_item_attrs stdAttrs withColon in
+              source_map ~loc:pci_loc
+                (self#attachDocAttrsToLayout
+                  ~stdAttrs
+                  ~docAttrs
+                  ~loc:x.pci_name.loc
+                  ~layout
+                  ())
+            in
+            makeNonIndentedBreakingList (
+              match l with
+              | [] -> raise (NotPossible "No recursive class bindings")
+              | [x] -> [class_description ~class_keyword:true x]
+              | x :: xs ->
+                 (class_description ~class_keyword:true x)::
+                 (List.map class_description xs)
+            )
+        | Psig_module {pmd_name; pmd_type={pmty_desc=Pmty_alias alias}; pmd_attributes} ->
+            let {stdAttrs; docAttrs} =
+              partitionAttributes ~partDoc:true pmd_attributes
+            in
+            let layout =
+              self#attach_std_item_attrs stdAttrs @@
+              label ~space:true
+                (makeList ~postSpace:true [
+                   atom "module";
+                   atom pmd_name.txt;
+                   atom "="
+                 ])
+                (self#longident_loc alias)
+            in
+            self#attachDocAttrsToLayout
+              ~stdAttrs
+              ~docAttrs
+              ~loc:pmd_name.loc
+              ~layout
+              ()
+        | Psig_module pmd ->
+            let {stdAttrs; docAttrs} =
+              partitionAttributes ~partDoc:true pmd.pmd_attributes
+            in
+            let letPattern =
+              makeList
+                [makeList ~postSpace:true [atom "module"; (atom pmd.pmd_name.txt)];
+                 atom ":"]
+            in
+            let layout =
+              self#attach_std_item_attrs stdAttrs @@
+              (self#module_type letPattern pmd.pmd_type)
+            in
+            self#attachDocAttrsToLayout
+              ~stdAttrs
+              ~docAttrs
+              ~loc:pmd.pmd_name.loc
+              ~layout
+              ()
+        | Psig_open od ->
+          let {stdAttrs; docAttrs} =
+            partitionAttributes ~partDoc:true od.popen_attributes
+          in
+          let layout =
+            self#attach_std_item_attrs stdAttrs @@
+            label ~space:true
+              (atom ("open" ^ (override od.popen_override)))
+              (self#longident_loc od.popen_lid)
+          in
+          self#attachDocAttrsToLayout
+            ~stdAttrs
+            ~docAttrs
+            ~loc:od.popen_lid.loc
+            ~layout
+            ()
+        | Psig_include incl ->
+          let {stdAttrs; docAttrs} =
+            partitionAttributes ~partDoc:true incl.pincl_attributes
+          in
+          let layout =
+            self#attach_std_item_attrs stdAttrs @@
+            (self#module_type (atom "include") incl.pincl_mod)
+          in
+          self#attachDocAttrsToLayout
+            ~stdAttrs
+            ~docAttrs
+            ~loc:incl.pincl_mod.pmty_loc
+            ~layout
+            ()
+        | Psig_modtype x ->
+          let name = atom x.pmtd_name.txt in
+          let letPattern = makeList ~postSpace:true [atom "module type"; name; atom "="] in
+          let main = match x.pmtd_type with
+            | None -> makeList ~postSpace:true [atom "module type"; name]
+            | Some mt -> self#module_type letPattern mt
+          in
+          let {stdAttrs; docAttrs} =
+            partitionAttributes ~partDoc:true x.pmtd_attributes
+          in
+          let layout =
+            self#attach_std_item_attrs stdAttrs main
+          in
+          self#attachDocAttrsToLayout
+            ~stdAttrs
+            ~docAttrs
+            ~loc:x.pmtd_name.loc
+            ~layout
+            ()
+        | Psig_class_type l -> self#class_type_declaration_list l
+        | Psig_recmodule decls ->
+            let items = List.mapi (fun i xx ->
+              let {stdAttrs; docAttrs} =
+                partitionAttributes ~partDoc:true xx.pmd_attributes
+              in
+              let letPattern =
+                makeList [
+                  makeList ~postSpace:true [
+                    atom (if i == 0 then "module rec" else "and");
+                    atom xx.pmd_name.txt
+                  ];
+                 atom ":"
+                ]
+              in
+              let layout =
+                self#attach_std_item_attrs stdAttrs
+                  (self#module_type ~space:true letPattern xx.pmd_type)
+              in
+              let layoutWithDocAttrs =
+                self#attachDocAttrsToLayout
+                 ~stdAttrs
+                 ~docAttrs
+                 ~loc:xx.pmd_name.loc
+                 ~layout
+                 ()
+              in
+              (extractLocModDecl xx, layoutWithDocAttrs)
+            ) decls
+            in
+            makeNonIndentedBreakingList
+              (groupAndPrint
+                ~xf:(fun (_, layout) -> layout)
+                ~getLoc:(fun (loc, _) -> loc)
+                ~comments:self#comments
+                items)
+
+        | Psig_attribute a -> self#floating_attribute a
+        | Psig_extension (({loc}, _) as ext, attrs) ->
+          let {stdAttrs; docAttrs} =
+            partitionAttributes ~partDoc:true attrs
+          in
+          let layout =
+            self#attach_std_item_attrs stdAttrs (self#item_extension ext)
+          in
+          self#attachDocAttrsToLayout
+            ~stdAttrs
+            ~docAttrs
+            ~loc
+            ~layout
+            ()
+    in
+    source_map ~loc:x.psig_loc item
+
+  method non_arrowed_module_type ?(space=true) letPattern x =
+    match x.pmty_desc with
+      | Pmty_alias li ->
+        label ~space
+          letPattern
+          (formatPrecedence (label ~space:true (atom "module") (self#longident_loc li)))
+      | Pmty_typeof me ->
+        let labelWithoutFinalWrap =
+          label ~space:true
+            (label ~space:true
+               letPattern
+               (makeList
+                  ~inline:(false, false)
+                  ~wrap:("(","")
+                  ~postSpace:true
+                  [atom "module type of"]))
+            (self#module_expr me)
+        in
+        makeList ~wrap:("",")") [labelWithoutFinalWrap]
+      | _ -> self#simple_module_type ~space letPattern x
+
+  method simple_module_type ?(space=true) letPattern x =
+    match x.pmty_desc with
+      | Pmty_ident li -> label ~space letPattern (self#longident_loc li)
+      | Pmty_signature s ->
+        let items =
+          groupAndPrint
+          ~xf:self#signature_item
+          ~getLoc:(fun x -> x.psig_loc)
+          ~comments:self#comments
+          s
+        in
+        let shouldBreakLabel = if List.length s > 1 then `Always else `Auto in
+        label
+          ~indent:0
+          ~break:shouldBreakLabel
+          (makeList
+            [label
+               ~break:shouldBreakLabel
+                (makeList
+                  ~postSpace:true
+                  [letPattern; (atom "{")])
+              (source_map
+                 ~loc:x.pmty_loc
+                 (makeList
+                    ~break:(if List.length s > 1 then Always else IfNeed)
+                    ~inline:(true, true)
+                    ~postSpace:true
+                    ~sep:(SepFinal (";", ";"))
+                    items))])
+          (atom "}")
+      | Pmty_extension (s, e) -> label ~space letPattern (self#payload "%" s e)
+      | _ ->
+        makeList ~break:IfNeed ~wrap:("", ")")
+          [self#module_type ~space:false (makeList ~pad:(false,true) ~wrap:("","(") [letPattern]) x]
+
+  method module_type ?(space=true) letPattern x =
+    let pmty = match x.pmty_desc with
+      | Pmty_functor _ ->
+        (* The segments that should be separated by arrows. *)
+        let rec extract_args args xx = match xx.pmty_desc with
+          | Pmty_functor (_, None, mt2) -> extract_args (`Unit :: args) mt2
+          | Pmty_functor (s, Some mt1, mt2) ->
+            let arg =
+              if s.txt = "_"
+              then self#module_type ~space:false (atom "") mt1
+              else self#module_type ~space (makeList [(atom s.txt); atom ":"]) mt1
+            in
+            extract_args (`Arg arg :: args) mt2
+          | _ ->
+            let prepare_arg = function
+              | `Unit -> atom "()"
+              | `Arg x -> x
+            in
+            let args = match args with
+              | [`Unit] -> []
+              | _ -> List.rev_map prepare_arg args
+            in
+            (args, self#module_type (atom "") xx)
+        in
+        let args, ret = extract_args [] x in
+        label ~space letPattern
+          (makeList
+             ~break:IfNeed
+             ~sep:(Sep "=>")
+             ~preSpace:true
+             ~inline:(true, true)
+             [makeTup args; ret])
+
+      (* See comments in sugar_parser.mly about why WITH constraints aren't "non
+       * arrowed" *)
+      | Pmty_with (mt, l) ->
+          let modSub atm li2 token = makeList ~postSpace:true [
+            atom "module";
+            atm;
+            atom token;
+            self#longident_loc li2
+          ] in
+          let typeAtom = atom "type" in
+          let eqAtom = atom "=" in
+          let destrAtom = atom ":=" in
+          let with_constraint = function
+            | Pwith_type (li, td) ->
+                self#formatOneTypeDef
+                  typeAtom
+                  (makeList ~preSpace:true [(self#longident_loc li)])
+                  eqAtom
+                  td
+            | Pwith_module (li, li2) ->
+                modSub (self#longident_loc li) li2 "="
+            | Pwith_typesubst td ->
+                self#formatOneTypeDef
+                  typeAtom
+                  (atom ~loc:td.ptype_name.loc td.ptype_name.txt)
+                  destrAtom
+                  td
+            | Pwith_modsubst (s, li2) -> modSub (atom s.txt) li2 ":="
+          in
+          (match l with
+            | [] -> self#module_type ~space letPattern mt
+            | _ ->
+              label ~space letPattern
+                (label ~space:true
+                  (makeList ~preSpace:true [self#module_type ~space:false (atom "") mt; atom "with"])
+                  (makeList
+                     ~break:IfNeed
+                     ~inline:(true, true)
+                     ~sep:(Sep "and")
+                     ~postSpace:true
+                     ~preSpace:true
+                     (List.map with_constraint l)))
+          )
+        (* Seems like an infinite loop just waiting to happen. *)
+        | _ -> self#non_arrowed_module_type ~space letPattern x
+    in
+    source_map ~loc:x.pmty_loc pmty
+
+  method simple_module_expr ?(hug=false) x = match x.pmod_desc with
+    | Pmod_unpack e ->
+        let exprLayout = match e.pexp_desc with
+        | Pexp_constraint (e, {ptyp_desc = Ptyp_package(lid, cstrs)}) ->
+          formatTypeConstraint
+            (makeList ~postSpace:true [atom "val"; (self#unparseExpr e)])
+            (self#typ_package ~mod_prefix:false lid cstrs)
+        | _ -> makeList ~postSpace:true [atom "val"; (self#unparseExpr e)]
+        in formatPrecedence exprLayout
+    | Pmod_ident li ->
+        ensureSingleTokenSticksToLabel (self#longident_loc li)
+    | Pmod_constraint (unconstrainedRet, mt) ->
+        let letPattern = makeList [(self#module_expr unconstrainedRet); atom ":"]
+        in
+        formatPrecedence (self#module_type letPattern mt)
+    | Pmod_structure s ->
+        let wrap = if hug then ("({", "})") else ("{", "}") in
+        let items =
+          groupAndPrint
+            ~xf:self#structure_item
+            ~getLoc:(fun x -> x.pstr_loc)
+            ~comments:self#comments
+            s
+        in
+        makeList
+          ~break:Always_rec
+          ~inline:(true, false)
+          ~wrap
+          ~postSpace:true
+          ~sep:(SepFinal (";", ";"))
+          items
+    | _ ->
+        (* For example, functor application will be wrapped. *)
+        formatPrecedence (self#module_expr x)
+
+  method module_expr x =
+    match x.pmod_desc with
+    | Pmod_functor _ ->
+      let (argsList, return) = self#curriedFunctorPatternsAndReturnStruct x in
+      (* See #19/20 in syntax.mls - cannot annotate return type at
+               the moment. *)
+      self#wrapCurriedFunctionBinding funToken ~sweet:true ~arrow:"=>" (makeTup argsList) []
+        ([self#moduleExpressionToFormattedApplicationItems return], None)
+    | Pmod_apply _ ->
+      self#moduleExpressionToFormattedApplicationItems x
+    | Pmod_extension (s, e) -> self#payload "%" s e
+    | Pmod_unpack _
+    | Pmod_ident _
+    | Pmod_constraint _
+    | Pmod_structure _ -> self#simple_module_expr x
+
+
+  method structure structureItems =
+    match structureItems with
+    | [] -> atom ""
+    | first::_ as structureItems ->
+      let last = match (List.rev structureItems) with | last::_ -> last | [] -> assert false in
+      let loc_start = first.pstr_loc.loc_start in
+      let loc_end = last.pstr_loc.loc_end in
+      let items =
+        groupAndPrint
+          ~xf:self#structure_item
+          ~getLoc:(fun x -> x.pstr_loc)
+          ~comments:self#comments
+          structureItems
+      in
+      source_map ~loc:{loc_start; loc_end; loc_ghost = false}
+        (makeList
+           ~postSpace:true
+           ~break:Always_rec
+           ~indent:0
+           ~inline:(true, false)
+           ~sep:(SepFinal (";", ";"))
+           items)
+
+  (*
+     How do modules become parsed?
+     let module (X: sig) = blah;
+       Will not parse! (Should just make it parse to let [X:sig =]).
+     let module X: sig = blah;
+       Becomes Pmod_constraint
+     let module X: sig = (blah:sig);
+       Becomes Pmod_constraint .. Pmod_constraint
+     let module X = blah:typ;
+       Becomes Pmod_constraint
+     let module X (Y:y) (Z:z):r => Q
+       Becomes Pmod_functor...=> Pmod_constraint
+
+     let module X (Y:y) (Z:z):r => (Q:r2)
+       Probably becomes Pmod_functor...=> (Pmod_constraint..
+       Pmod_constraint)
+
+    let (module X) =
+      Is a *completely* different thing (unpacking/packing first class modules).
+      We should make sure this is very well distinguished.
+      - Just replace all "let module" with a new three letter keyword (mod)?
+      - Reserve let (module X) for unpacking first class modules.
+
+    See the notes about how Ppat_constraint become parsed and attempt to unify
+    those as well.
+  *)
+
+  method let_module_binding prefixText bindingName moduleExpr =
+    let (argsList, return) = self#curriedFunctorPatternsAndReturnStruct moduleExpr in (
+      match (argsList, return.pmod_desc) with
+        (* Simple module with type constraint, no functor args. *)
+        | ([], Pmod_constraint (unconstrainedRetTerm, ct)) ->
+            let letPattern =
+              makeList
+                [makeList ~postSpace:true [atom prefixText; bindingName];
+                 atom ":"]
+            in
+            let typeConstraint = self#module_type letPattern ct in
+            let includingEqual = makeList ~postSpace:true [typeConstraint; atom "="]
+            in
+            formatAttachmentApplication applicationFinalWrapping (Some (true, includingEqual))
+              ([self#moduleExpressionToFormattedApplicationItems unconstrainedRetTerm], None)
+
+        (* Simple module with type no constraint, no functor args. *)
+        | ([], _) ->
+          self#formatSimplePatternBinding prefixText bindingName None
+            ([self#moduleExpressionToFormattedApplicationItems return], None)
+        | (_, _) ->
+            (* A functor *)
+            let (argsWithConstraint, actualReturn) = (
+              match return.pmod_desc with
+                (* A functor with constrained return type:
+                 *
+                 * let module X = (A) (B) : Ret => ...
+                 * *)
+                | Pmod_constraint (me, ct) ->
+                  ([makeTup argsList;
+                    self#non_arrowed_module_type (atom ":") ct], me)
+                | _ -> ([makeTup argsList], return)
+            ) in
+            self#wrapCurriedFunctionBinding prefixText ~arrow:"=>"
+              (makeList [bindingName; atom " ="]) argsWithConstraint
+              ([self#moduleExpressionToFormattedApplicationItems actualReturn], None)
+    )
+
+    method class_opening class_keyword name pci_virt ls =
+      let firstToken = if class_keyword then "class" else "and" in
+      match (pci_virt, ls) with
+        (* When no class params, it's a very simple formatting for the
+           opener - no breaking. *)
+        | (Virtual, []) ->
+          (firstToken, atom "virtual", [atom name])
+        | (Concrete, []) ->
+          (firstToken, atom name, [])
+        | (Virtual, _::_) ->
+          (firstToken, atom "virtual", [atom name; self#class_params_def ls])
+        | (Concrete, _::_) ->
+          (firstToken, atom name, [self#class_params_def ls])
+
+
+  (* TODO: TODOATTRIBUTES: Structure items don't have attributes, but each
+     pstr_desc *)
+  method structure_item term =
+    let item = (
+      match term.pstr_desc with
+        | Pstr_eval (e, attrs) ->
+            let {stdAttrs; jsxAttrs; uncurried} = partitionAttributes attrs in
+            if uncurried then Hashtbl.add uncurriedTable e.pexp_loc true;
+            let layout = self#attach_std_item_attrs stdAttrs (self#unparseUnattributedExpr e) in
+            (* If there was a JSX attribute BUT JSX component wasn't detected,
+               that JSX attribute needs to be pretty printed so it doesn't get
+               lost *)
+            (match jsxAttrs with
+            | [] -> layout
+            | _::_ ->
+              let jsxAttrNodes = List.map self#attribute jsxAttrs in
+              makeList ~sep:(Sep " ") (jsxAttrNodes @ [layout]))
+        | Pstr_type (_, []) -> assert false
+        | Pstr_type (rf, l)  -> (self#type_def_list (rf, l))
+        | Pstr_value (rf, l) -> (self#bindings (rf, l))
+        | Pstr_typext te -> (self#type_extension te)
+        | Pstr_exception ed -> (self#exception_declaration ed)
+        | Pstr_module x ->
+            let bindingName = atom ~loc:x.pmb_name.loc x.pmb_name.txt in
+            self#attach_std_item_attrs x.pmb_attributes @@
+            self#let_module_binding "module" bindingName x.pmb_expr
+        | Pstr_open od ->
+            self#attach_std_item_attrs od.popen_attributes @@
+            makeList ~postSpace:true [
+              atom ("open" ^ (override od.popen_override));
+              self#longident_loc od.popen_lid;
+            ]
+        | Pstr_modtype x ->
+            let name = atom x.pmtd_name.txt in
+            let letPattern = makeList ~postSpace:true [atom "module type"; name; atom "="] in
+            let main = match x.pmtd_type with
+              | None -> makeList ~postSpace:true [atom "module type"; name]
+              | Some mt -> self#module_type letPattern mt
+            in
+            self#attach_std_item_attrs x.pmtd_attributes main
+        | Pstr_class l -> self#class_declaration_list l
+        | Pstr_class_type l -> self#class_type_declaration_list l
+        | Pstr_primitive vd -> self#primitive_declaration vd
+        | Pstr_include incl ->
+            self#attach_std_item_attrs incl.pincl_attributes @@
+            (* Kind of a hack *)
+            let moduleExpr = incl.pincl_mod in
+            self#moduleExpressionToFormattedApplicationItems
+              ~prefix:"include"
+              moduleExpr
+
+        | Pstr_recmodule decls -> (* 3.07 *)
+            let items = List.mapi (fun i xx ->
+              let {stdAttrs; docAttrs} =
+                partitionAttributes ~partDoc:true xx.pmb_attributes
+              in
+              let layout =
+                self#attach_std_item_attrs stdAttrs @@
+                self#let_module_binding
+                  (if i == 0 then "module rec" else "and")
+                  (atom xx.pmb_name.txt)
+                  xx.pmb_expr
+              in
+              let layoutWithDocAttrs =
+                self#attachDocAttrsToLayout
+                 ~stdAttrs
+                 ~docAttrs
+                 ~loc:xx.pmb_name.loc
+                 ~layout
+                 ()
+              in
+              (extractLocModuleBinding xx, layoutWithDocAttrs)
+            ) decls
+            in
+            makeNonIndentedBreakingList
+              (groupAndPrint
+                ~xf:(fun (_, layout) -> layout)
+                ~getLoc:(fun (loc, _) -> loc)
+                ~comments:self#comments
+                items)
+        | Pstr_attribute a -> self#floating_attribute a
+        | Pstr_extension ((extension, PStr [item]), a) ->
+          begin match item.pstr_desc with
+            | Pstr_value (rf, l) -> self#bindings ~extension (rf, l)
+            | _ ->
+                let {stdAttrs; docAttrs} =
+                  partitionAttributes ~partDoc:true a
+                in
+                let layout =
+                  self#attach_std_item_attrs ~extension stdAttrs
+                     (self#structure_item item)
+                in
+                makeList ~inline:(true, true) ~break:Always
+                  ((List.map self#attribute docAttrs)@[layout])
+          end
+        | Pstr_extension (e, a) ->
+          (* Notice how extensions have attributes - but not every structure
+             item does. *)
+          self#attach_std_item_attrs a (self#item_extension e)
+    ) in
+    source_map ~loc:term.pstr_loc item
+
+  method type_extension te =
+    let formatOneTypeExtStandard prepend ({ptyext_path} as te) =
+      let name = self#longident_loc ptyext_path in
+      let item = self#formatOneTypeExt prepend name (atom "+=") te in
+      let {stdAttrs; docAttrs} =
+        partitionAttributes ~partDoc:true te.ptyext_attributes
+      in
+      let layout = self#attach_std_item_attrs stdAttrs item in
+      self#attachDocAttrsToLayout
+        ~stdAttrs
+        ~docAttrs
+        ~loc:ptyext_path.loc
+        ~layout
+        ()
+    in
+    formatOneTypeExtStandard (atom "type") te
+
+  (* [allowUnguardedSequenceBodies] allows sequence expressions {} to the right of `=>` to not
+     be guarded in `{}` braces. *)
+  method case_list ?(allowUnguardedSequenceBodies=false) l =
+    let rec appendLabelToLast items rhs =
+      match items with
+        | hd::[] -> (label ~indent:0 ~space:true hd rhs)::[]
+        | hd::tl -> hd::(appendLabelToLast tl rhs)
+        | [] -> raise (NotPossible "Cannot append to last of nothing")
+    in
+
+    let case_row {pc_lhs; pc_guard; pc_rhs} =
+      let theOrs = orList pc_lhs in
+
+      (* match x with *)
+      (* | AnotherReallyLongVariantName (_, _, _)   *)
+      (* | AnotherReallyLongVariantName2 (_, _, _)
+           when true => {                           *)
+
+      (*   }                                        *)
+
+      (*<sbi><X>match x with</X>   *)
+      (*     <Y>everythingElse</Y> *)
+      (*</sbi>                     *)
+
+
+
+      (*     ............................................................
+             :    each or segment has a spaced list <> that ties its    :
+             : bar "|" to its pattern                                   :
+             ...:..........................................................:.....
+             :  :  each or-patterned match is grouped in SpacedBreakableInline  :
+             :  :                                                          :    :
+             v  v                                                          v    v
+             <sbi><>|<lb><A><>     FirstThingStandalone t =></A></><B>t</B></lb></></sbi>
+             <sbi><>|<C>           AnotherReallyLongVariantName (_, _, _)</C></>
+             ^    <>|<lb><><lb><D>AnotherReallyLongVariantNam2 (_, _, _)</D>             (label the last in or ptn for or and label it again for arrow)
+             :        ^  ^   ^     <E>when true<E></lb> =></><F>{
+             :        :  :   :    </F>}</lb></sbi> ^       ^
+             :        :  :   :            ^     ^   :      :
+             :        :  :   :            :     :   :      :
+             :        :  :   :If there is :a WHERE  :      :
+             :        :  :   :an extra    :label is :      :
+             :        :  :   :inserted bef:ore the  :      :
+             :        :  :   :arrow.      :     :   :      :
+             :        :  :   :............:.....:...:      :
+             :        :  :                :     :          :
+             :        :  :                :     :          :
+             :        :  :                :     :          :
+             :        :  :The left side of:this final label:
+             :        :  :uses a list to  :append the arrow:
+             :        :  :................:.....:..........:
+             :        :                   :     :
+             :        :                   :     :
+             :        :                   :     :
+             :        :Final or segment is:     :
+             :        :wrapped in lbl that:     :
+             :        :partitions pattern :     :
+             :        :and arrow from     :     :
+             :        :expression.        :     :
+             :        :                   :     :
+             :        :...................:     :
+             :     [orsWithWhereAndArrowOnLast] :
+             :                                  :
+             :..................................:
+                         [row]
+
+      *)
+      let bar xx = makeList ~postSpace:true [atom "|"; xx] in
+      let appendWhereAndArrow p = match pc_guard with
+        | None -> makeList ~postSpace:true [p; atom "=>"]
+        | Some g ->
+          (* when x should break as a whole - extra list added around it to make it break as one *)
+          let withWhen = label ~space:true p
+              (makeList ~break:Layout.Never ~inline:(true, true) ~postSpace:true
+                 [label ~space:true (atom "when") (self#unparseExpr g)])
+          in
+          makeList ~inline:(true, true) ~postSpace:true [withWhen; atom "=>"]
+      in
+      let rec appendWhereAndArrowToLastOr = function
+        | [] -> []
+        | hd::tl ->
+          let formattedHd = self#pattern hd in
+          let formattedHd =
+            if tl == [] then appendWhereAndArrow formattedHd else formattedHd
+          in
+          (formattedHd :: appendWhereAndArrowToLastOr tl)
+      in
+      let orsWithWhereAndArrowOnLast = appendWhereAndArrowToLastOr theOrs in
+      let rhs =
+        if allowUnguardedSequenceBodies then
+          match (self#under_pipe#letList pc_rhs) with
+          (* TODO: Still render a list with located information here so that
+               comments (eol) are interleaved *)
+          | [hd] -> hd
+          (* In this case, we don't need any additional indentation, because there aren't
+             wrapping {} which would cause zero indentation to look strange. *)
+          | lst -> makeUnguardedLetSequence lst
+        else self#under_pipe#unparseExpr pc_rhs
+      in
+      source_map
+        (* Fake shift the location to accommodate for the bar, to make sure
+           * the wrong comments don't make their way past the next bar. *)
+        ~loc:(expandLocation ~expand:(0, 0) {
+            loc_start = pc_lhs.ppat_loc.loc_start;
+            loc_end = pc_rhs.pexp_loc.loc_end;
+            loc_ghost = false;
+          })
+        (makeList ~break:Always_rec ~inline:(true, true)
+           (List.map bar (appendLabelToLast orsWithWhereAndArrowOnLast rhs)))
+    in
+    groupAndPrint
+      ~xf:case_row
+      ~getLoc:(fun {pc_lhs; pc_rhs} -> {pc_lhs.ppat_loc with loc_end = pc_rhs.pexp_loc.loc_end})
+      ~comments:self#comments
+      l
+
+  (* Formats a list of a single expr param in such a way that the parens of the function or
+   * (poly)-variant application and the wrapping of the param stick together when the layout breaks.
+   *  Example: `foo({a: 1, b: 2})` needs to be formatted as
+   *  foo({
+   *    a: 1,
+   *    b: 2
+   *  })
+   *  when the line length dictates breaking. Notice how `({` and `})` 'hug'.
+   *  Also see "isSingleArgParenApplication" which determines if
+   *  this kind of formatting should happen. *)
+  method singleArgParenApplication ?(wrap=("", "")) ?(uncurried=false) es =
+    let (lwrap, rwrap) = wrap in
+    let lparen = lwrap ^ (if uncurried then  "(. " else "(") in
+    let rparen = ")" ^ rwrap in
+    match es with
+    | [{pexp_attributes = []; pexp_desc = Pexp_record (l, eo)}] ->
+      self#unparseRecord ~wrap:(lparen, rparen) l eo
+    | [{pexp_attributes = []; pexp_desc = Pexp_tuple l}] ->
+      self#unparseSequence ~wrap:(lparen, rparen) ~construct:`Tuple l
+    | [{pexp_attributes = []; pexp_desc = Pexp_array l}] ->
+      self#unparseSequence ~wrap:(lparen, rparen) ~construct:`Array l
+    | [{pexp_attributes = []; pexp_desc = Pexp_object cs}] ->
+      self#classStructure ~wrap:(lparen, rparen) cs
+    | [{pexp_attributes = []; pexp_desc = Pexp_extension (s, p)}] when s.txt = "bs.obj" ->
+      self#formatBsObjExtensionSugar ~wrap:(lparen, rparen) p
+    | [({pexp_attributes = []} as exp)] when (is_simple_list_expr exp) ->
+          (match view_expr exp with
+          | `list xs ->
+              self#unparseSequence ~construct:`List ~wrap:(lparen, rparen) xs
+          | `cons xs ->
+              self#unparseSequence ~construct:`ES6List ~wrap:(lparen, rparen) xs
+          | _ -> assert false)
+    | _ -> assert false
+
+
+  method label_x_expression_param (l, e) =
+    let term = self#unparseProtectedExpr e in
+    let param = match (l, e) with
+      | (Nolabel, _) -> term
+      | (Labelled lbl, _) when is_punned_labelled_expression e lbl ->
+        makeList [atom namedArgSym; term]
+      | (Optional lbl, _) when is_punned_labelled_expression e lbl ->
+        makeList [atom namedArgSym; label term (atom "?")]
+      | (Labelled lbl, _) ->
+        label (atom (namedArgSym ^ lbl ^ "=")) term
+      | (Optional lbl, _) ->
+        label (atom (namedArgSym ^ lbl ^ "=?")) term
+    in
+    source_map ~loc:e.pexp_loc param
+
+  method label_x_expression_params ?wrap ?(uncurried=false) xs =
+    match xs with
+      (* function applications with unit as only argument should be printed differently
+       * e.g. print_newline(()) should be printed as print_newline() *)
+      | [(Nolabel, {pexp_attributes = []; pexp_desc = Pexp_construct ( {txt= Lident "()"}, None)})]
+          -> makeList
+              ~break:Never
+              ?wrap
+              [if uncurried then atom "(.)" else atom "()"]
+
+      (* The following cases provide special formatting when there's only one expr_param that is a tuple/array/list/record etc.
+       *  e.g. foo({a: 1, b: 2})
+       *  becomes ->
+       *  foo({
+       *    a: 1,
+       *    b: 2,
+       *  })
+       *  when the line-length indicates breaking.
+       *)
+      | [(Nolabel, exp)] when isSingleArgParenApplication [exp] ->
+          self#singleArgParenApplication ?wrap ~uncurried [exp]
+      | params ->
+          makeTup ?wrap ~uncurried (List.map self#label_x_expression_param params)
+
+  (*
+   * Prefix represents an optional layout. When passed it will be "prefixed" to
+   * the funExpr. Example, given `bar(x, y)` with prefix `foo`, we get
+   * foobar(x,y). When the arguments break, the closing `)` is nicely aligned
+   * on the height of the prefix:
+   *  foobar(
+   *    x,
+   *    y,
+   *  )  --> notice how `)` sits on the height of `foo` instead of `bar`
+   *
+   *  ~wrap -> represents optional "wrapping", might be useful in context of jsx
+   *  where braces are required:
+   * prop={bar(   -> `{` is formatted before the funExpr
+   *   x,
+   *   y,
+   * )}      -> notice how the closing brace hugs: `)}`
+   *)
+  method formatFunAppl ?(prefix=(atom "")) ?(wrap=("", "")) ~jsxAttrs ~args ~funExpr ~applicationExpr ?(uncurried=false) () =
+    let (leftWrap, rightWrap) = wrap in
+    let uncurriedApplication = uncurried in
+    (* If there was a JSX attribute BUT JSX component wasn't detected,
+       that JSX attribute needs to be pretty printed so it doesn't get
+       lost *)
+    let maybeJSXAttr = List.map self#attribute jsxAttrs in
+    let categorizeFunApplArgs args =
+      let reverseArgs = List.rev args in
+      match reverseArgs with
+      | ((_, {pexp_desc = Pexp_fun _}) as callback)::args
+          when
+            [] == List.filter (fun (_, e) -> match e.pexp_desc with Pexp_fun _ -> true | _ -> false) args
+          (* default to normal formatting if there's more than one callback *)
+          -> `LastArgIsCallback(callback, List.rev args)
+      | _ -> `NormalFunAppl args
+    in
+    let formattedFunExpr = match funExpr.pexp_desc with
+      (* pipe first chain or sharpop chain as funExpr, no parens needed, we know how to parse *)
+      | Pexp_apply ({pexp_desc = Pexp_ident {txt = Lident s}}, _)
+        when requireNoSpaceFor s ->
+        self#unparseExpr funExpr
+      | Pexp_field _ -> self#unparseExpr funExpr
+      | _ -> self#simplifyUnparseExpr funExpr
+    in
+    let formattedFunExpr = makeList [prefix; atom leftWrap; formattedFunExpr] in
+    begin match categorizeFunApplArgs args with
+    | `LastArgIsCallback(callbackArg, args) ->
+        (* This is the following case:
+         * Thing.map(foo, bar, baz, (abc, z) =>
+         *   MyModuleBlah.toList(argument)
+         *)
+        let (argLbl, cb) = callbackArg in
+        let {stdAttrs; uncurried} = partitionAttributes cb.pexp_attributes in
+        let cbAttrs = stdAttrs in
+        if uncurried then Hashtbl.add uncurriedTable cb.pexp_loc true;
+        let (cbArgs, retCb) = self#curriedPatternsAndReturnVal {cb with pexp_attributes = []} in
+        let cbArgs = if cbAttrs != [] then
+            makeList ~break:IfNeed ~inline:(true, true) ~postSpace:true
+              (List.map self#attribute cbAttrs @ cbArgs)
+        else makeList cbArgs in
+        let theCallbackArg = match argLbl with
+          | Optional s -> makeList ([atom namedArgSym; atom s; atom "=?"]@[cbArgs])
+          | Labelled s -> makeList ([atom namedArgSym; atom s; atom "="]@[cbArgs])
+          | Nolabel -> cbArgs
+        in
+        let theFunc =
+          source_map ~loc:funExpr.pexp_loc
+            (makeList
+               ~wrap:("", (if uncurriedApplication then "(." else "("))
+               [formattedFunExpr])
+        in
+        let formattedFunAppl = begin match self#letList retCb with
+        | [x] ->
+          (* force breaks for test assertion style callbacks, e.g.
+           *  describe("App", () => test("math", () => Expect.expect(1 + 2) |> toBe(3)));
+           * should always break for readability of the tests:
+           *  describe("App", () =>
+           *    test("math", () =>
+           *      Expect.expect(1 + 2) |> toBe(3)
+           *    )
+           *  );
+           *)
+          let forceBreak = match funExpr.pexp_desc with
+          | Pexp_ident ident when
+              let lastIdent = Longident.last ident.txt in
+              List.mem lastIdent ["test"; "describe"; "it"; "expect"] -> true
+          | _ -> false
+          in
+          let returnValueCallback =
+            makeList
+              ~break:(if forceBreak then Always else IfNeed)
+              ~wrap:("=> ", ")" ^ rightWrap)
+              [x]
+          in
+          let argsWithCallbackArgs = List.concat [(List.map self#label_x_expression_param args); [theCallbackArg]] in
+          let left = label
+            theFunc
+            (makeList
+               ~pad:(uncurriedApplication, false)
+               ~wrap:("", " ") ~break:IfNeed ~inline:(true, true) ~sep:(Sep ",") ~postSpace:true
+              argsWithCallbackArgs)
+          in
+          label left returnValueCallback
+        | xs ->
+          let printWidthExceeded = Reason_heuristics.funAppCallbackExceedsWidth ~printWidth:settings.width ~args ~funExpr () in
+          if printWidthExceeded = false then
+              (*
+               * Thing.map(foo, bar, baz, (abc, z) =>
+               *   MyModuleBlah.toList(argument)
+               * )
+               *
+               * To get this kind of formatting we need to construct the following tree:
+               * <Label>
+               * <left>Thing.map(foo, bar, baz, (abc, z)</left><right>=>
+               *   MyModuleBlah.toList(argument)
+               * )</right>
+               * </Label>
+               *
+               * where left is
+               * <Label><left>Thing.map(</left></right>foo, bar, baz, (abc, z) </right></Label>
+               *
+               * The <right> part of that label could be a <List> with wrap:("", " ") break:IfNeed inline:(true, true)
+               * with items: "foo", "bar", "baz", "(abc, z)", separated by commas.
+               *
+               * this is also necessary to achieve the following formatting where }) hugs :
+               * test("my test", () => {
+               *   let x = a + b;
+               *   let y = z + c;
+               *   x + y
+               * });
+               *)
+            let right =
+              source_map ~loc:retCb.pexp_loc
+                (makeList ~break:Always_rec ~wrap:("=> {", "})" ^ rightWrap) ~sep:(SepFinal (";", ";")) xs)
+            in
+            let argsWithCallbackArgs =
+              List.map self#label_x_expression_param args @ [theCallbackArg]
+            in
+            let left = label
+                theFunc
+                (makeList ~wrap:("", " ") ~break:IfNeed ~inline:(true, true) ~sep:(Sep ",") ~postSpace:true
+                   argsWithCallbackArgs)
+            in
+            label left right
+          else
+            (* Since the heuristic says the line length is exceeded in this case,
+             * we conveniently format everything as
+             * <label><left>Thing.map(</left><right><list>
+             *   foo,
+             *   bar,
+             *   baz,
+             *   <label> <left>(abc) =></left> <right><list> {
+             *     let x = 1;
+             *     let y = 2;
+             *     x + y
+             *   }</list></right></label>
+             * )</list></right></label>
+            *)
+            let args =
+              makeList ~break:Always ~wrap:("", ")" ^ rightWrap) ~sep:commaTrail (
+                (List.map self#label_x_expression_param args) @
+                [label ~space:true (makeList ~wrap:("", " =>") [theCallbackArg])
+                   (source_map ~loc:retCb.pexp_loc (makeLetSequence xs))]
+              )
+            in
+            label theFunc args
+        end in
+        maybeJSXAttr @ [formattedFunAppl]
+    | `NormalFunAppl args ->
+      let theFunc =
+        source_map ~loc:funExpr.pexp_loc formattedFunExpr
+      in
+      (* reset here only because [function,match,try,sequence] are lower priority *)
+      (* The "expression location" might be different than the location of the actual
+       * function application because things like surrounding { } expand the
+       * parsed location (in body of while loop for example).
+       * We recover the most meaningful function application location we can.*)
+      let (syntheticApplicationLocation, syntheticArgLoc) = match args with
+        | [] -> (funExpr.pexp_loc, funExpr.pexp_loc)
+        | _::_ ->
+          {funExpr.pexp_loc with loc_end = applicationExpr.pexp_loc.loc_end},
+          {funExpr.pexp_loc with loc_start = funExpr.pexp_loc.loc_end; loc_end = applicationExpr.pexp_loc.loc_end}
+      in
+      let theArgs = self#reset#label_x_expression_params ~wrap:("", rightWrap) ~uncurried args in
+      maybeJSXAttr @ [source_map ~loc:syntheticApplicationLocation
+                        (label theFunc (source_map ~loc:syntheticArgLoc theArgs))]
+    end
+end;;
+
+let toplevel_phrase ppf x =
+  match x with
+  | Ptop_def s -> format_layout ppf (printer#structure s)
+  | Ptop_dir _ -> print_string "(* top directives not supported *)"
+
+let case_list ppf x =
+  List.iter (format_layout ppf) (printer#case_list x)
+
+(* Convert a Longident to a list of strings.
+   E.g. M.Constructor will be ["Constructor"; "M.Constructor"]
+   Also support ".Constructor" to specify access without a path.
+ *)
+let longident_for_arity lid =
+  let rec toplevel = function
+    | Lident s ->
+        [s]
+    | Ldot (lid, s) ->
+        let append_s x = x ^ "." ^ s in
+        s :: (List.map append_s (toplevel lid))
+    | Lapply (_,s) ->
+        toplevel s in
+   match lid with
+    | Lident s ->
+        ("." ^ s) :: toplevel lid
+    | _ ->
+        toplevel lid
+
+(* add expilcit_arity to a list of attributes
+ *)
+let add_explicit_arity loc attributes =
+  ({txt="explicit_arity"; loc}, PStr []) ::
+  normalized_attributes "explicit_arity" attributes
+
+(* explicit_arity_exists check if expilcit_arity exists
+ *)
+let explicit_arity_not_exists attributes =
+  not (attribute_exists "explicit_arity" attributes)
+
+(* wrap_expr_with_tuple wraps an expression
+ * with tuple as a sole argument.
+ *)
+let wrap_expr_with_tuple exp =
+  {exp with pexp_desc = Pexp_tuple [exp]}
+
+(* wrap_pat_with_tuple wraps an pattern
+ * with tuple as a sole argument.
+ *)
+let wrap_pat_with_tuple pat =
+  {pat with ppat_desc = Ppat_tuple [pat]}
+
+
+
+(* explicit_arity_constructors is a set of constructors that are known to have
+ * multiple arguments
+ *
+ *)
+
+module StringSet = Set.Make(String);;
+
+let built_in_explicit_arity_constructors = ["Some"; "Assert_failure"; "Match_failure"]
+
+let explicit_arity_constructors = StringSet.of_list(built_in_explicit_arity_constructors @ (!configuredSettings).constructorLists)
+
+let add_explicit_arity_mapper super =
+  let super_expr = super.Ast_mapper.expr in
+  let super_pat = super.Ast_mapper.pat in
+  let expr mapper expr =
+    let expr =
+      match expr with
+      | {pexp_desc=Pexp_construct(lid, Some sp);
+         pexp_loc;
+         pexp_attributes} when
+          List.exists
+            (fun c -> StringSet.mem c explicit_arity_constructors)
+            (longident_for_arity lid.txt) &&
+          explicit_arity_not_exists pexp_attributes ->
+        {pexp_desc=Pexp_construct(lid, Some (wrap_expr_with_tuple sp));
+         pexp_loc;
+         pexp_attributes=add_explicit_arity pexp_loc pexp_attributes}
+      | x -> x
+    in
+    super_expr mapper expr
+  and pat mapper pat =
+    let pat =
+      match pat with
+      | {ppat_desc=Ppat_construct(lid, Some sp);
+         ppat_loc;
+         ppat_attributes} when
+          List.exists
+            (fun c -> StringSet.mem c explicit_arity_constructors)
+            (longident_for_arity lid.txt) &&
+          explicit_arity_not_exists ppat_attributes ->
+        {ppat_desc=Ppat_construct(lid, Some (wrap_pat_with_tuple sp));
+         ppat_loc;
+         ppat_attributes=add_explicit_arity ppat_loc ppat_attributes}
+      | x -> x
+    in
+    super_pat mapper pat
+  in
+  { super with Ast_mapper. expr; pat }
+
+let preprocessing_mapper =
+  ml_to_reason_swap_operator_mapper
+    (escape_stars_slashes_mapper
+      (add_explicit_arity_mapper Ast_mapper.default_mapper))
+
+let core_type ppf x =
+  format_layout ppf
+    (printer#core_type (apply_mapper_to_type x preprocessing_mapper))
+
+let pattern ppf x =
+  format_layout ppf
+    (printer#pattern (apply_mapper_to_pattern x preprocessing_mapper))
+
+let signature (comments : Comment.t list) ppf x =
+  List.iter (fun comment -> printer#trackComment comment) comments;
+  format_layout ppf ~comments
+    (printer#signature (apply_mapper_to_signature x preprocessing_mapper))
+
+let structure (comments : Comment.t list) ppf x =
+  List.iter (fun comment -> printer#trackComment comment) comments;
+  format_layout ppf ~comments
+    (printer#structure (apply_mapper_to_structure x preprocessing_mapper))
+
+let expression ppf x =
+  format_layout ppf
+    (printer#unparseExpr (apply_mapper_to_expr x preprocessing_mapper))
+
+let case_list = case_list
+
+end
+in
+object
+  method core_type = Formatter.core_type
+  method pattern = Formatter.pattern
+  method signature = Formatter.signature
+  method structure = Formatter.structure
+  (* For merlin-destruct *)
+  method toplevel_phrase = Formatter.toplevel_phrase
+  method expression = Formatter.expression
+  method case_list = Formatter.case_list
+end

--- a/tools/liquidity/reason/reason_pprint_ast.mli
+++ b/tools/liquidity/reason/reason_pprint_ast.mli
@@ -1,0 +1,16 @@
+open Ast_404.Parsetree
+
+val configure :
+  width:int ->
+  assumeExplicitArity:bool -> constructorLists:string list -> unit
+
+val createFormatter : unit ->
+  <
+    case_list : Format.formatter -> case list -> unit;
+    core_type : Format.formatter -> core_type -> unit;
+    expression : Format.formatter -> expression -> unit;
+    pattern : Format.formatter -> pattern -> unit;
+    signature : Reason_comment.t list -> Format.formatter -> signature -> unit;
+    structure : Reason_comment.t list -> Format.formatter -> structure -> unit;
+    toplevel_phrase : Format.formatter -> toplevel_phrase -> unit;
+  >

--- a/tools/liquidity/reason/reason_string.ml
+++ b/tools/liquidity/reason/reason_string.ml
@@ -1,0 +1,3 @@
+module String = struct
+  include String
+end

--- a/tools/liquidity/reason/reason_syntax_util.ml
+++ b/tools/liquidity/reason/reason_syntax_util.ml
@@ -1,0 +1,557 @@
+(* Hello! Welcome to the Reason syntax util logic.
+
+  This file's shared between the Reason repo and the BuckleScript repo. In
+  Reason, it's in src/reason-parser. In BuckleScript, it's in
+  jscomp/outcome_printer. We periodically copy this file from Reason (the source
+  of truth) to BuckleScript, then uncomment the #if #else #end cppo macros you
+  see in the file. That's because BuckleScript's on OCaml 4.02 while Reason's on
+  4.04; so the #if macros surround the pieces of code that are different between
+  the two compilers.
+
+  When you modify this file, please make sure you're not dragging in too many
+  things. You don't necessarily have to test the file on both Reason and
+  BuckleScript; ping @chenglou and a few others and we'll keep them synced up by
+  patching the right parts, through the power of types(tm)
+*)
+
+(* #if defined BS_NO_COMPILER_PATCH then *)
+open Ast_404
+(* #end *)
+
+open Asttypes
+open Ast_mapper
+open Parsetree
+open Longident
+
+(** Check to see if the string `s` is made up of `keyword` and zero or more
+    trailing `_` characters. *)
+let potentially_conflicts_with ~keyword s =
+  let s_length = String.length s in
+  let keyword_length = String.length keyword in
+  (* It can't be a match if s is shorter than keyword *)
+  s_length >= keyword_length && (
+    try
+      (* Ensure s starts with keyword... *)
+      for i = 0 to keyword_length - 1 do
+        if keyword.[i] <> s.[i] then raise Exit;
+      done;
+      (* ...and contains nothing else except trailing _ characters *)
+      for i = keyword_length to s_length - 1 do
+        if s.[i] <> '_' then raise Exit;
+      done;
+      (* If we've made it this far there's a potential conflict *)
+      true
+    with
+    | Exit -> false
+  )
+
+(** Add/remove an appropriate suffix when mangling potential keywords *)
+let string_add_suffix x = x ^ "_"
+let string_drop_suffix x = String.sub x 0 (String.length x - 1)
+
+(** What do these *_swap functions do? Here's an example: Reason code uses `!`
+    for logical not, while ocaml uses `not`. So, for converting between reason
+    and ocaml syntax, ocaml `not` converts to `!`, reason `!` converts to
+    `not`.
+
+    In more complicated cases where a reserved keyword exists in one syntax but
+    not the other, these functions translate any potentially conflicting
+    identifier into the same identifier with a suffix attached, or remove the
+    suffix when converting back. Two examples:
+
+    reason to ocaml:
+
+    pub: invalid in reason to begin with
+    pub_: pub
+    pub__: pub_
+
+    ocaml to reason:
+
+    pub: pub_
+    pub_: pub__
+    pub__: pub___
+
+    =====
+
+    reason to ocaml:
+
+    match: match_
+    match_: match__
+    match__: match___
+
+    ocaml to reason:
+
+    match: invalid in ocaml to begin with
+    match_: match
+    match__: match_
+*)
+
+let reason_to_ml_swap = function
+  | "!" -> "not"
+  | "^" -> "!"
+  | "++" -> "^"
+  | "===" -> "=="
+  | "==" -> "="
+  (* ===\/ and !==\/ are not representable in OCaml but
+   * representable in Reason
+   *)
+  | "\\!==" -> "!=="
+  |  "\\===" -> "==="
+  | "!=" -> "<>"
+  | "!==" -> "!="
+  | x when (
+    potentially_conflicts_with ~keyword:"match" x
+    || potentially_conflicts_with ~keyword:"method" x
+    || potentially_conflicts_with ~keyword:"private" x
+    || potentially_conflicts_with ~keyword:"not" x) -> string_add_suffix x
+  | x when (
+    potentially_conflicts_with ~keyword:"switch_" x
+    || potentially_conflicts_with ~keyword:"pub_" x
+    || potentially_conflicts_with ~keyword:"pri_" x) -> string_drop_suffix x
+  | everything_else -> everything_else
+
+let ml_to_reason_swap = function
+  | "not" -> "!"
+  | "!" -> "^"
+  | "^" -> "++"
+  | "==" -> "==="
+  | "=" -> "=="
+  (* ===\/ and !==\/ are not representable in OCaml but
+   * representable in Reason
+   *)
+  | "!==" -> "\\!=="
+  |  "===" -> "\\==="
+  | "<>" -> "!="
+  | "!=" -> "!=="
+  | x when (
+    potentially_conflicts_with ~keyword:"match_" x
+    || potentially_conflicts_with ~keyword:"method_" x
+    || potentially_conflicts_with ~keyword:"private_" x
+    || potentially_conflicts_with ~keyword:"not_" x) -> string_drop_suffix x
+  | x when (
+    potentially_conflicts_with ~keyword:"switch" x
+    || potentially_conflicts_with ~keyword:"pub" x
+    || potentially_conflicts_with ~keyword:"pri" x) -> string_add_suffix x
+  | everything_else -> everything_else
+
+let escape_string str =
+  let buf = Buffer.create (String.length str) in
+  String.iter (fun c ->
+      match c with
+      | '\t' -> Buffer.add_string buf "\\t"
+      | '\r' -> Buffer.add_string buf "\\r"
+      | '\n' -> Buffer.add_string buf "\\n"
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '"'  -> Buffer.add_string buf "\\\""
+      | c when c < ' ' -> Buffer.add_string buf (Char.escaped c)
+      | c -> Buffer.add_char buf c
+    ) str;
+  Buffer.contents buf
+
+(* the stuff below contains side-effects and are not used by BuckleScript's
+  vendored version of reason_syntax_util.ml. So we can neglect it *)
+
+(* #if defined BS_NO_COMPILER_PATCH then *)
+
+(*
+    UTF-8 characters are encoded like this (most editors are UTF-8)
+    0xxxxxxx (length 1)
+    110xxxxx 10xxxxxx (length 2)
+    1110xxxx 10xxxxxx 10xxxxxx (length 3)
+    11110xxx 10xxxxxx 10xxxxxx 10xxxxxx (length 4)
+   Numbers over 127 cannot be encoded in UTF in a single byte, so they use two
+  bytes. That means we can use any characters between 128-255 to encode special
+  characters that would never be written by the user and thus never be confused
+  for our special formatting characters.
+*)
+(* Logic for handling special behavior that only happens if things break. We
+  use characters that will never appear in the printed output if actually
+  written in source code. The OCaml formatter will replace them with the escaped
+  versions When moving to a new formatter, the formatter may *not* escape these
+  an in that case we need the formatter to accept blacklists of characters to
+  escape, but more likely is that the new formatter allows us to do these kinds
+  of if-break logic without writing out special characters for post-processing.
+*)
+module TrailingCommaMarker = struct
+  (* TODO: You can detect failed parsings by *NOT* omitting the final comma *ever*. *)
+  (* A trailing comma will only be rendered if it is not immediately
+   * followed by a closing paren, bracket, or brace *)
+  let char = Char.chr 249 (* ˘ *)
+  let string = String.make 1 char
+end
+
+(* Special character marking the end of a line. Nothing should be printed
+ * after this marker. Example usage: // comments shouldn't have content printed
+ * at the end of the comment. By attaching an EOLMarker.string at the end of the
+ * comment our postprocessing step will ensure a linebreak at the position
+ * of the marker. *)
+module EOLMarker = struct
+  let char = Char.chr 248
+  let string = String.make 1 char
+end
+
+(** [is_prefixed prefix i str] checks if prefix is the prefix of str
+  * starting from position i
+  *)
+let is_prefixed prefix str i =
+  let len = String.length prefix in
+  let j = ref 0 in
+  while !j < len && String.unsafe_get prefix !j =
+                    String.unsafe_get str (i + !j) do
+    incr j
+  done;
+  (!j = len)
+
+(**
+ * pick_while returns a tuple where first element is longest prefix (possibly empty) of the list of elements that satisfy p
+ * and second element is the remainder of the list
+ *)
+let rec pick_while p = function
+  | [] -> [], []
+  | hd::tl when p hd ->
+                  let (satisfied, not_satisfied) = pick_while p tl in
+                  hd :: satisfied, not_satisfied
+  | l -> ([], l)
+
+
+(** [find_substring sub str i]
+    returns the smallest [j >= i] such that [sub = str.[j..length sub - 1]]
+    raises [Not_found] if there is no such j
+    behavior is not defined if [sub] is the empty string
+*)
+let find_substring sub str i =
+  let len = String.length str - String.length sub in
+  let found = ref false and i = ref i in
+  while not !found && !i <= len do
+    if is_prefixed sub str !i then
+      found := true
+    else
+      incr i;
+  done;
+  if not !found then
+    raise Not_found;
+  !i
+
+(** [replace_string old_str new_str str] replaces old_str to new_str in str *)
+let replace_string old_str new_str str =
+  match find_substring old_str str 0 with
+  | exception Not_found -> str
+  | occurrence ->
+    let buffer = Buffer.create (String.length str + 15) in
+    let rec loop i j =
+      Buffer.add_substring buffer str i (j - i);
+      Buffer.add_string buffer new_str;
+      let i = j + String.length old_str in
+      match find_substring old_str str i with
+      | j -> loop i j
+      | exception Not_found ->
+        Buffer.add_substring buffer str i (String.length str - i)
+    in
+    loop 0 occurrence;
+    Buffer.contents buffer
+
+(* This is lifted from https://github.com/bloomberg/bucklescript/blob/14d94bb9c7536b4c5f1208c8e8cc715ca002853d/jscomp/ext/ext_string.ml#L32
+  Thanks @bobzhang and @hhugo! *)
+let split_by ?(keep_empty=false) is_delim str =
+  let len = String.length str in
+  let rec loop acc last_pos pos =
+    if pos = -1 then
+      if last_pos = 0 && not keep_empty then
+        (*
+           {[ split " test_unsafe_obj_ffi_ppx.cmi" ~keep_empty:false ' ']}
+        *)
+        acc
+      else
+        String.sub str 0 last_pos :: acc
+    else
+      if is_delim str.[pos] then
+        let new_len = (last_pos - pos - 1) in
+        if new_len <> 0 || keep_empty then
+          let v = String.sub str (pos + 1) new_len in
+          loop ( v :: acc)
+            pos (pos - 1)
+        else loop acc pos (pos - 1)
+    else loop acc last_pos (pos - 1)
+  in
+  loop [] len (len - 1)
+
+let rec trim_right_idx str idx =
+  if idx = -1 then 0
+  else
+    match String.get str idx with
+    | '\t' | ' ' | '\n' | '\r' -> trim_right_idx str (idx - 1)
+    | _ -> idx + 1
+
+let trim_right str =
+  let length = String.length str in
+  if length = 0 then ""
+  else
+    let index = trim_right_idx str (length - 1) in
+    if index = 0 then ""
+    else if index = length then
+      str
+    else String.sub str 0 index
+
+
+let processLine line =
+  let rightTrimmed = trim_right line in
+  let trimmedLen = String.length rightTrimmed in
+  if trimmedLen = 0 then
+    rightTrimmed
+  else
+    let segments =
+      split_by
+        ~keep_empty:false
+        (fun c -> c = TrailingCommaMarker.char)
+        rightTrimmed in
+    (* Now we concat the portions back together without any trailing comma markers
+      - except we detect if there was a final trailing comma marker which we know
+      must be before a newline so we insert a regular comma. This achieves
+      "intelligent" trailing commas. *)
+    let hadTrailingCommaMarkerBeforeNewline =
+      String.get rightTrimmed (trimmedLen - 1) = TrailingCommaMarker.char
+    in
+    let almostEverything = String.concat "" segments in
+    let lineBuilder = if hadTrailingCommaMarkerBeforeNewline then
+      almostEverything ^ ","
+    else
+      almostEverything
+    in
+    (* Ensure EOLMarker.char is replaced by a newline *)
+    split_by ~keep_empty:false (fun c -> c = EOLMarker.char) lineBuilder
+    |> List.map trim_right
+    |> String.concat "\n"
+
+let processLineEndingsAndStarts str =
+  split_by ~keep_empty:true (fun x -> x = '\n') str
+  |> List.map processLine
+  |> String.concat "\n"
+  |> String.trim
+
+let isLineComment str =
+  (* true iff the first \n is the last character *)
+  match String.index str '\n' with
+  | exception Not_found -> false
+  | n -> n = String.length str - 1
+
+(** Generate a suitable extension node for Merlin's consumption,
+    for the purposes of reporting a syntax error - only used
+    in recovery mode.
+ *)
+let syntax_error_extension_node loc message =
+  let str = Location.mkloc "merlin.syntax-error" loc in
+  let payload = PStr [{
+    pstr_loc = Location.none;
+    pstr_desc =
+      Pstr_eval (
+        {
+          pexp_loc = Location.none;
+          pexp_desc = Pexp_constant (Parsetree.Pconst_string (message, None));
+          pexp_attributes = [];
+        },
+        []
+      );
+  }]
+ in
+ (str, payload)
+
+(** identifier_mapper maps all identifiers in an AST with a mapping function f
+  this is used by swap_operator_mapper right below, to traverse the whole AST
+  and swapping the symbols listed above.
+  *)
+let identifier_mapper f super =
+{ super with
+  expr = begin fun mapper expr ->
+    let expr =
+      match expr with
+        | {pexp_desc=Pexp_ident ({txt} as id)} ->
+             let swapped = match txt with
+               | Lident s -> Lident (f s)
+               | Ldot(longPrefix, s) -> Ldot(longPrefix, f s)
+               | Lapply (y,s) -> Lapply (y, s)
+             in
+             {expr with pexp_desc=Pexp_ident ({id with txt=swapped})}
+        | _ -> expr
+    in
+    super.expr mapper expr
+  end;
+  pat = begin fun mapper pat ->
+    let pat =
+      match pat with
+        | {ppat_desc=Ppat_var ({txt} as id)} ->
+             {pat with ppat_desc=Ppat_var ({id with txt=(f txt)})}
+        | _ -> pat
+    in
+    super.pat mapper pat
+  end;
+  signature_item = begin fun mapper signatureItem ->
+    let signatureItem =
+      match signatureItem with
+        | {psig_desc=Psig_value ({pval_name} as name)} ->
+            {signatureItem with psig_desc=Psig_value ({name with pval_name=({pval_name with txt=(f name.pval_name.txt)})})}
+        | _ -> signatureItem
+    in
+    super.signature_item mapper signatureItem
+  end;
+}
+
+let remove_stylistic_attrs_mapper_maker super =
+  let open Ast_404 in
+  let open Ast_mapper in
+{ super with
+  expr = begin fun mapper expr ->
+    let {Reason_attributes.stylisticAttrs; arityAttrs; docAttrs; stdAttrs; jsxAttrs} =
+      Reason_attributes.partitionAttributes ~allowUncurry:false expr.pexp_attributes
+    in
+    let expr = if stylisticAttrs != [] then
+      { expr with pexp_attributes = arityAttrs @ docAttrs @ stdAttrs @ jsxAttrs }
+    else expr
+    in
+    super.expr mapper expr
+  end;
+  pat = begin fun mapper pat ->
+    let {Reason_attributes.stylisticAttrs; arityAttrs; docAttrs; stdAttrs; jsxAttrs} =
+      Reason_attributes.partitionAttributes ~allowUncurry:false pat.ppat_attributes
+    in
+    let pat = if stylisticAttrs != [] then
+      { pat with ppat_attributes = arityAttrs @ docAttrs @ stdAttrs @ jsxAttrs }
+    else pat
+    in
+    super.pat mapper pat
+  end;
+}
+
+let remove_stylistic_attrs_mapper =
+  remove_stylistic_attrs_mapper_maker Ast_mapper.default_mapper
+
+(** escape_stars_slashes_mapper escapes all stars and slashes in an AST *)
+let escape_stars_slashes_mapper =
+  let escape_stars_slashes str =
+    if String.contains str '/' then
+      replace_string "/*" "/\\*" @@
+      replace_string "*/" "*\\/" @@
+      replace_string "//" "/\\/" @@
+      str
+    else
+      str
+  in
+  identifier_mapper escape_stars_slashes
+
+(* To be used in parser, transform a token into an ast node with different identifier
+ *)
+let reason_to_ml_swap_operator_mapper = identifier_mapper reason_to_ml_swap
+
+(* To be used in printer, transform an ast node into a token with different identifier
+ *)
+let ml_to_reason_swap_operator_mapper = identifier_mapper ml_to_reason_swap
+
+(* attribute_equals tests an attribute is txt
+ *)
+let attribute_equals to_compare = function
+  | ({txt}, _) -> txt = to_compare
+
+(* attribute_exists tests if an attribute exists in a list
+ *)
+let attribute_exists txt attributes = List.exists (attribute_equals txt) attributes
+
+(* conflicted_attributes tests if both attribute1 and attribute2
+ * exist
+ *)
+let attributes_conflicted attribute1 attribute2 attributes =
+  attribute_exists attribute1 attributes &&
+  attribute_exists attribute2 attributes
+
+(* normalized_attributes removes attribute from a list of attributes
+ *)
+let normalized_attributes attribute attributes =
+  List.filter (fun x -> not (attribute_equals attribute x)) attributes
+
+(* apply_mapper family applies an ast_mapper to an ast *)
+let apply_mapper_to_structure s mapper = mapper.structure mapper s
+let apply_mapper_to_signature s mapper = mapper.signature mapper s
+let apply_mapper_to_type      s mapper = mapper.typ       mapper s
+let apply_mapper_to_expr      s mapper = mapper.expr      mapper s
+let apply_mapper_to_pattern   s mapper = mapper.pat       mapper s
+
+let apply_mapper_to_toplevel_phrase toplevel_phrase mapper =
+  match toplevel_phrase with
+  | Ptop_def x -> Ptop_def (apply_mapper_to_structure x mapper)
+  | x -> x
+
+let apply_mapper_to_use_file use_file mapper =
+  List.map (fun x -> apply_mapper_to_toplevel_phrase x mapper) use_file
+
+(* The following logic defines our own Error object
+ * and register it with ocaml so it knows how to print it
+ *)
+
+type error = Syntax_error of string
+
+exception Error of Location.t * error
+
+let report_error ppf (Syntax_error err) =
+  Format.(fprintf ppf "%s" err)
+
+let () =
+  Location.register_error_of_exn
+    (function
+     | Error (loc, err) ->
+        Some (Location.error_of_printer loc report_error err)
+     | _ ->
+        None
+     )
+
+let map_first f = function
+  | [] -> invalid_arg "Syntax_util.map_first: empty list"
+  | x :: xs -> f x :: xs
+
+let map_last f l =
+  match List.rev l with
+  | [] -> invalid_arg "Syntax_util.map_last: empty list"
+  | x :: xs -> List.rev (f x :: xs)
+
+type menhirMessagesError = {
+  msg: string;
+  loc: Location.t;
+}
+
+type menhirError =
+  | NoMenhirMessagesError
+  | MenhirMessagesError of menhirMessagesError
+
+let menhirMessagesError = ref [NoMenhirMessagesError]
+
+let findMenhirErrorMessage loc =
+    let rec find messages =
+      match messages with
+      | MenhirMessagesError err :: _ when err.loc = loc -> MenhirMessagesError err
+      | _ :: tail -> find tail
+      | [] -> NoMenhirMessagesError
+    in find !menhirMessagesError
+
+let default_error_message = "<syntax error>"
+
+let add_error_message err =
+  let msg = try
+    ignore (find_substring default_error_message err.msg 0);
+    [MenhirMessagesError {err with msg = "A syntax error occurred. Help us improve this message: https://github.com/facebook/reason/blob/master/src/README.md#add-a-menhir-error-message"}]
+  with
+  | Not_found -> [MenhirMessagesError err]
+  in
+  menhirMessagesError := !menhirMessagesError @ msg
+
+let location_is_before loc1 loc2 =
+  let open Location in
+  loc1.loc_end.Lexing.pos_cnum <= loc2.loc_start.Lexing.pos_cnum
+
+let location_contains loc1 loc2 =
+  let open Location in
+  loc1.loc_start.Lexing.pos_cnum <= loc2.loc_start.Lexing.pos_cnum &&
+  loc1.loc_end.Lexing.pos_cnum >= loc2.loc_end.Lexing.pos_cnum
+
+let explode_str str =
+  let rec loop acc i =
+    if i < 0 then acc else loop (str.[i] :: acc) (i - 1)
+  in
+    loop [] (String.length str - 1)
+(* #end *)

--- a/tools/liquidity/reason/reason_syntax_util.mli
+++ b/tools/liquidity/reason/reason_syntax_util.mli
@@ -1,0 +1,115 @@
+(* Hello! Welcome to the Reason syntax util logic.
+
+  This file's shared between the Reason repo and the BuckleScript repo. In
+  Reason, it's in src/reason-parser. In BuckleScript, it's in
+  jscomp/outcome_printer. We periodically copy this file from Reason (the source
+  of truth) to BuckleScript, then uncomment the #if #else #end cppo macros you
+  see in the file. That's because BuckleScript's on OCaml 4.02 while Reason's on
+  4.04; so the #if macros surround the pieces of code that are different between
+  the two compilers.
+
+  When you modify this file, please make sure you're not dragging in too many
+  things. You don't necessarily have to test the file on both Reason and
+  BuckleScript; ping @chenglou and a few others and we'll keep them synced up by
+  patching the right parts, through the power of types(tm)
+*)
+
+val ml_to_reason_swap : string -> string
+
+val escape_string : string -> string
+
+(* Everything below is used by reason repo but not the BuckleScript repo *)
+
+(* #if defined BS_NO_COMPILER_PATCH then *)
+
+val reason_to_ml_swap : string -> string
+
+module TrailingCommaMarker : sig val char : char val string : string end
+module EOLMarker : sig val char : char val string : string end
+
+val pick_while : ('a -> bool) -> 'a list -> 'a list * 'a list
+
+val split_by : ?keep_empty:bool -> (char -> bool) -> string -> string list
+
+val processLineEndingsAndStarts : string -> string
+
+val isLineComment : string -> bool
+
+val syntax_error_extension_node :
+  Ast_404.Location.t ->
+  string -> string Ast_404.Location.loc * Ast_404.Parsetree.payload
+
+val remove_stylistic_attrs_mapper : Ast_404.Ast_mapper.mapper
+
+val escape_stars_slashes_mapper :
+  Ast_404.Ast_mapper.mapper -> Ast_404.Ast_mapper.mapper
+
+val reason_to_ml_swap_operator_mapper :
+  Ast_404.Ast_mapper.mapper -> Ast_404.Ast_mapper.mapper
+
+val ml_to_reason_swap_operator_mapper :
+  Ast_404.Ast_mapper.mapper -> Ast_404.Ast_mapper.mapper
+
+val attribute_exists : 'a -> ('a Ast_404.Asttypes.loc * 'b) list -> bool
+
+val attributes_conflicted :
+  'a -> 'a -> ('a Ast_404.Asttypes.loc * 'b) list -> bool
+
+val normalized_attributes :
+  'a ->
+  ('a Ast_404.Asttypes.loc * 'b) list -> ('a Ast_404.Asttypes.loc * 'b) list
+
+val apply_mapper_to_structure :
+  Ast_404.Parsetree.structure ->
+  Ast_404.Ast_mapper.mapper -> Ast_404.Parsetree.structure
+
+val apply_mapper_to_signature :
+  Ast_404.Parsetree.signature ->
+  Ast_404.Ast_mapper.mapper -> Ast_404.Parsetree.signature
+
+val apply_mapper_to_type :
+  Ast_404.Parsetree.core_type ->
+  Ast_404.Ast_mapper.mapper -> Ast_404.Parsetree.core_type
+
+val apply_mapper_to_expr :
+  Ast_404.Parsetree.expression ->
+  Ast_404.Ast_mapper.mapper -> Ast_404.Parsetree.expression
+
+val apply_mapper_to_pattern :
+  Ast_404.Parsetree.pattern ->
+  Ast_404.Ast_mapper.mapper -> Ast_404.Parsetree.pattern
+
+val apply_mapper_to_toplevel_phrase :
+  Ast_404.Parsetree.toplevel_phrase ->
+  Ast_404.Ast_mapper.mapper -> Ast_404.Parsetree.toplevel_phrase
+
+val apply_mapper_to_use_file :
+  Ast_404.Parsetree.toplevel_phrase list ->
+  Ast_404.Ast_mapper.mapper -> Ast_404.Parsetree.toplevel_phrase list
+
+type error = Syntax_error of string
+
+exception Error of Ast_404.Location.t * error
+
+val map_first : ('a -> 'a) -> 'a list -> 'a list
+
+val map_last : ('a -> 'a) -> 'a list -> 'a list
+
+type menhirMessagesError = { msg : string; loc : Ast_404.Location.t; }
+
+type menhirError =
+    NoMenhirMessagesError
+  | MenhirMessagesError of menhirMessagesError
+
+val findMenhirErrorMessage : Ast_404.Location.t -> menhirError
+
+val default_error_message : string
+
+val add_error_message : menhirMessagesError -> unit
+
+val location_is_before : Ast_404.Location.t -> Ast_404.Location.t -> bool
+
+val location_contains : Ast_404.Location.t -> Ast_404.Location.t -> bool
+
+val explode_str : string -> char list
+(* #end *)

--- a/tools/liquidity/reason/reason_toolchain.ml
+++ b/tools/liquidity/reason/reason_toolchain.ml
@@ -1,0 +1,975 @@
+(***********************************************************************)
+(*                                                                     *)
+(*                                Reason                               *)
+(*                                                                     *)
+(***********************************************************************)
+(*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *)
+
+
+
+(* Entry points in the parser *)
+
+(**
+ * Provides a simple interface to the most common parsing entrypoints required
+ * by editor/IDE toolchains, preprocessors, and pretty printers.
+ *
+ * The form of this entrypoint includes more than what the standard OCaml
+ * toolchain (oprof/ocamldoc) expects, but is still compatible.
+ *
+ * [implementation_with_comments] and [interface_with_comments] includes
+ * additional information (about comments) suitable for building pretty
+ * printers, editor, IDE and VCS integration.
+ *
+ * The comments include the full text of the comment (typically in between the
+ * "(*" and the "*)", as well as location information for that comment.
+ *
+ * WARNING: The "end" location is one greater than the actual final position!
+ * (for both [associatedTextLoc] and [commentLoc]).
+ *
+ * Currently, the location information for comments is of the form:
+ *
+ *  (associatedTextLoc)
+ *
+ * But we should quickly change it to be of the form:
+ *
+ *  (associatedTextLoc, commentLoc)
+ *
+ * Where the [commentLoc] is the actual original location of the comment,
+ * and the [associatedTextLoc] records the location in the file that the
+ * comment is attached to. If [associatedTextLoc] and [commentLoc] are the
+ * same, then the comment is "free floating" in that it only attaches to itself.
+ * The [Reason] pretty printer will try its best to interleave those comments
+ * in the containing list etc. But if [associatedTextLoc] expands beyond
+ * the [commentLoc] it means the comment and the AST that is captured by
+ * the [associatedTextLoc] are related - where "related" is something
+ * this [reason_toolchain] decides (but in short it handles "end of line
+ * comments"). Various pretty printers can decide how to preserve this
+ * relatedness. Ideally, it would preserve end of line comments, but in the
+ * short term, it might merely use that relatedness to correctly attach
+ * end of line comments to the "top" of the AST node.
+ *
+ *    let lst = [
+ *
+ *    ];   (*    Comment    *)
+ *         ----commentLoc-----
+ *    ---associatedTextLoc----
+ *
+ *
+ * Ideally that would be formatted as:
+ *
+ *    let lst = [
+ *
+ *    ];   (*    Comment    *)
+ *
+ * Or:
+ *
+ *    let lst = [ ];   (*    Comment    *)
+ *
+ *
+ * But a shorter term solution would use that [associatedTextLoc] to at least
+ * correctly attach the comment to the correct node, even if not "end of line".
+ *
+ *   (*    Comment    *)
+ *   let lst = [ ];
+ *)
+
+open Migrate_parsetree
+open Ast_404
+
+open Location
+open Lexing
+
+module From_current = Convert(OCaml_current)(OCaml_404)
+module To_current = Convert(OCaml_404)(OCaml_current)
+
+module S = MenhirLib.General (* Streams *)
+
+module Comment = Reason_comment
+
+let setup_lexbuf use_stdin filename =
+  (* Use custom method of lexing from the channel to keep track of the input so that we can
+     reformat tokens in the toolchain*)
+  let lexbuf =
+    match use_stdin with
+      | true -> Lexing.from_channel
+        stdin
+      | false ->
+        let file_chan = open_in filename in
+        seek_in file_chan 0;
+        Lexing.from_channel file_chan
+  in
+  Location.init lexbuf filename;
+  lexbuf
+
+
+module type Toolchain = sig
+  (* Parsing *)
+  val core_type_with_comments: Lexing.lexbuf -> (Parsetree.core_type * Reason_comment.t list)
+  val implementation_with_comments: Lexing.lexbuf -> (Parsetree.structure * Reason_comment.t list)
+  val interface_with_comments: Lexing.lexbuf -> (Parsetree.signature * Reason_comment.t list)
+
+  val core_type: Lexing.lexbuf -> Parsetree.core_type
+  val implementation: Lexing.lexbuf -> Parsetree.structure
+  val interface: Lexing.lexbuf -> Parsetree.signature
+  val toplevel_phrase: Lexing.lexbuf -> Parsetree.toplevel_phrase
+  val use_file: Lexing.lexbuf -> Parsetree.toplevel_phrase list
+
+  (* Printing *)
+  val print_interface_with_comments: Format.formatter -> (Parsetree.signature * Reason_comment.t list) -> unit
+  val print_implementation_with_comments: Format.formatter -> (Parsetree.structure * Reason_comment.t list) -> unit
+
+end
+
+module type Toolchain_spec = sig
+  val safeguard_parsing: Lexing.lexbuf ->
+    (unit -> ('a * Reason_comment.t list)) -> ('a * Reason_comment.t list)
+
+  type token
+
+  module Lexer_impl: sig
+    val init: unit -> unit
+    val token: Lexing.lexbuf -> token
+    val comments: unit -> (String.t * Location.t) list
+  end
+
+  val core_type: Lexing.lexbuf -> Parsetree.core_type
+  val implementation: Lexing.lexbuf -> Parsetree.structure
+  val interface: Lexing.lexbuf -> Parsetree.signature
+  val toplevel_phrase: Lexing.lexbuf -> Parsetree.toplevel_phrase
+  val use_file: Lexing.lexbuf -> Parsetree.toplevel_phrase list
+
+  val format_interface_with_comments: (Parsetree.signature * Reason_comment.t list) -> Format.formatter -> unit
+  val format_implementation_with_comments: (Parsetree.structure * Reason_comment.t list) -> Format.formatter -> unit
+end
+
+let rec left_expand_comment should_scan_prev_line source loc_start =
+  if loc_start = 0 then
+    (String.unsafe_get source 0, true, 0)
+  else
+    let c = String.unsafe_get source (loc_start - 1) in
+    match c with
+    | '\t' | ' ' -> left_expand_comment should_scan_prev_line source (loc_start - 1)
+    | '\n' when should_scan_prev_line -> left_expand_comment should_scan_prev_line source (loc_start - 1)
+    | '\n' -> (c, true, loc_start)
+    | _ -> (c, false, loc_start)
+
+let rec right_expand_comment should_scan_next_line source loc_start =
+  if loc_start = String.length source then
+    (String.unsafe_get source (String.length source - 1), true, String.length source)
+  else
+    let c = String.unsafe_get source loc_start in
+    match c with
+    | '\t' | ' ' -> right_expand_comment should_scan_next_line source (loc_start + 1)
+    | '\n' when should_scan_next_line -> right_expand_comment should_scan_next_line source (loc_start + 1)
+    | '\n' -> (c, true, loc_start)
+    | _ -> (c, false, loc_start)
+
+
+module Create_parse_entrypoint (Toolchain_impl: Toolchain_spec) :Toolchain = struct
+
+  let buffer_add_lexbuf buf skip lexbuf =
+    let bytes = lexbuf.Lexing.lex_buffer in
+    let start = lexbuf.Lexing.lex_start_pos + skip in
+    let stop = lexbuf.Lexing.lex_buffer_len in
+    Buffer.add_subbytes buf bytes start (stop - start)
+
+  let refill_buff buf refill lb =
+    let skip = lb.Lexing.lex_buffer_len - lb.Lexing.lex_start_pos in
+    let result = refill lb in
+    buffer_add_lexbuf buf skip lb;
+    result
+
+  (* replaces Lexing.from_channel so we can keep track of the input for comment modification *)
+  let keep_from_lexbuf buffer lexbuf =
+    buffer_add_lexbuf buffer 0 lexbuf;
+    let refill_buff = refill_buff buffer lexbuf.Lexing.refill_buff in
+    {lexbuf with refill_buff}
+
+  let wrap_with_comments parsing_fun lexbuf =
+    let input_copy = Buffer.create 0 in
+    let lexbuf = keep_from_lexbuf input_copy lexbuf in
+    Toolchain_impl.safeguard_parsing lexbuf (fun () ->
+      let _ = Toolchain_impl.Lexer_impl.init () in
+      let ast = parsing_fun lexbuf in
+      let unmodified_comments = Toolchain_impl.Lexer_impl.comments() in
+      let contents = Buffer.contents input_copy in
+      Buffer.reset input_copy;
+      if contents = "" then
+        let _  = Parsing.clear_parser() in
+        let make_regular (text, location) =
+          Comment.make ~location Comment.Regular text in
+        (ast, List.map make_regular unmodified_comments)
+      else
+        let rec classifyAndNormalizeComments unmodified_comments =
+          match unmodified_comments with
+          | [] -> []
+          | hd :: tl -> (
+              let classifiedTail = classifyAndNormalizeComments tl in
+              let (txt, physical_loc) = hd in
+              (* When searching for "^" regexp, returns location of newline + 1 *)
+              let (stop_char, eol_start, virtual_start_pos) =
+                left_expand_comment false contents physical_loc.loc_start.pos_cnum
+              in
+              if Reason_syntax_util.isLineComment txt then
+                let comment = Comment.make
+                  ~location:physical_loc
+                  (if eol_start then SingleLine else EndOfLine)
+                  txt
+                in
+                comment :: classifiedTail
+              else
+              let one_char_before_stop_char =
+                if virtual_start_pos <= 1 then
+                  ' '
+                else
+                  String.unsafe_get contents (virtual_start_pos - 2)
+              in
+              (*
+               *
+               * The following logic are designed for cases like:
+               * | (* comment *)
+               *   X => 1
+               * we want to extend the comment to the next line so it can be
+               * correctly attached to X
+               *
+               * But we don't want it to extend to next line in this case:
+               *
+               * true || (* comment *)
+               *   false
+               *
+               *)
+              let should_scan_next_line = stop_char = '|' &&
+                                          (one_char_before_stop_char = ' ' ||
+                                           one_char_before_stop_char = '\n' ||
+                                           one_char_before_stop_char = '\t' ) in
+              let (_, eol_end, virtual_end_pos) = right_expand_comment should_scan_next_line contents physical_loc.loc_end.pos_cnum in
+              let end_pos_plus_one = physical_loc.loc_end.pos_cnum in
+              let comment_length = (end_pos_plus_one - physical_loc.loc_start.pos_cnum - 4) in
+              let original_comment_contents = String.sub contents (physical_loc.loc_start.pos_cnum + 2) comment_length in
+              let location = {
+                physical_loc with
+                loc_start = {physical_loc.loc_start with pos_cnum = virtual_start_pos};
+                loc_end = {physical_loc.loc_end with pos_cnum = virtual_end_pos}
+              } in
+              let just_after loc' =
+                loc'.loc_start.pos_cnum == location.loc_end.pos_cnum - 1 &&
+                loc'.loc_start.pos_lnum == location.loc_end.pos_lnum
+              in
+              let category = match (eol_start, eol_end, classifiedTail) with
+                | (true, true, _) -> Comment.SingleLine
+                | (false, true, _) -> Comment.EndOfLine
+                | (false, false, comment :: _)
+                  (* End of line comment is one that has nothing but newlines or
+                   * other comments its right, and has some AST to the left of it.
+                   * For example, there are two end of line comments in:
+                   *
+                   *    | Y(int, int); /* eol1 */ /* eol2 */
+                   *)
+                  when Comment.category comment = Comment.EndOfLine
+                    && just_after (Comment.location comment) ->
+                  Comment.EndOfLine
+                | _ -> Comment.Regular
+              in
+              let comment =
+                Comment.make ~location category original_comment_contents
+              in
+              comment :: classifiedTail
+            )
+        in
+        let modified_and_comment_with_category = classifyAndNormalizeComments unmodified_comments in
+        let _  = Parsing.clear_parser() in
+        (ast, modified_and_comment_with_category)
+    )
+
+  let invalidLex = "invalidCharacter.orComment.orString"
+
+  (*
+   * The canonical interface/implementations (with comments) are used with
+   * recovering mode for IDE integration. The parser itself likely
+   * implements its own recovery, but we need to recover in the event
+   * that the file couldn't even lex.
+   * Note, the location reported here is broken for some lexing errors
+   * (nested comments or unbalanced strings in comments) but at least we don't
+   * crash the process. TODO: Report more accurate location in those cases.
+   *)
+  let implementation_with_comments lexbuf =
+    try wrap_with_comments Toolchain_impl.implementation lexbuf
+    with err when !Reason_config.recoverable ->
+      let loc, msg = match err with
+        | Location.Error err -> (err.loc, err.msg)
+        | _ ->
+          let loc = Location.curr lexbuf in
+          match Reason_syntax_util.findMenhirErrorMessage loc with
+          | Reason_syntax_util.MenhirMessagesError errMessage ->
+            (errMessage.Reason_syntax_util.loc, errMessage.Reason_syntax_util.msg)
+          | _ -> (loc, invalidLex)
+      in
+      let error = Reason_syntax_util.syntax_error_extension_node loc msg in
+      ([Ast_helper.Str.mk ~loc (Parsetree.Pstr_extension (error, []))], [])
+
+  let core_type_with_comments lexbuf =
+    try wrap_with_comments Toolchain_impl.core_type lexbuf
+    with err when !Reason_config.recoverable ->
+      let loc, msg = match err with
+        | Location.Error err -> (err.loc, err.msg)
+        | _ -> (Location.curr lexbuf, invalidLex)
+      in
+      let error = Reason_syntax_util.syntax_error_extension_node loc msg in
+      (Ast_helper.Typ.mk ~loc (Parsetree.Ptyp_extension error), [])
+
+  let interface_with_comments lexbuf =
+    try wrap_with_comments Toolchain_impl.interface lexbuf
+    with err when !Reason_config.recoverable ->
+      let loc, msg = match err with
+        | Location.Error err -> (err.loc, err.msg)
+        | _ -> (Location.curr lexbuf, invalidLex)
+      in
+      let error = Reason_syntax_util.syntax_error_extension_node loc msg in
+      ([Ast_helper.Sig.mk ~loc (Parsetree.Psig_extension (error, []))], [])
+
+  let toplevel_phrase_with_comments lexbuf =
+    wrap_with_comments Toolchain_impl.toplevel_phrase lexbuf
+
+  let use_file_with_comments lexbuf =
+    wrap_with_comments Toolchain_impl.use_file lexbuf
+
+  (** [ast_only] wraps a function to return only the ast component
+   *)
+  let ast_only f =
+    (fun lexbuf -> lexbuf |> f |> fst)
+
+  let implementation = ast_only implementation_with_comments
+
+  let core_type = ast_only core_type_with_comments
+
+  let interface = ast_only interface_with_comments
+
+  let toplevel_phrase = ast_only toplevel_phrase_with_comments
+
+  let use_file = ast_only use_file_with_comments
+
+  (* Printing *)
+  let print_interface_with_comments formatter interface =
+    Toolchain_impl.format_interface_with_comments interface formatter
+
+  let print_implementation_with_comments formatter implementation =
+    Toolchain_impl.format_implementation_with_comments implementation formatter
+end
+
+module OCaml_syntax = struct
+  (* The OCaml parser keep doc strings in the comment list.
+     To avoid duplicating comments, we need to filter comments that appear
+     as doc strings is the AST out of the comment list. *)
+  let doc_comments_filter () =
+    let open Ast_mapper in
+    let open Parsetree in
+    let seen = Hashtbl.create 7 in
+    let attribute mapper = function
+      | ({ Location. txt = ("ocaml.doc" | "ocaml.text")},
+        PStr [{ pstr_desc = Pstr_eval ({ pexp_desc = Pexp_constant (Pconst_string(_text, None)) } , _);
+                pstr_loc = loc }]) as attribute ->
+        (* Workaround: OCaml 4.02.3 kept an initial '*' in docstrings.
+         * For other versions, we have to put the '*' back. *)
+        Hashtbl.add seen loc ();
+        default_mapper.attribute mapper attribute
+      | attribute -> default_mapper.attribute mapper attribute
+    in
+    let mapper = {default_mapper with attribute} in
+    let filter (_text, loc) = not (Hashtbl.mem seen loc) in
+    (mapper, filter)
+
+  module Lexer_impl = struct
+    let init = Lexer.init
+    let token = Lexer.token
+
+    let filtered_comments = ref []
+    let filter_comments filter =
+      filtered_comments := List.filter filter (Lexer.comments ())
+    let comments () = !filtered_comments
+  end
+  module OCaml_parser = Parser
+  type token = OCaml_parser.token
+
+  (* OCaml parser parses into compiler-libs version of Ast.
+     Parsetrees are converted to Reason version on the fly. *)
+
+  let parse_and_filter_doc_comments iter fn lexbuf=
+    let it, filter = doc_comments_filter () in
+    let result = fn lexbuf in
+    ignore (iter it result);
+    Lexer_impl.filter_comments filter;
+    result
+
+
+  let implementation lexbuf =
+    parse_and_filter_doc_comments
+      (fun it -> it.Ast_mapper.structure it)
+      (fun lexbuf -> From_current.copy_structure
+                       (Parser.implementation Lexer.token lexbuf))
+      lexbuf
+
+  let core_type lexbuf =
+    parse_and_filter_doc_comments
+      (fun it -> it.Ast_mapper.typ it)
+      (fun lexbuf -> From_current.copy_core_type
+                       (Parser.parse_core_type Lexer.token lexbuf))
+      lexbuf
+
+  let interface lexbuf =
+    parse_and_filter_doc_comments
+      (fun it -> it.Ast_mapper.signature it)
+      (fun lexbuf -> From_current.copy_signature
+                       (Parser.interface Lexer.token lexbuf))
+      lexbuf
+
+  let filter_toplevel_phrase it = function
+    | Parsetree.Ptop_def str -> ignore (it.Ast_mapper.structure it str)
+    | Parsetree.Ptop_dir _ -> ()
+
+  let toplevel_phrase lexbuf =
+    parse_and_filter_doc_comments
+      filter_toplevel_phrase
+      (fun lexbuf -> From_current.copy_toplevel_phrase
+          (Parser.toplevel_phrase Lexer.token lexbuf))
+      lexbuf
+
+  let use_file lexbuf =
+    parse_and_filter_doc_comments
+      (fun it result -> List.map (filter_toplevel_phrase it) result)
+      (fun lexbuf ->
+        List.map
+          From_current.copy_toplevel_phrase
+          (Parser.use_file Lexer.token lexbuf))
+      lexbuf
+
+  (* Skip tokens to the end of the phrase *)
+  (* TODO: consolidate these copy-paste skip/trys into something that works for
+   * every syntax (also see [Reason_syntax_util]). *)
+  let rec skip_phrase lexbuf =
+    try
+      match Lexer.token lexbuf with
+        OCaml_parser.SEMISEMI | OCaml_parser.EOF -> ()
+      | _ -> skip_phrase lexbuf
+    with
+      | Lexer.Error (Lexer.Unterminated_comment _, _)
+      | Lexer.Error (Lexer.Unterminated_string, _)
+      | Lexer.Error (Lexer.Unterminated_string_in_comment _, _)
+      | Lexer.Error (Lexer.Illegal_character _, _) ->
+          skip_phrase lexbuf
+
+  let maybe_skip_phrase lexbuf =
+    if Parsing.is_current_lookahead OCaml_parser.SEMISEMI
+    || Parsing.is_current_lookahead OCaml_parser.EOF
+    then ()
+    else skip_phrase lexbuf
+
+  let safeguard_parsing lexbuf fn =
+    try fn ()
+    with
+    | Lexer.Error(Lexer.Illegal_character _, _) as err
+      when !Location.input_name = "//toplevel//"->
+        skip_phrase lexbuf;
+        raise err
+    | Syntaxerr.Error _ as err
+      when !Location.input_name = "//toplevel//" ->
+        maybe_skip_phrase lexbuf;
+        raise err
+    (* Escape error is raised as a general catchall when a syntax_error() is
+       thrown in the parser.
+     *)
+    | Parsing.Parse_error | Syntaxerr.Escape_error ->
+        let loc = Location.curr lexbuf in
+        if !Location.input_name = "//toplevel//"
+        then maybe_skip_phrase lexbuf;
+        raise(Syntaxerr.Error(Syntaxerr.Other loc))
+
+  (* Unfortunately we drop the comments because there doesn't exist an ML
+   * printer that formats comments *and* line wrapping! (yet) *)
+  let format_interface_with_comments (signature, _) formatter =
+    Pprintast.signature formatter
+      (To_current.copy_signature signature)
+  let format_implementation_with_comments (structure, _) formatter =
+    let structure =
+      Reason_syntax_util.(apply_mapper_to_structure structure remove_stylistic_attrs_mapper)
+    in
+    Pprintast.structure formatter
+      (To_current.copy_structure structure)
+end
+
+let insert_completion_ident : Lexing.position option ref = ref None
+
+module Reason_syntax = struct
+  module I = Reason_parser.MenhirInterpreter
+  module Lexer_impl = struct
+    include Reason_lexer
+    let init () = init ?insert_completion_ident:!insert_completion_ident ()
+  end
+  type token = Reason_parser.token
+
+  (* [tracking_supplier] is a supplier that tracks the last token read *)
+  type tracking_supplier = {
+    (* The last token that was obtained from the lexer, together with its start
+       and end positions. Warning: before the first call to the lexer has taken
+       place, a None value is stored here. *)
+
+    mutable last_token: (token * Lexing.position * Lexing.position) option;
+
+    (* A supplier function that returns one token at a time*)
+    get_token: unit -> (token * Lexing.position * Lexing.position)
+  }
+
+  (* [lexbuf_to_supplier] returns a supplier to be feed into Menhir's incremental API.
+   * Each time the supplier is called, a new token in the lexbuf is returned.
+   * If the supplier is called after an EOF is already returned, a syntax error will be raised.
+   *
+   * This makes sure at most one EOF token is returned by supplier, which
+   * is the default behavior of ocamlyacc.
+  *)
+  let lexbuf_to_supplier lexbuf =
+    let s = I.lexer_lexbuf_to_supplier Reason_lexer.token lexbuf in
+    let eof_met = ref false in
+    let get_token = fun () ->
+      let (token, s, e) = s () in
+      if token = Reason_parser.EOF then
+        if not !eof_met then
+          let _ = eof_met := true in
+          (token, s, e)
+        else
+          raise(Syntaxerr.Error(Syntaxerr.Other (Location.curr lexbuf)))
+      else
+        (token, s, e)
+    in
+    let last_token = None in
+    {last_token; get_token}
+
+  let read supplier =
+    let t = supplier.get_token () in
+    supplier.last_token <- Some t;
+    t
+
+  let last_token supplier =
+    match supplier.last_token with
+    | Some (t, _, _) -> t
+    | None -> assert false
+
+  (* read last token's location from a supplier *)
+  let last_token_loc supplier =
+    match supplier.last_token with
+    | Some (_, s, e) ->
+      {
+        loc_start = s;
+        loc_end = e;
+        loc_ghost = false;
+      }
+    | None -> assert false
+
+  (* get the stack of a checkpoint *)
+  let stack checkpoint =
+    match checkpoint with
+    | I.HandlingError env ->
+      I.stack env
+    | _ ->
+      assert false
+
+  (* get state number of a checkpoint *)
+  let state checkpoint : int =
+    match Lazy.force (stack checkpoint) with
+    | S.Nil ->
+      0
+    | S.Cons (I.Element (s, _, _, _), _) ->
+      I.number s
+
+  (* [loop_handle_yacc] mimic yacc's error handling mechanism in menhir.
+     When it hits an error state, it pops up the stack until it finds a
+     state when the error can be shifted or reduced.
+
+     This is similar to Menhir's default behavior for error handling, with
+     one subtle difference:
+     When loop_handle_yacc recovers from the error, unlike Menhir, it doesn't
+     discard the input token immediately. Instead, it restarts the parsing
+     from recovered state with the original lookahead token that caused the
+     error. If there is still an error, the look ahead token is then discarded.
+
+     yacc's behavior gives us a chance to recover the following code :
+     ```
+     {
+       let a = 1;
+       Js.
+     }
+     ```
+     , where "}" is the lookahead token that triggers an error state. With
+     yacc's behavior, "}" will still be shifted once we recover from "Js.",
+     giving the parser the ability to reduce the whole program to a sequence
+     expression.
+  *)
+
+  let rec normalize_checkpoint = function
+    | I.Shifting _ | I.AboutToReduce _ as checkpoint ->
+      normalize_checkpoint (I.resume checkpoint)
+    | checkpoint -> checkpoint
+
+  (* Simply submit a token to the parser *)
+  let offer_normalize checkpoint triple =
+    normalize_checkpoint (I.offer checkpoint triple)
+
+  let offer_normalize_many checkpoint triples =
+    let rec loop acc xs = match xs with
+    | [] -> Some acc
+    | triple :: xs ->
+      begin match normalize_checkpoint (I.offer acc triple) with
+      | I.InputNeeded _ as checkpoint' -> loop checkpoint' xs
+      | _ -> None
+      end
+    in
+    loop checkpoint triples
+
+  (* Insert a semicolon before submitting a token to the parser *)
+  let try_inserting_semi_on = function
+    | Reason_parser.LET
+    | Reason_parser.TYPE
+    | Reason_parser.MODULE
+    | Reason_parser.OPEN
+    | Reason_parser.EXCEPTION
+    | Reason_parser.INCLUDE
+    | Reason_parser.DOCSTRING _
+    | Reason_parser.LIDENT _
+    | Reason_parser.UIDENT _
+    | Reason_parser.IF
+    | Reason_parser.WHILE
+    | Reason_parser.FOR
+    | Reason_parser.SWITCH
+    | Reason_parser.TRY
+    | Reason_parser.ASSERT
+    | Reason_parser.LAZY
+    | Reason_parser.LBRACKETAT -> true
+    | _ -> false
+
+  let try_inserting_semi checkpoint ((_, pos, _) as triple) =
+    match offer_normalize checkpoint (Reason_parser.SEMI, pos, pos) with
+    | I.InputNeeded _ as checkpoint' ->
+      Some (offer_normalize checkpoint' triple)
+    | _ -> None
+
+  let try_inserting_label_on = function
+    | Reason_parser.INFIXOP0 s when s.[0] == '=' ->
+        let is_optional = String.length s > 1 && s.[1] == '?' in
+        let idx = if is_optional then 2 else 1 in
+        let operator = String.sub s idx (String.length s - idx) in
+        let token = match operator with
+        | "-" -> Some Reason_parser.MINUS
+        | "-." -> Some Reason_parser.MINUSDOT
+        | "+" -> Some Reason_parser.PLUS
+        | "+." -> Some Reason_parser.PLUSDOT
+        | "!" -> Some Reason_parser.BANG
+        | _ -> None
+        in
+        token, is_optional
+    | _ -> None, false
+
+  let try_inserting_equal_unary checkpoint (_, pos, _) ~optional token =
+    match offer_normalize checkpoint (Reason_parser.EQUAL, pos, pos) with
+    | I.InputNeeded _ as checkpoint' ->
+        if optional then
+          match offer_normalize checkpoint' (Reason_parser.QUESTION, pos, pos) with
+          | I.InputNeeded _ as checkpoint'' ->
+            Some (offer_normalize checkpoint'' (token, pos, pos))
+          | _ -> None
+        else
+          Some (offer_normalize checkpoint' (token, pos, pos))
+    | _ -> None
+
+  let try_inserting_postfix checkpoint infix ((_, pos, _) as triple) =
+    (* we know that the infix was exclusively composed of '^' *)
+    let rec mk_postfixes acc i =
+      if i < 0 then
+        acc
+      else
+        let triple = (Reason_parser.POSTFIXOP "^", pos, pos) in
+        mk_postfixes (triple :: acc) (i - 1)
+    in
+    let infixes = mk_postfixes [] (String.length infix - 1) in
+    match offer_normalize_many checkpoint infixes with
+    | Some (I.InputNeeded _ as checkpoint') ->
+        Some (offer_normalize checkpoint' triple)
+    | _ -> None
+
+  (* Offer and insert a semicolon in case of failure *)
+  let offer_normalize checkpoint triple =
+    match offer_normalize checkpoint triple with
+    | I.HandlingError _ as error_checkpoint ->
+      (* About to enter error state:
+         if the token is the beginning of an item (LET, TYPE, ...), try
+         inserting a SEMICOLON, otherwise return the checkpoint to the caller.
+      *)
+      let (token, _, _) = triple in
+      if try_inserting_semi_on token then
+        match try_inserting_semi checkpoint triple with
+          | Some (I.InputNeeded _ as checkpoint') -> checkpoint'
+          | Some _ | None -> error_checkpoint
+      else begin match try_inserting_label_on token with
+        | Some tokn, optional ->
+          begin match try_inserting_equal_unary ~optional checkpoint triple tokn with
+            | Some (I.InputNeeded _ as checkpoint') -> checkpoint'
+            | Some _ | None -> error_checkpoint
+          end
+        | None, _ -> error_checkpoint
+      end
+    | checkpoint -> checkpoint
+
+  let commit_invalid_docstrings = function
+    | [] -> ()
+    | docstrings ->
+      let process_invalid_docstring (text, loc) = Reason_lexer.add_invalid_docstring text loc in
+      List.iter process_invalid_docstring (List.rev docstrings)
+
+  let custom_error supplier env =
+    let loc = last_token_loc supplier in
+    let token = match supplier.last_token with
+      | Some token -> token
+      | None -> assert false
+    in
+    let state = I.current_state_number env in
+    (* Check the error database to see what's the error message
+    associated with the current parser state  *)
+    let msg = Reason_syntax_util.default_error_message
+        (* Reason_parser_explain.message env token  *)
+    in
+    let msg_with_state = Printf.sprintf "%d: %s" state msg in
+    raise (Reason_syntax_util.Error (loc, (Reason_syntax_util.Syntax_error msg_with_state)))
+
+  let rec handle_other supplier checkpoint =
+    match checkpoint with
+    | I.InputNeeded env ->
+      (* An input needed in the "other" case means we are recovering from an error *)
+      begin match supplier.last_token with
+        | None -> assert false
+        | Some triple ->
+          (* We just recovered from the error state, try the original token again *)
+          let checkpoint_with_previous_token = I.offer checkpoint triple in
+          let checkpoint = try match I.shifts checkpoint_with_previous_token with
+            | None -> checkpoint
+              (* The original token still fail to be parsed, discard *)
+            | Some _ -> normalize_checkpoint checkpoint_with_previous_token
+          with
+          | Syntaxerr.Error _ as exn -> raise exn
+          | Syntaxerr.Escape_error -> custom_error supplier env
+          in
+          handle_inputs_needed supplier [([], checkpoint)]
+      end
+
+    | I.HandlingError env when !Reason_config.recoverable ->
+      let loc = last_token_loc supplier in
+      begin match Reason_syntax_util.findMenhirErrorMessage loc with
+        | Reason_syntax_util.MenhirMessagesError _ -> ()
+        | Reason_syntax_util.NoMenhirMessagesError ->
+          let token = match supplier.last_token with
+            | Some token -> token
+            | None -> assert false
+          in
+          let msg =
+            Reason_syntax_util.default_error_message
+            (* Reason_parser_explain.message env token *)
+          in
+          Reason_syntax_util.add_error_message Reason_syntax_util.{loc = loc; msg = msg};
+      end;
+      let checkpoint = I.resume checkpoint in
+      (* Enter error recovery state *)
+      handle_other supplier checkpoint
+
+    | I.HandlingError env as error_checkpoint ->
+      (* If not in a recoverable state, resume just enough to be able to
+       * catch a nice error message above. *)
+      let token = last_token supplier in
+      if Hashtbl.mem Reason_lexer.reverse_keyword_table token then
+        custom_error supplier env
+      else
+        let cp = I.resume error_checkpoint in
+        handle_other supplier (normalize_checkpoint cp)
+    | I.Rejected ->
+      let loc = last_token_loc supplier in
+      raise Syntaxerr.(Error(Syntaxerr.Other loc))
+
+    | I.Accepted v ->
+      (* The parser has succeeded and produced a semantic value. *)
+      v
+
+    | I.Shifting _ | I.AboutToReduce _ ->
+      handle_other supplier (normalize_checkpoint checkpoint)
+
+  and handle_inputs_needed supplier checkpoints =
+    match read supplier with
+    (* ES6_FUN token marks a possible fork point *)
+    | Reason_parser.ES6_FUN, _, _ as triple ->
+      let process_checkpoint (invalid_docstrings, checkpoint as x) tl =
+        match offer_normalize checkpoint triple with
+        | I.HandlingError _ -> x :: tl
+        | checkpoint' -> x :: (invalid_docstrings, checkpoint') :: tl
+      in
+      handle_inputs_needed supplier (List.fold_right process_checkpoint checkpoints [])
+
+    | Reason_parser.DOCSTRING text, loc_start, loc_end as triple ->
+      let process_checkpoint (invalid_docstrings, checkpoint) =
+        match offer_normalize checkpoint triple with
+        | I.HandlingError _ ->
+          (* DOCSTRING at an invalid position: store it and add it back to
+           * comments if this checkpoint is "committed"
+           * TODO: print warning? *)
+          let invalid_docstring = (text, { Location. loc_ghost = false; loc_start; loc_end }) in
+          (invalid_docstring :: invalid_docstrings, checkpoint)
+        | checkpoint' -> (invalid_docstrings, checkpoint')
+      in
+      handle_inputs_needed supplier (List.map process_checkpoint checkpoints)
+
+    (*
+     * This catches the `foo^^` case (which the parser thinks is an error – infix
+     * without 2nd operand) and inserts as many postfix ops as there are carets
+     * in the operator. We catch the token here and don't actually fork checkpoints
+     * because catching this in `handle_other` would be too late – we would only
+     * see the token where the error was (e.g. semicolon).
+     *)
+    | Reason_parser.INFIXOP1 op, _, _ as triple
+      when List.for_all (fun x -> x == '^') (Reason_syntax_util.explode_str op) ->
+      let rec process_checkpoints inputs_needed checkpoints =
+        match checkpoints with
+        | [] -> handle_inputs_needed supplier inputs_needed
+        | (invalid_docstrings, checkpoint) :: tl ->
+          begin match offer_normalize checkpoint triple with
+          | I.InputNeeded _ as checkpoint' ->
+            let next_triple = read supplier in
+            begin match offer_normalize checkpoint' next_triple with
+            | I.HandlingError _ ->
+              begin match try_inserting_postfix checkpoint op next_triple with
+              | Some (I.Accepted _ as cp) -> handle_other supplier cp
+              | Some cp ->
+                process_checkpoints ((invalid_docstrings, cp) :: inputs_needed) tl
+              | None ->
+                process_checkpoints ((invalid_docstrings, checkpoint') :: inputs_needed) tl
+              end
+            | checkpoint'' ->
+              process_checkpoints ((invalid_docstrings, checkpoint'') :: inputs_needed) tl
+            end
+          | checkpoint' ->
+              process_checkpoints ((invalid_docstrings, checkpoint') :: inputs_needed) tl
+          end
+      in
+      process_checkpoints [] checkpoints
+
+    | triple ->
+      begin match checkpoints with
+        | [] -> assert false
+        | [docstrings, checkpoint] ->
+          begin match offer_normalize checkpoint triple with
+            | I.InputNeeded _ as checkpoint' ->
+              handle_inputs_needed supplier [docstrings, checkpoint']
+            | checkpoint ->
+              commit_invalid_docstrings docstrings;
+              handle_other supplier checkpoint
+          end
+        | checkpoints ->
+          let rec process_checkpoints inputs_needed others = function
+            |  (docstrings, checkpoint) :: xs ->
+              begin match offer_normalize checkpoint triple with
+                | I.Accepted _ as other ->
+                  commit_invalid_docstrings docstrings;
+                  handle_other supplier other
+                | I.InputNeeded _ as checkpoint' ->
+                  process_checkpoints ((docstrings, checkpoint') :: inputs_needed) others xs
+                | other -> process_checkpoints inputs_needed ((docstrings, other) :: others) xs
+              end
+            | [] ->
+              match List.rev inputs_needed with
+              | [] ->
+                begin match List.rev others with
+                  | (docstrings, checkpoint) :: _ ->
+                    commit_invalid_docstrings docstrings;
+                    handle_other supplier checkpoint
+                  | [] -> assert false
+                end
+              | inputs_needed -> handle_inputs_needed supplier inputs_needed
+          in
+          process_checkpoints [] [] checkpoints
+      end
+
+  let initial_run constructor lexbuf =
+    let checkpoint = constructor lexbuf.lex_curr_p in
+    let supplier = lexbuf_to_supplier lexbuf in
+    match normalize_checkpoint checkpoint with
+    | I.InputNeeded _ as checkpoint ->
+      handle_inputs_needed supplier [[], checkpoint]
+    | other -> handle_other supplier other
+
+  let implementation lexbuf =
+    initial_run Reason_parser.Incremental.implementation lexbuf
+
+  let interface lexbuf =
+    initial_run Reason_parser.Incremental.interface lexbuf
+
+  let core_type lexbuf =
+    initial_run Reason_parser.Incremental.parse_core_type lexbuf
+
+  let toplevel_phrase lexbuf =
+    initial_run Reason_parser.Incremental.toplevel_phrase lexbuf
+
+  let use_file lexbuf =
+    initial_run Reason_parser.Incremental.use_file lexbuf
+
+  (* Skip tokens to the end of the phrase *)
+  let rec skip_phrase lexbuf =
+    try
+      match Lexer_impl.token lexbuf with
+        Reason_parser.SEMI | Reason_parser.EOF -> ()
+      | _ -> skip_phrase lexbuf
+    with
+    | Lexer_impl.Error (Lexer_impl.Unterminated_comment _, _)
+    | Lexer_impl.Error (Lexer_impl.Unterminated_string, _)
+    | Lexer_impl.Error (Lexer_impl.Unterminated_string_in_comment _, _)
+    | Lexer_impl.Error (Lexer_impl.Illegal_character _, _) -> skip_phrase lexbuf
+
+  let maybe_skip_phrase lexbuf =
+    if Parsing.is_current_lookahead Reason_parser.SEMI
+    || Parsing.is_current_lookahead Reason_parser.EOF
+    then ()
+    else skip_phrase lexbuf
+
+  let safeguard_parsing lexbuf fn =
+    try fn ()
+    with
+    | Lexer_impl.Error(Lexer_impl.Illegal_character _, _) as err
+      when !Location.input_name = "//toplevel//"->
+      skip_phrase lexbuf;
+      raise err
+    | Syntaxerr.Error _ as err
+      when !Location.input_name = "//toplevel//" ->
+      maybe_skip_phrase lexbuf;
+      raise err
+    | Parsing.Parse_error | Syntaxerr.Escape_error ->
+      let loc = Location.curr lexbuf in
+      if !Location.input_name = "//toplevel//"
+      then maybe_skip_phrase lexbuf;
+      raise(Syntaxerr.Error(Syntaxerr.Other loc))
+    | Error _ as x ->
+      let loc = Location.curr lexbuf in
+      if !Location.input_name = "//toplevel//"
+      then
+        let _ = maybe_skip_phrase lexbuf in
+        raise(Syntaxerr.Error(Syntaxerr.Other loc))
+      else
+        raise x
+    | x -> raise x
+
+  let format_interface_with_comments (signature, comments) formatter =
+    let reason_formatter = Reason_pprint_ast.createFormatter () in
+    reason_formatter#signature comments formatter signature
+
+  let format_implementation_with_comments (implementation, comments) formatter =
+    let reason_formatter = Reason_pprint_ast.createFormatter () in
+    reason_formatter#structure comments formatter implementation
+end
+
+module ML = Create_parse_entrypoint (OCaml_syntax)
+module RE = Create_parse_entrypoint (Reason_syntax)


### PR DESCRIPTION
New option `--re` will tell the compiler to use a ReasonML parser.
* Support for 12tz, 12.3tz
* No support for other liquidity OCaml extensions (TODO)