### PR TITLE
Generate contracts whose parameter is compatible with future Michelson

### DIFF
--- a/tools/liquidity/liquidDeploy.ml
+++ b/tools/liquidity/liquidDeploy.ml
@@ -812,7 +812,7 @@ let run ~debug liquid entry_name input_string storage_string =
   let parameter = match contract_sig.f_entries_sig with
     | [_] -> input
     | _ -> LiquidEncode.encode_const contract.ty_env contract_sig
-             (CConstr (prefix_entry ^ entry_name,
+             (CConstr (entry_name,
                        (LiquidDecode.decode_const input))) in
   let storage =
     LiquidData.translate { contract.ty_env with filename = "run_storage" }
@@ -1155,7 +1155,7 @@ let forge_call ?head ?source ?public_key
   let parameter = match contract_sig.f_entries_sig with
     | [_] -> input
     | _ -> LiquidEncode.encode_const contract.ty_env contract_sig
-             (CConstr (prefix_entry ^ entry_name,
+             (CConstr (entry_name,
                        (LiquidDecode.decode_const input))) in
   let _, loc_table =
     LiquidToTezos.convert_contract ~expand:true pre_michelson in
@@ -1474,7 +1474,7 @@ let forge_call_arg ?(entry_name="main") liquid input_string =
   let parameter = match contract_sig.f_entries_sig with
     | [_] -> input
     | _ -> LiquidEncode.encode_const contract.ty_env contract_sig
-             (CConstr (prefix_entry ^ entry_name,
+             (CConstr (entry_name,
                        (LiquidDecode.decode_const input))) in
   let param_m = LiquidMichelson.compile_const parameter in
   LiquidToTezos.(string_of_const @@ convert_const ~expand:false param_m)

--- a/tools/liquidity/liquidEncode.ml
+++ b/tools/liquidity/liquidEncode.ml
@@ -302,7 +302,7 @@ and encode_contract_sig csig =
   | entries ->
     Tsum ("_entries",
           List.map (fun { entry_name; parameter = t } ->
-              (prefix_entry ^ entry_name, t)
+              (entry_name, t)
             ) entries)
 
 and get_lambda_type ~decompiling args = function
@@ -687,7 +687,7 @@ and encode env ( exp : typed_exp ) : encoded_exp =
             | _ -> false
           -> arg
         | Some entry ->
-          let constr = prefix_entry ^ entry in
+          let constr = entry in
           let rec iter entries =
             match entries with
             | [] -> assert false
@@ -700,7 +700,7 @@ and encode env ( exp : typed_exp ) : encoded_exp =
                 | [ e ] -> e.parameter
                 | _ ->
                   let cstrs =
-                    List.map (fun e -> prefix_entry ^ e.entry_name, e.parameter)
+                    List.map (fun e -> e.entry_name, e.parameter)
                       entries in
                   Tsum ("", cstrs)
               in
@@ -1468,7 +1468,7 @@ and encode_contract ?(annot=false) ?(decompiling=false) contract =
     | _ ->
       let parameter = mk_typed ~loc (Var "parameter") parameter in
       let ecstrs = List.mapi (fun i e ->
-          let constr = prefix_entry ^ e.entry_sig.entry_name in
+          let constr = e.entry_sig.entry_name in
           env.env.constrs <- StringMap.add constr ("_entries", i) env.env.constrs;
           constr, e.entry_sig.parameter
         ) contract.entries in
@@ -1477,7 +1477,7 @@ and encode_contract ?(annot=false) ?(decompiling=false) contract =
       MatchVariant {
         arg = parameter;
         cases = List.mapi (fun i e ->
-            let constr = prefix_entry ^ e.entry_sig.entry_name in
+            let constr = e.entry_sig.entry_name in
             let pat =
               PConstr (constr, [e.entry_sig.parameter_name]) in
             let body =

--- a/tools/liquidity/liquidFromParsetree.ml
+++ b/tools/liquidity/liquidFromParsetree.ml
@@ -48,7 +48,7 @@ let ident_counter = ref 0
 let minimal_version = 0.9
 
 (* The maximal version of liquidity files that are accepted by this compiler *)
-let maximal_version = 1.042
+let maximal_version = 1.043
 
 
 open Asttypes

--- a/tools/liquidity/liquidInterp.ml
+++ b/tools/liquidity/liquidInterp.ml
@@ -241,7 +241,7 @@ let rec constrlabel_is_in_type c = function
     List.exists (fun (_, t) -> constrlabel_is_in_type c t) l
   | Tcontract s ->
     List.exists (fun e ->
-        c = prefix_entry ^ e.entry_name ||
+        c = e.entry_name ||
         constrlabel_is_in_type c e.parameter)
       s.entries_sig
   | Tvar { contents = { contents = { tyo = Some ty }}} ->

--- a/tools/liquidity/liquidMain.ml
+++ b/tools/liquidity/liquidMain.ml
@@ -369,7 +369,7 @@ let translate () =
   let parameter_const = match contract_sig.f_entries_sig with
     | [_] -> input
     | _ -> LiquidEncode.encode_const contract.ty_env contract_sig
-             (CConstr (prefix_entry ^ entry_name,
+             (CConstr (entry_name,
                        (LiquidDecode.decode_const input))) in
   let to_str mic_data =
     let mic_data = LiquidMichelson.compile_const mic_data in

--- a/tools/liquidity/liquidToParsetree.ml
+++ b/tools/liquidity/liquidToParsetree.ml
@@ -22,7 +22,7 @@
 (****************************************************************************)
 
 (* The version that will be required to compile the generated files. *)
-let output_version = "1.042"
+let output_version = "1.043"
 
 open Asttypes
 open Longident

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -1658,15 +1658,26 @@ let has_reserved_prefix s =
   | _ -> false
 
 (** Prefix for constructor used to encode entry point names *)
-let prefix_entry = "_Liq_entry_"
+let prefixes_entry = ["_Liq_entry_"]
 
 (** Prefix for constructor used to encode contracts *)
 let prefix_contract = "_Liq_contract_"
 
 let entry_name_of_case s =
-  Scanf.sscanf s
-    (Scanf.format_from_string prefix_entry "" ^^ "%s%!")
-    (fun x -> x)
+  let rec iter = function
+    | [] -> raise Not_found
+    | prefix_entry :: prefixes ->
+       try
+         Scanf.sscanf s
+           (Scanf.format_from_string prefix_entry "" ^^ "%s%!")
+           (fun x -> x)
+       with _ -> iter prefixes in
+  try iter prefixes_entry
+  with _ ->
+        if String.length s = 0 then raise Not_found
+        else match s.[0] with
+             | '_' | 'a' .. 'z' -> s
+             | _ -> raise Not_found
 
 let is_entry_case s =
   try


### PR DESCRIPTION
Contracts generated with version 1.043 will be callable with entry points, from contracts in the future version of Michelson.

Now, option `--no-annot` does not remove entry points annotations as they are semantically significant.