### PR TITLE
Views (with Love output)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,8 @@ TESTS=$(DOC_TESTS) $(SIMPLE_TESTS) $(MORE_TESTS:=.liq) $(RE_TESTS:=.reliq) $(OTH
 TODO_LOVE_TESTS=doc/doc16.liq doc/doc19.liq doc/doc21.liq doc/doc76.liq \
   test19.liq test_loop_left.liq test_inline.liq \
   test_rec_fun.liq lambda_const.liq others/token_no_fee.liq
-LOVE_TESTS:=$(filter-out $(TODO_LOVE_TESTS) , $(TESTS))
+EXTRA_LOVE_TESTS=test_view.liq
+LOVE_TESTS:=$(filter-out $(TODO_LOVE_TESTS) , $(TESTS)) $(EXTRA_LOVE_TESTS)
 
 tests: build
 	@echo ---------------------

--- a/tests/test_view.liq
+++ b/tests/test_view.liq
@@ -1,0 +1,28 @@
+contract type C0 = sig
+
+  type storage
+  val%entry default : unit
+  val%view get_i : unit -> int
+end
+
+type storage = (int, bool) map
+
+let%entry default (c : [%view (get_i : bool -> int)]) s =
+  if Contract.view c get_i false > 0 then failwith ();
+  [], s
+
+let%entry default2 (c : address) s =
+  match [%view C0.get_i] c with
+  | None -> failwith ()
+  | Some c ->
+    if Contract.view c get_i () > 0 then failwith ();
+    [], s
+
+let%entry default3 (c : address) s =
+  if Contract.view c get_i false > 0 then failwith ();
+  [], s
+
+let%view is_ok i storage : bool =
+  match Map.find i storage with
+  | Some b -> b
+  | None -> false

--- a/tools/liquidity/liquidData.ml
+++ b/tools/liquidity/liquidData.ml
@@ -50,9 +50,9 @@ let rec default_const = function
     CSignature
       "edsigthTzJ8X7MPmNeEwybRAvdxS1pupqcM5Mk4uCuyZAe7uEk\
        68YpuGDeViW8wSXMrCi5CwoNgqs8V2w8ayB5dMJzrYCHhD8C7"
-  | Taddress | Tcontract ((None | Some "default"), _) ->
+  | Taddress | Tcontract_handle ((None | Some "default"), _) ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", None)
-  | Tcontract (e, _) ->
+  | Tcontract_handle (e, _) ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", e)
   | Tchainid -> CString "NetXwhYbWGa82xo"
   | Ttuple l ->
@@ -105,9 +105,9 @@ let rec default_empty_const = function
     CSignature
       "edsigthTzJ8X7MPmNeEwybRAvdxS1pupqcM5Mk4uCuyZAe7uEk\
        68YpuGDeViW8wSXMrCi5CwoNgqs8V2w8ayB5dMJzrYCHhD8C7"
-  | Taddress | Tcontract ((None | Some "default"), _) ->
+  | Taddress | Tcontract_handle ((None | Some "default"), _) ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", None)
-  | Tcontract (e, _) ->
+  | Tcontract_handle (e, _) ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", e)
   | Tchainid -> CString "NetXwhYbWGa82xo"
   | Ttuple l ->
@@ -162,9 +162,9 @@ let rec default_empty_untyped_const = function
     CSignature
       "edsigthTzJ8X7MPmNeEwybRAvdxS1pupqcM5Mk4uCuyZAe7uEk\
        68YpuGDeViW8wSXMrCi5CwoNgqs8V2w8ayB5dMJzrYCHhD8C7"
-  | Taddress | Tcontract ((None | Some "default"), _) ->
+  | Taddress | Tcontract_handle ((None | Some "default"), _) ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", None)
-  | Tcontract (e, _) ->
+  | Tcontract_handle (e, _) ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", e)
   | Tchainid -> CString "NetXwhYbWGa82xo"
   | Ttuple l ->

--- a/tools/liquidity/liquidData.ml
+++ b/tools/liquidity/liquidData.ml
@@ -50,7 +50,7 @@ let rec default_const = function
     CSignature
       "edsigthTzJ8X7MPmNeEwybRAvdxS1pupqcM5Mk4uCuyZAe7uEk\
        68YpuGDeViW8wSXMrCi5CwoNgqs8V2w8ayB5dMJzrYCHhD8C7"
-  | Taddress | Tcontract_handle ((None | Some "default"), _) ->
+  | Taddress | Tcontract_handle ((None | Some "default"), _) | Tcontract_view _ ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", None)
   | Tcontract_handle (e, _) ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", e)
@@ -105,7 +105,7 @@ let rec default_empty_const = function
     CSignature
       "edsigthTzJ8X7MPmNeEwybRAvdxS1pupqcM5Mk4uCuyZAe7uEk\
        68YpuGDeViW8wSXMrCi5CwoNgqs8V2w8ayB5dMJzrYCHhD8C7"
-  | Taddress | Tcontract_handle ((None | Some "default"), _) ->
+  | Taddress | Tcontract_handle ((None | Some "default"), _) | Tcontract_view _ ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", None)
   | Tcontract_handle (e, _) ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", e)
@@ -162,7 +162,7 @@ let rec default_empty_untyped_const = function
     CSignature
       "edsigthTzJ8X7MPmNeEwybRAvdxS1pupqcM5Mk4uCuyZAe7uEk\
        68YpuGDeViW8wSXMrCi5CwoNgqs8V2w8ayB5dMJzrYCHhD8C7"
-  | Taddress | Tcontract_handle ((None | Some "default"), _) ->
+  | Taddress | Tcontract_handle ((None | Some "default"), _) | Tcontract_view _ ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", None)
   | Tcontract_handle (e, _) ->
     CContract ("KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi", e)

--- a/tools/liquidity/liquidDecode.ml
+++ b/tools/liquidity/liquidDecode.ml
@@ -285,9 +285,11 @@ and entry_of_case param_constrs top_storage (pat, body, fee_body) =
         parameter;
         parameter_name;
         storage_name;
+        return = None;
       };
       code = decode body;
       fee_code;
+      view = false;
     }
   | _ -> raise Exit
 

--- a/tools/liquidity/liquidDecode.ml
+++ b/tools/liquidity/liquidDecode.ml
@@ -113,7 +113,7 @@ and decode ( exp : encoded_exp ) : typed_exp =
     let amount = decode amount in
     let contract = decode contract in
     let entry = match contract.ty, entry with
-      | Tcontract (Some e, _ ), _ | _, Some e -> Some e
+      | Tcontract_handle (Some e, _ ), _ | _, Some e -> Some e
       | _, None -> None in
     let arg = decode arg in
     let desc = Call { contract; amount; entry; arg } in

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -48,7 +48,7 @@ let const_name_of_datatype = function
   | Tset _ -> "s"
   | Tmap _ -> "map"
   | Tbigmap _ -> "bigmap"
-  | Tcontract _ -> "contrat"
+  | Tcontract_handle _ -> "contrat"
   | Tor _ -> "or"
   | Tlambda _ | Tclosure _  -> "fun"
   | Tfail -> "fail"

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -816,9 +816,11 @@ and decompile env contract =
     entries = [{ entry_sig = { entry_name;
                                parameter = contract.mic_parameter;
                                parameter_name;
-                               storage_name };
+                               storage_name;
+                               return = None };
                  code;
-                 fee_code }];
+                 fee_code;
+                 view = false }];
     c_init = None;
     subs = [];
     ty_env = env ;

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -55,7 +55,7 @@ let const_name_of_datatype = function
   | Toperation -> "op"
   | Taddress -> "addr"
   | Tchainid -> "chain"
-  | Tvar _ | Tpartial _ -> assert false
+  | Tvar _ | Tpartial _ | Tcontract_view _ -> assert false
 
 
 let vars_nums = Hashtbl.create 101

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -451,7 +451,8 @@ let rec decompile_next (env : env) node =
 
     | N_CONTRACT (entry, entry_param), [arg] ->
       let entry = match entry with None -> "default" | Some e -> e in
-      mklet env node (ContractAt { arg = arg_of arg; entry; entry_param })
+      mklet env node (ContractAt { arg = arg_of arg;
+                                   entry = Entry entry; entry_param })
 
     | N_UNPACK ty, [arg] ->
       mklet env node (Unpack { arg = arg_of arg; ty })
@@ -637,18 +638,27 @@ let rec decompile_next (env : env) node =
                     amount = arg_of amount })
 
 
+
     | N_CALL, [ { kind = N_SELF entry }; amount; arg] ->
       let entry = match entry with None -> "default" | Some e -> e in
       mklet env node
-        (SelfCall { amount = arg_of amount;
-                    entry;
-                    arg = arg_of arg })
+        (Call { contract = DSelf;
+                amount = Some (arg_of amount);
+                entry = Entry entry;
+                arg = arg_of arg })
+
+    (* | N_CALL, [ { kind = N_SELF entry }; amount; arg] ->
+     *   let entry = match entry with None -> "default" | Some e -> e in
+     *   mklet env node
+     *     (SelfCall { amount = arg_of amount;
+     *                 entry;
+     *                 arg = arg_of arg }) *)
 
     | N_CALL, [contract; amount; arg] ->
       mklet env node
-        (Call { contract = arg_of contract;
-                amount = arg_of amount;
-                entry = None;
+        (Call { contract = DContract (arg_of contract);
+                amount = Some (arg_of amount);
+                entry = NoEntry;
                 arg = arg_of arg })
 
     | N_CREATE_CONTRACT contract, args ->

--- a/tools/liquidity/liquidEncode.ml
+++ b/tools/liquidity/liquidEncode.ml
@@ -275,6 +275,8 @@ let rec encode_type ?(decompiling=false) ty =
     Tsum (name, List.map (fun (c, ty) -> c, encode_type ~decompiling ty) cstys)
   | Tcontract_handle (entry, param) ->
     Tcontract_handle (entry, encode_type ~decompiling param)
+  | Tcontract_view (v, p, r) ->
+    Tcontract_view (v, encode_type ~decompiling p, encode_type ~decompiling r)
   | Tvar _ | Tpartial _ ->
     (* Removed during typechecking (if monomorphized)  *)
     ty
@@ -330,6 +332,7 @@ let rec allowed_type
   | Tcontract_handle (_, t) ->
     allow_contract &&
     allowed_type ~allow_big_map ~allow_operation:false ~allow_contract:true t
+  | Tcontract_view (_, _, _) -> assert false (* Not in Michelson *)
   | Tor (t1, t2) ->
     allowed_type ~allow_big_map ~allow_operation ~allow_contract t1 &&
     allowed_type ~allow_big_map ~allow_operation ~allow_contract t2

--- a/tools/liquidity/liquidEncode.ml
+++ b/tools/liquidity/liquidEncode.ml
@@ -273,8 +273,8 @@ let rec encode_type ?(decompiling=false) ty =
     Trecord (name, List.map (fun (l, ty) -> l, encode_type ~decompiling ty) labels)
   | Tsum (name, cstys) ->
     Tsum (name, List.map (fun (c, ty) -> c, encode_type ~decompiling ty) cstys)
-  | Tcontract (entry, param) ->
-    Tcontract (entry, encode_type ~decompiling param)
+  | Tcontract_handle (entry, param) ->
+    Tcontract_handle (entry, encode_type ~decompiling param)
   | Tvar _ | Tpartial _ ->
     (* Removed during typechecking (if monomorphized)  *)
     ty
@@ -327,7 +327,7 @@ let rec allowed_type
     allowed_type ~allow_big_map ~allow_operation ~allow_contract t
   | Tlist t | Toption t ->
     allowed_type ~allow_big_map ~allow_operation ~allow_contract t
-  | Tcontract (_, t) ->
+  | Tcontract_handle (_, t) ->
     allow_contract &&
     allowed_type ~allow_big_map ~allow_operation:false ~allow_contract:true t
   | Tor (t1, t2) ->

--- a/tools/liquidity/liquidEncode.ml
+++ b/tools/liquidity/liquidEncode.ml
@@ -1558,9 +1558,11 @@ and encode_contract ?(annot=false) ?(decompiling=false) contract =
           parameter_name = pname;
           storage_name;
           parameter = encode_parameter_type env parameter;
+          return = None;
         };
         code;
         fee_code;
+        view = false;
       }];
     ty_env = contract.ty_env;
     c_init;

--- a/tools/liquidity/liquidFromParsetree.ml
+++ b/tools/liquidity/liquidFromParsetree.ml
@@ -263,9 +263,9 @@ let rec translate_type env ?expected typ =
 
   | { ptyp_desc = Ptyp_extension ({ txt = "handle" }, PTyp t) } ->
     let expected = match expected with
-      | Some Tcontract (_, t) -> Some t
+      | Some Tcontract_handle (_, t) -> Some t
       | _ -> None in
-    Tcontract (None, translate_type env ?expected t)
+    Tcontract_handle (None, translate_type env ?expected t)
 
   | { ptyp_desc = Ptyp_constr ({ txt = ty_name; loc }, params); ptyp_loc } ->
     let ty_name = str_of_id ty_name in
@@ -368,7 +368,7 @@ let rec set_curry_flag ty = match ty with
   | Tunit | Tbool | Tint | Tnat | Ttez | Tstring | Tbytes | Ttimestamp | Tkey
   | Tkey_hash | Tsignature | Toperation | Taddress | Tfail | Tchainid -> ()
   | Ttuple tyl -> List.iter set_curry_flag tyl
-  | Toption ty | Tlist ty | Tset ty | Tcontract (_, ty) -> set_curry_flag ty
+  | Toption ty | Tlist ty | Tset ty | Tcontract_handle (_, ty) -> set_curry_flag ty
   | Tmap (ty1, ty2) | Tbigmap (ty1, ty2) | Tor (ty1, ty2) ->
     set_curry_flag ty1; set_curry_flag ty2
   | Tlambda (ty1, ty2, u) ->

--- a/tools/liquidity/liquidInfer.ml
+++ b/tools/liquidity/liquidInfer.ml
@@ -912,15 +912,16 @@ and contract_tvars_to_unit ~keep_tvars (contract : typed_contract) =
              init_args = List.map (fun (x, loc, ty) ->
                  x, loc, vars_to_unit ~loc ty) init_args;
              init_body = tvars_to_unit init_body } in
-  let entries = List.map (fun { entry_sig; code; fee_code } ->
+  let entries = List.map (fun { entry_sig; code; fee_code; view } ->
       { entry_sig = { entry_sig with
                       parameter =
                         vars_to_unit ~loc:(code : typed_exp).loc
                           entry_sig.parameter };
         code = tvars_to_unit code;
+        view;
         fee_code = match fee_code with
           | None -> None
-          | Some fee_code -> Some (tvars_to_unit fee_code)
+          | Some fee_code -> Some (tvars_to_unit fee_code);
       }) contract.entries in
   let rec env_tvars_to_unit ty_env = {
     ty_env with
@@ -1156,6 +1157,7 @@ and mono_contract vtys c =
           (string_of_type pty);
       { code;
         fee_code;
+        view = e.view;
         entry_sig = { e.entry_sig with parameter = pty } }
     ) c.entries in
   let c_init = match c.c_init with

--- a/tools/liquidity/liquidInit.ml
+++ b/tools/liquidity/liquidInit.ml
@@ -79,8 +79,12 @@ let tmp_contract_of_init ~loc env (init : (datatype, 'a) exp LiquidTypes.init) s
     entries = [{ entry_sig = { entry_name = "default";
                                parameter;
                                parameter_name = "_parameter";
-                               storage_name = "_storage" };
-                 code; fee_code = None }];
+                               storage_name = "_storage";
+                               return = None };
+                 code;
+                 fee_code = None;
+                 view = false;
+               }];
     ty_env = env;
     c_init = None;
     subs = [];

--- a/tools/liquidity/liquidInterp.ml
+++ b/tools/liquidity/liquidInterp.ml
@@ -257,7 +257,8 @@ let rec constrlabel_is_in_type c = function
     false
   | Ttuple tys -> List.exists (constrlabel_is_in_type c) tys
   | Toption ty | Tlist ty | Tset ty | Tcontract_handle (_, ty) -> constrlabel_is_in_type c ty
-  | Tmap (t1, t2) | Tbigmap (t1, t2) | Tor (t1, t2) | Tlambda (t1, t2, _) ->
+  | Tmap (t1, t2) | Tbigmap (t1, t2) | Tor (t1, t2) | Tlambda (t1, t2, _) |
+    Tcontract_view (_, t1, t2) ->
     constrlabel_is_in_type c t1 || constrlabel_is_in_type c t2
   | Tclosure ((t1, t2), t3, _) ->
     constrlabel_is_in_type c t1 ||

--- a/tools/liquidity/liquidInterp.ml
+++ b/tools/liquidity/liquidInterp.ml
@@ -256,7 +256,7 @@ let rec constrlabel_is_in_type c = function
   | Tkey | Tkey_hash | Tsignature | Toperation | Taddress | Tfail | Tchainid ->
     false
   | Ttuple tys -> List.exists (constrlabel_is_in_type c) tys
-  | Toption ty | Tlist ty | Tset ty | Tcontract (_, ty) -> constrlabel_is_in_type c ty
+  | Toption ty | Tlist ty | Tset ty | Tcontract_handle (_, ty) -> constrlabel_is_in_type c ty
   | Tmap (t1, t2) | Tbigmap (t1, t2) | Tor (t1, t2) | Tlambda (t1, t2, _) ->
     constrlabel_is_in_type c t1 || constrlabel_is_in_type c t2
   | Tclosure ((t1, t2), t3, _) ->

--- a/tools/liquidity/liquidMichelson.ml
+++ b/tools/liquidity/liquidMichelson.ml
@@ -213,7 +213,7 @@ let rec compile_desc depth env ~loc desc =
     amount @
     [ push ~loc Tunit CUnit; ii ~loc TRANSFER_TOKENS ]
 
-  | Call { contract = ({ ty = Tcontract _ } as contract);
+  | Call { contract = ({ ty = Tcontract_handle _ } as contract);
            amount; entry; arg } ->
     (* Contract.call compiled to TRANSFER_TOKENS *)
     let contract = compile depth env contract in

--- a/tools/liquidity/liquidNamespace.ml
+++ b/tools/liquidity/liquidNamespace.ml
@@ -191,6 +191,10 @@ let rec normalize_type ?from_env ~in_env ty =
              normalize_type ?from_env ~in_env t2, u)
   | Tcontract_handle (e, ty) ->
     Tcontract_handle (e, normalize_type ?from_env ~in_env ty)
+  | Tcontract_view (v, t1, t2) ->
+    Tcontract_view (v,
+                    normalize_type ?from_env ~in_env t1,
+                    normalize_type ?from_env ~in_env t2)
   | Trecord (name, fields) ->
     let _, found_env =
       try find_type_loose ~loc:noloc name in_env []

--- a/tools/liquidity/liquidNamespace.ml
+++ b/tools/liquidity/liquidNamespace.ml
@@ -189,8 +189,8 @@ let rec normalize_type ?from_env ~in_env ty =
   | Tlambda (t1, t2, u) ->
     Tlambda (normalize_type ?from_env ~in_env t1,
              normalize_type ?from_env ~in_env t2, u)
-  | Tcontract (e, ty) ->
-    Tcontract (e, normalize_type ?from_env ~in_env ty)
+  | Tcontract_handle (e, ty) ->
+    Tcontract_handle (e, normalize_type ?from_env ~in_env ty)
   | Trecord (name, fields) ->
     let _, found_env =
       try find_type_loose ~loc:noloc name in_env []

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -74,7 +74,7 @@ module Michelson = struct
     | Tfail | Tunit | Tbool | Tint   | Tnat | Ttez | Tstring | Tbytes
     | Ttimestamp | Tkey | Tkey_hash | Tsignature | Toperation | Taddress | Tchainid ->
       true
-    | Ttuple _ | Trecord _ | Tsum _ | Tcontract _ | Tor _ | Toption _ | Tlist _
+    | Ttuple _ | Trecord _ | Tsum _ | Tcontract_handle _ | Tor _ | Toption _ | Tlist _
     | Tset _ | Tmap _ | Tbigmap _ | Tlambda _ | Tclosure _ ->
       false
     | Tvar _ -> true
@@ -104,7 +104,7 @@ module Michelson = struct
         bprint_type_record name fmt b indent labels annots
       | Tsum (name, constrs) ->
         bprint_type_sum name fmt b indent constrs annots
-      | Tcontract (_entry, ty) ->
+      | Tcontract_handle (_entry, ty) ->
         let indent = fmt.increase_indent indent in
         Printf.bprintf b "(contract";
         bprint_annots b annots;
@@ -926,11 +926,11 @@ module LiquidDebug = struct
           ) rtys;
       | Tsum (Some name, _) ->
         Printf.bprintf b "%s" name;
-      | Tcontract (Some entry, ty) ->
+      | Tcontract_handle (Some entry, ty) ->
         Printf.bprintf b "[%%handle %s : " entry;
         bprint_type b "" ty;
         Printf.bprintf b "]";
-      | Tcontract (None, ty) ->
+      | Tcontract_handle (None, ty) ->
         Printf.bprintf b "[%%handle ";
         bprint_type b "" ty;
         Printf.bprintf b "]";

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -74,7 +74,8 @@ module Michelson = struct
     | Tfail | Tunit | Tbool | Tint   | Tnat | Ttez | Tstring | Tbytes
     | Ttimestamp | Tkey | Tkey_hash | Tsignature | Toperation | Taddress | Tchainid ->
       true
-    | Ttuple _ | Trecord _ | Tsum _ | Tcontract_handle _ | Tor _ | Toption _ | Tlist _
+    | Ttuple _ | Trecord _ | Tsum _ | Tcontract_handle _ | Tcontract_view _
+    | Tor _ | Toption _ | Tlist _
     | Tset _ | Tmap _ | Tbigmap _ | Tlambda _ | Tclosure _ ->
       false
     | Tvar _ -> true
@@ -111,6 +112,7 @@ module Michelson = struct
         Printf.bprintf b "%c%s" fmt.newline indent;
         bprint_type fmt b indent ty [];
         Printf.bprintf b ")";
+      | Tcontract_view _ -> assert false
       | Tor (ty1, ty2) ->
         let indent = fmt.increase_indent indent in
         Printf.bprintf b "(or";
@@ -933,6 +935,12 @@ module LiquidDebug = struct
       | Tcontract_handle (None, ty) ->
         Printf.bprintf b "[%%handle ";
         bprint_type b "" ty;
+        Printf.bprintf b "]";
+      | Tcontract_view (v, t1, t2) ->
+        Printf.bprintf b "[%%view %s : " v;
+        bprint_type b "" t1;
+        Printf.bprintf b " -> ";
+        bprint_type b "" t2;
         Printf.bprintf b "]";
       | Tor (ty1, ty2) ->
         Printf.bprintf b "(";

--- a/tools/liquidity/liquidSimplify.ml
+++ b/tools/liquidity/liquidSimplify.ml
@@ -63,7 +63,13 @@ let rec compute decompile code to_inline =
     | Fold { body; arg; acc }
     | MapFold { body; arg; acc } -> 30 + size body + size arg + size acc
     | Call { contract; amount; arg } ->
-      1 + size contract + size amount + size arg
+      let sc = match contract with
+        | DContract c -> size c
+        | DSelf -> 0 in
+      let sa = match amount with
+        | Some a -> size a
+        | None -> 0 in
+      1 + sc + sa + size arg
     | SelfCall { amount; arg } ->
       1 + size amount + size arg
     | Transfer { dest; amount } ->
@@ -309,8 +315,12 @@ let rec compute decompile code to_inline =
       { exp with desc = Transfer { dest; amount } }
 
     | Call { contract; amount; entry; arg } ->
-      let contract = iter contract in
-      let amount = iter amount in
+      let contract = match contract with
+        | DContract c -> DContract (iter c)
+        | DSelf -> DSelf in
+      let amount = match amount with
+        | Some a -> Some (iter a)
+        | None -> None in
       let arg = iter arg in
       { exp with desc = Call { contract; amount; entry; arg } }
 

--- a/tools/liquidity/liquidToParsetree.ml
+++ b/tools/liquidity/liquidToParsetree.ml
@@ -98,7 +98,7 @@ module HAbbrev = Hashtbl.Make (struct
         Trecord ("", List.map (fun (fn, fty) -> (fn, erase_names fty)) fl)
       | Tsum (_sn, cl) ->
         Tsum (None, List.map (fun (cn, cty) -> (cn, erase_names cty)) cl)
-      | Tcontract (entry, ty) -> Tcontract (entry, erase_names ty)
+      | Tcontract_handle (entry, ty) -> Tcontract_handle (entry, erase_names ty)
     let hash ty = Hashtbl.hash (erase_names ty)
     let equal ty1 ty2 = eq_types (erase_names ty1) (erase_names ty2)
   end)
@@ -206,7 +206,7 @@ let rec convert_type ~abbrev ?name ty =
           (StringMap.bindings subst)
       with Not_found -> params in
     typ_constr name args
-  | Tcontract (_, ty) ->
+  | Tcontract_handle (_, ty) ->
     Typ.extension (id "handle", PTyp (convert_type ~abbrev ty))
   | Tvar { contents = { contents = { id; tyo = None | Some Tpartial _ }}} ->
     Typ.var id
@@ -220,7 +220,7 @@ let rec convert_type ~abbrev ?name ty =
       let caml_ty, t_name = match ty with
         | Ttez | Tunit | Ttimestamp | Tint | Tnat | Tbool
         | Tkey | Tkey_hash | Tsignature | Tstring | Tbytes | Toperation | Taddress
-        | Tfail | Trecord _ | Tsum _ | Tcontract _ | Tchainid -> assert false
+        | Tfail | Trecord _ | Tsum _ | Tcontract_handle _ | Tchainid -> assert false
         | Ttuple args ->
           Typ.tuple (List.map (convert_type ~abbrev) args), "pair_t"
         | Tor (x,y) ->

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -125,6 +125,7 @@ and entry_sig = {
   storage_name : string;   (** name of the storage argument (type is
                                common to all entry points in a
                                contract) *)
+  return : datatype option;(** return type for views *)
 }
 
 (** An entry point *)
@@ -132,6 +133,7 @@ and 'exp entry = {
   entry_sig : entry_sig; (** Signature of the entry point *)
   code : 'exp;           (** Liquidity code for the entry point *)
   fee_code : 'exp option;(** Code for the entry point's fees *)
+  view : bool;
 }
 
 (** Global values *)
@@ -1637,6 +1639,7 @@ let contract_sig_of_default ?sig_name parameter = {
       parameter;
       parameter_name = "parameter";
       storage_name = "storage";
+      return = None;
     }];
 }
 

--- a/tools/liquidity/liquidUntype.ml
+++ b/tools/liquidity/liquidUntype.ml
@@ -326,6 +326,7 @@ and untype_entry env (entry : (datatype, 'a) exp entry) =
                 };
     code;
     fee_code;
+    view = entry.view;
   }
 
 and untype_contract contract =

--- a/tools/liquidity/liquidUntype.ml
+++ b/tools/liquidity/liquidUntype.ml
@@ -209,9 +209,13 @@ let rec untype (env : env) (code : (datatype, 'a) exp) : (unit, 'b) exp =
                  amount = untype env amount }
 
     | Call { contract; amount; entry; arg } ->
-      Call { contract = untype env contract;
-             amount = untype env amount;
-             entry;
+      let contract = match contract with
+        | DSelf -> DSelf
+        | DContract c -> DContract (untype env c) in
+      let amount = match amount with
+        | None -> None
+        | Some a -> Some (untype env a) in
+      Call { contract; amount; entry;
              arg = untype env arg }
 
     | Self { entry } -> Self { entry }

--- a/tools/liquidity/with-dune-network/liquidFromMicheline.ml
+++ b/tools/liquidity/with-dune-network/liquidFromMicheline.ml
@@ -276,7 +276,7 @@ let rec convert_type ?(parameter=false) env expr =
 
     | Prim(_, "contract", [x], annots) ->
       let parameter = convert_type env x in
-      Tcontract (None, parameter)
+      Tcontract_handle (None, parameter)
 
     | Prim(_, "lambda", [x;y], _debug) ->
       Tlambda
@@ -410,7 +410,7 @@ let rec convert_const env ?ty expr =
           CTimestamp (ISO8601.of_string s)
         | Some Tkey -> CKey s
         | Some Tkey_hash -> CKey_hash s
-        | Some Taddress | Some Tcontract _ ->
+        | Some Taddress | Some Tcontract_handle _ ->
           (match String.split_on_char '%' s with
            | [s] -> CContract (s, None)
            | [s; e] -> CContract (s, Some e)
@@ -434,7 +434,7 @@ let rec convert_const env ?ty expr =
         | Some Tsignature ->
           (* CSignature Ed25519.Signature.(to_b58check s) *)
           CSignature (to_hex s)
-        | Some (Taddress | Tcontract _) ->
+        | Some (Taddress | Tcontract_handle _) ->
           let c = MBytes.sub s 0 22 in
           let e = MBytes.sub s 22 (MBytes.length s - 22) in
           let e =

--- a/tools/liquidity/with-dune-network/liquidToMicheline.ml
+++ b/tools/liquidity/with-dune-network/liquidToMicheline.ml
@@ -122,7 +122,7 @@ let rec convert_type ~loc ?parameter expr =
   | Ttuple (x :: tys) ->
     prim_type ~loc "pair" [convert_type ~loc x; convert_type ~loc (Ttuple tys)]
   | Tor (x,y) -> prim_type ~loc "or" [convert_type ~loc x; convert_type ~loc y]
-  | Tcontract (e, parameter) ->
+  | Tcontract_handle (e, parameter) ->
     prim_type ~loc "contract" [convert_type ~loc parameter]
   | Tlambda (x,y, _) ->
     prim_type ~loc "lambda" [convert_type ~loc x;

--- a/tools/liquidity/with-dune-network/liquidToMicheline.ml
+++ b/tools/liquidity/with-dune-network/liquidToMicheline.ml
@@ -138,7 +138,7 @@ let rec convert_type ~loc ?parameter expr =
   | Trecord (name, labels) -> convert_record_type ~loc ?parameter name labels
   | Tsum (name, constrs) -> convert_sum_type ~loc ?parameter name constrs
   | Tfail -> convert_type ~loc Tunit (* use unit for failures *)
-  | Tvar _ | Tpartial _ -> assert false
+  | Tvar _ | Tpartial _ | Tcontract_view _ -> assert false
 
 and convert_record_type ~loc ?parameter name labels =
   convert_composed_type "pair" ~loc ?parameter (Some name) labels

--- a/tools/love/compil_utils.ml
+++ b/tools/love/compil_utils.ml
@@ -632,6 +632,12 @@ let get_signature_from_name name ty tenv =
     sig_content = [name, SEntry ty]
   }
 
+let view_signature tenv name ty =
+  TYPE.Anonymous {
+    TYPE.sig_kind = Contract [];
+    sig_content = [name, SView ty]
+  }
+
 let the = function
     None -> failwith "Compil_utils.the"
   | Some o -> o

--- a/tools/love/compil_utils.ml
+++ b/tools/love/compil_utils.ml
@@ -99,6 +99,7 @@ let bigmap (t, t') = Love_type_list.get_type "bigmap" [t; t']
 let option t = Love_type_list.get_type "option" [t]
 let variant (t, t') = Love_type_list.get_type "variant" [t; t']
 let entrypoint t = Love_type_list.get_type "entrypoint" [t]
+let tview t = Love_type_list.get_type "view" [t]
 
 let to_poly_variant = function
   | TUser (LName "unit", [])      -> `TUnit

--- a/tools/love/liq2love.ml
+++ b/tools/love/liq2love.ml
@@ -458,7 +458,7 @@ and liqtype_to_lovetype ?loc ?(aliases=StringMap.empty) (env : env) tv =
         UnknownType (name, f, e, loc) ->
         raise (UnknownType (name, (fun t -> let t1 = f t in t2 t1), e, loc))
     in t2 t1
-  | Tcontract (s, c) ->
+  | Tcontract_handle (s, c) ->
     let ty = ltl c in
     TContractInstance (Compil_utils.get_signature_from_name s ty env)
   | Tor (t1,t2) -> (
@@ -1157,7 +1157,7 @@ let rec liqexp_to_loveexp (env : env) (e : typed_exp) : AST.exp * TYPE.t =
         let tmp_ctrname = "CalledContract" in
         let tmp_entrypt = "entry_pt" in
         match contract.ty with
-          Tcontract (cname, ty) ->
+          Tcontract_handle (cname, ty) ->
           let cssig, entry_typ =
             let ty = liqtype_to_lovetype env ty in
             Compil_utils.get_signature_from_name cname ty env, ty
@@ -2935,7 +2935,7 @@ let contract_to_lovevalue env ~ty addr =
     error "Love compile const: Not a valid contract %s." addr
   | Ok c ->
     match ty with
-    | Some (Tcontract (entry, paramty)) ->
+    | Some (Tcontract_handle (entry, paramty)) ->
       let entry = match entry with None -> "default" | Some e -> e in
       let love_sig = {
         sig_kind = Contract [];
@@ -3046,7 +3046,7 @@ let rec liqconst_to_lovevalue
 
     | CKey_hash kh -> (
         match ty with
-        | Some (Taddress | Tcontract _ ) ->
+        | Some (Taddress | Tcontract_handle _ ) ->
           contract_to_lovevalue env ~ty kh
         | _ ->
           match Signature.Public_key_hash.of_b58check_opt kh with

--- a/tools/love/liq2love.ml
+++ b/tools/love/liq2love.ml
@@ -461,6 +461,11 @@ and liqtype_to_lovetype ?loc ?(aliases=StringMap.empty) (env : env) tv =
   | Tcontract_handle (s, c) ->
     let ty = ltl c in
     TContractInstance (Compil_utils.get_signature_from_name s ty env)
+  | Tcontract_view (v, param, ret) ->
+    let param = ltl param in
+    let ret = ltl ret in
+    let ty = TArrow (param, ret) in
+    TContractInstance (Compil_utils.view_signature env v ty)
   | Tor (t1,t2) -> (
       let t1 = ltl t1 and t2 = ltl t2 in
       let sumtyp = variant (t1,t2) in

--- a/tools/love/preprocess.ml
+++ b/tools/love/preprocess.ml
@@ -92,9 +92,13 @@ let rec ttfail_to_tvar ({ desc; ty; loc } as e) =
       Transfer { dest = ttfail_to_tvar dest;
                  amount = ttfail_to_tvar amount }, tfail_to_tvar ty
     | Call { contract; amount; entry; arg } ->
-      Call { contract = ttfail_to_tvar contract;
-             amount = ttfail_to_tvar amount;
-             entry;
+      let contract = match contract with
+        | DSelf -> DSelf
+        | DContract c -> DContract (ttfail_to_tvar c) in
+      let amount = match amount with
+        | None -> None
+        | Some a -> Some (ttfail_to_tvar a) in
+      Call { contract; amount; entry;
              arg = ttfail_to_tvar arg }, tfail_to_tvar ty
     | MatchOption { arg; ifnone; some_name; ifsome } ->
       let ifnone = ttfail_to_tvar ifnone in

--- a/tools/love/preprocess.ml
+++ b/tools/love/preprocess.ml
@@ -321,14 +321,15 @@ and contract_ttfail_to_tvar (contract : typed_contract) =
                debug "[Preprocess.contract_ttfail_to_tvar] Preprocessing body of %s@." init_name;
                ttfail_to_tvar init_body
              )} in
-  let entries = List.map (fun { entry_sig; code } ->
+  let entries = List.map (fun { entry_sig; code; view; _ } ->
       debug "[Preprocess.contract_ttfail_to_tvar] Preprocessing entry %s@." entry_sig.entry_name;
       { entry_sig = { entry_sig with
                       parameter =
                         tfail_to_tvar ~loc:(code : typed_exp).loc
                           entry_sig.parameter };
         code = ttfail_to_tvar code;
-        fee_code = None
+        fee_code = None; (* TODO *)
+        view;
       }) contract.entries in
   let rec env_ttfail_to_tvar ty_env = {
     ty_env with

--- a/tools/love/preprocess.ml
+++ b/tools/love/preprocess.ml
@@ -19,7 +19,7 @@ let rec tfail_to_tvar ?loc ty = match ty with
     Trecord (rn, List.map (fun (fn, fty) -> (fn, tfail_to_tvar ?loc fty)) fl)
   | Tsum (sn, cl) ->
     Tsum (sn, List.map (fun (cn, cty) -> (cn, tfail_to_tvar ?loc cty)) cl)
-  | Tcontract (s, c) -> Tcontract (s, tfail_to_tvar ?loc c)
+  | Tcontract_handle (s, c) -> Tcontract_handle (s, tfail_to_tvar ?loc c)
   | Tvar { contents = { contents = { tyo = Some ty; id }}} ->
     debug "[Preprocess.tfail_to_tvar] TVar %s aliased" id;
     tfail_to_tvar ?loc ty

--- a/tools/love/preprocess.ml
+++ b/tools/love/preprocess.ml
@@ -20,6 +20,8 @@ let rec tfail_to_tvar ?loc ty = match ty with
   | Tsum (sn, cl) ->
     Tsum (sn, List.map (fun (cn, cty) -> (cn, tfail_to_tvar ?loc cty)) cl)
   | Tcontract_handle (s, c) -> Tcontract_handle (s, tfail_to_tvar ?loc c)
+  | Tcontract_view (v, t1, t2) ->
+    Tcontract_view (v, tfail_to_tvar ?loc t1, tfail_to_tvar ?loc t2)
   | Tvar { contents = { contents = { tyo = Some ty; id }}} ->
     debug "[Preprocess.tfail_to_tvar] TVar %s aliased" id;
     tfail_to_tvar ?loc ty


### PR DESCRIPTION
Declare, define and use views when compiling to Love.
Views can be used to access storage of other contracts without performing tedious contract calls and continuations.