### PR TITLE
Optimizations and externals in Love

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ DUNE_TESTS=$(shell find dune-network/src/bin_client/test/contracts -regex "[^\.]
 
 TESTS=$(DOC_TESTS) $(SIMPLE_TESTS) $(MORE_TESTS:=.liq) $(RE_TESTS:=.reliq) $(OTHER_TESTS:=.liq)
 
-TODO_LOVE_TESTS=doc/doc16.liq doc/doc19.liq doc/doc21.liq doc/doc76.liq \
-  test19.liq test_loop_left.liq test_inline.liq curry.liq \
+TODO_LOVE_TESTS=doc/doc76.liq \
+  test19.liq test_loop_left.liq curry.liq \
   test_rec_fun.liq lambda_const.liq \
   bug_216.liq bug_steven1.liq bug_steven2.liq bug202.reliq \
   others/alias.liq others/token_vote.liq others/token_no_fee.liq

--- a/tools/client/loveTarget.ml
+++ b/tools/client/loveTarget.ml
@@ -132,7 +132,7 @@ module Compiler = struct
     Liq2love.lovevalue_to_liqconst ?ty c
 
   let compile_datatype ty =
-    Liq2love.liqtype_to_lovetype (Love_tenv.empty (Contract []) ()) ty
+    Liq2love.liqtype_to_lovetype (Liq2love.empty_env (Contract [])) ty
 end
 
 include Compiler

--- a/tools/liquidity/build.ocp2
+++ b/tools/liquidity/build.ocp2
@@ -42,7 +42,7 @@
 
 *)
 
-version = "2.1-beta6";
+version = "2.1-beta7";
 
 if(with_version){
     version_info = { ocp2ml=true;

--- a/tools/liquidity/liquidCheck.ml
+++ b/tools/liquidity/liquidCheck.ml
@@ -630,7 +630,12 @@ and typecheck env ( exp : syntax_exp ) : typed_exp =
     let desc = If { cond; ifthen; ifelse } in
     mk ?name:exp.name ~loc desc ty
 
-  | Self { entry } ->
+  | Self { entry = None } ->
+    let ty = Tcontract (sig_of_full_sig env.t_contract_sig) in
+    let desc = Self { entry = None } in
+    mk ?name:exp.name ~loc desc ty
+
+  | Self { entry = Some entry } ->
     let self_entries = env.t_contract_sig.f_entries_sig in
     let parameter  =
       match List.find_opt (fun e -> e.entry_name = entry) self_entries with
@@ -645,7 +650,7 @@ and typecheck env ( exp : syntax_exp ) : typed_exp =
           self_entries;
     in
     let ty = Tcontract_handle (Some entry, parameter) in
-    let desc = Self { entry } in
+    let desc = Self { entry = Some entry } in
     mk ?name:exp.name ~loc desc ty
 
   | Transfer { dest; amount } ->

--- a/tools/liquidity/liquidDecomp.ml
+++ b/tools/liquidity/liquidDecomp.ml
@@ -629,7 +629,7 @@ let rec decompile_next (env : env) node =
     | N_LAMBDA_END _, [arg] -> arg_of arg
 
     | N_SELF entry, [] ->
-      let entry = match entry with None -> "default" | Some e -> e in
+      let entry = match entry with None -> Some "default" | Some _ -> entry in
       mklet env node (Self { entry })
 
     | N_TRANSFER, [dest; amount] ->

--- a/tools/liquidity/liquidMichelson.ml
+++ b/tools/liquidity/liquidMichelson.ml
@@ -266,7 +266,7 @@ let rec compile_desc depth env ~loc desc =
       LiquidLoc.raise_error ~loc
         "Typing error: \
          Self handle is not allowed inside non-inlined functions\n%!";
-    let entry = match entry with "default" -> None | _ -> Some entry in
+    let entry = match entry with Some "default" -> None | _ -> entry in
     [ ii ~loc (SELF entry) ]
 
   | SelfCall { amount; entry; arg } ->

--- a/tools/liquidity/liquidPrinter.ml
+++ b/tools/liquidity/liquidPrinter.ml
@@ -1255,7 +1255,9 @@ module LiquidDebug = struct
       bprint_code_rec ~debug b indent2 arg;
       Printf.bprintf b ")"
 
-    | Self { entry } ->
+    | Self { entry = None } ->
+      Printf.bprintf b "\n%s(Contrac.self ())" indent;
+    | Self { entry = Some entry } ->
       Printf.bprintf b "\n%s[%%handle Self.%s]" indent entry;
     | SelfCall { amount; entry; arg } ->
       Printf.bprintf b "\n%s(Self.%s" indent entry;

--- a/tools/liquidity/liquidToParsetree.ml
+++ b/tools/liquidity/liquidToParsetree.ml
@@ -614,7 +614,12 @@ and convert_code ~abbrev (expr : (datatype, 'a) exp) =
   | Call { amount = None; entry = (Entry _ | NoEntry) } ->
     assert false
 
-  | Self { entry } ->
+  | Self { entry = None } ->
+    Exp.apply ~loc
+      (Exp.ident (lid "Contract.self"))
+      [ Nolabel, Exp.construct (lid "()") None ]
+
+  | Self { entry = Some entry } ->
     Exp.extension (
       id ~loc "handle",
       PStr [

--- a/tools/liquidity/liquidTypes.ml
+++ b/tools/liquidity/liquidTypes.ml
@@ -969,7 +969,7 @@ and ('ty, 'a) exp_desc =
   (** Transfers:
       - {[ Account.transfer ~dest ~amount ]} *)
 
-  | Self of { entry: string }
+  | Self of { entry: string option }
 
   | SelfCall of { amount: ('ty, 'a) exp;
                   entry: string;

--- a/tools/love/compil_utils.ml
+++ b/tools/love/compil_utils.ml
@@ -246,11 +246,6 @@ let merge_args_with_funtyp args arrowtyp =
   in
   List.map (fun (_, e) -> e) args
 
-let add_var ?kind s t env =
-  match s with
-    "_" -> env
-  | _ -> Love_tenv.add_var ?kind s t env
-
 
 (** Returning the corresponding types in t2 that are polymorphic in t1.
     The argument aliases corresponds to the type aliases (such as type t = int). *)
@@ -559,18 +554,6 @@ let mk_primitive_lambda ?loc expected_typ spec_args prim_name =
     )
     | _ -> exp
   in add_not_binded_tvars tprim poly_prim
-
-let mk_primitive_lambda ?loc env ?expected_typ ?(spec_args=ANone) prim_name =
-  Log.debug "[mk_primitive_lambda] Primitive %s%a@."
-    prim_name
-    (fun fmt -> function
-      | None -> ()
-      | Some t -> Format.fprintf fmt " with expected type %a" Love_type.pretty t
-    ) expected_typ ;
-  let expexted_typ = match expected_typ with
-    | None -> None
-    | Some t -> Some (Love_tenv.normalize_type ~relative:true t env) in
-  mk_primitive_lambda ?loc expexted_typ spec_args prim_name
 
 let reserved_types =
   Collections.StringSet.of_list

--- a/tools/love/liq2love.ml
+++ b/tools/love/liq2love.ml
@@ -1174,8 +1174,11 @@ let liqprim_to_loveprim ?loc env (p : primitive) (args : TYPE.t list) =
       (LiquidTypes.string_of_primitive p)
 
   (* extended primitives *)
-  | Prim_extension (s1, _b, _l, _i1, _i2, _s2) ->
-    error ?loc "Primitive %s (%s) is unsupported" s1 (LiquidTypes.string_of_primitive p)
+  | Prim_extension (liq_fun, _effect, _targs, _nb_args, nb_ret, love_inst) ->
+    if nb_ret > 1 then
+      error ?loc "Extention %s (%s) must return one value" liq_fun love_inst;
+    love_inst, args
+
   (* generated in LiquidCheck *)
   | Prim_unused _
   | Prim_collect_call

--- a/tools/love/liq2love.ml
+++ b/tools/love/liq2love.ml
@@ -2660,16 +2660,17 @@ and liqapply_to_loveexp ?loc env typ prim args : AST.exp * TYPE.t =
       [mk_list ~typ:ty @@ List.map (fun e -> fst @@ ltl e) l], ty
 
   | Prim_is_nat, [e] -> (
-    (* if e >= 0 then Some (abs e) else None *)
+    (* if e < 0 then None else Some (abs e) *)
       let lovee, te = ltl e in
       let abs_e = mk_apply ?loc:lloc (mk_primitive_lambda ?loc env "abs") [lovee] in
       mk_if ?loc:lloc
         (mk_apply
-           (mk_primitive_lambda ?loc env "<="
+           (mk_primitive_lambda ?loc env "<"
               ~expected_typ:(te @=> te @=> bool ()))
            [lovee; mk_const @@ mk_cint Z.zero])
-        (mk_some (nat ()) abs_e)
-        (mk_none (nat ())), option (nat ())
+        (mk_none (nat ()))
+        (mk_some (nat ()) abs_e),
+      option (nat ())
     )
   | Prim_int, [cst] -> (
       debug "[liqapply_to_loveexp] Creating a cast@.";


### PR DESCRIPTION
## Trim unused contracts and signatures from output

This optimization is an over-approximation: it is applied only for top-level contracts as
sub(-sub)-contracts can be used outside the contract they are defined in.

## Extended primitives in Love

One can defend extended Love primitives by declaring them as externals with their type.

For instance a primitive for accessing account information can be written:

```ocaml
 external account_get_info :
   address -> (int option * bool * address option * address list)
   = "Account.get_info"
```

Type parameters can also be used, so for example we can redefined the Bytes.unpack primitive.

```ocaml
external unpack : [%type: 'a] -> bytes -> 'a option = "Bytes.unpack"
```

## Improvement: print signature in output

Print signature in verbose output (with `--verbose` or `-V n`) to show what has been compiled.

```
Signature of Dex:
  val%entry default : unit
  val%entry placeSellOrder : (address * nat * nat * nat * timestamp option)
  val%entry placeSellOrderFor : (address * nat * nat * nat * timestamp option * address)
  val%entry placeSellOrderMatching : (address * nat * nat * nat * timestamp option * nat)
  val%entry placeBuyOrder : (address * address * nat * nat * nat * timestamp option)
  val%entry placeBuyOrderFor : (address * address * nat * nat * nat * timestamp option * address)
  val%entry placeBuyOrderMatching : (address * address * nat * nat * nat * timestamp option * nat)
  val%entry cancelSellOrder : nat
  val%entry cancelBuyOrder : nat
  val%entry matchOrders : (nat * nat)
  val%entry cleanOrders : nat list
```

## Fix compilation of `is_nat` in Love