### PR TITLE
Constrain ocaml-migrate-parsetree < 2 in opam dependencies

### DIFF
--- a/docs/sphinx/src/installation/index.rst
+++ b/docs/sphinx/src/installation/index.rst
@@ -9,36 +9,26 @@ To install Liquidity from sources, you will need a working
 installation of OCaml with `OPAM
 <http://opam.ocaml.org/doc/2.0/Install.html>`__ at least version 2.0.
 
-As of Oct 4, 2019, the following process should work:
+As of Sept. 29, 2020, the following process should work:
 
-1. Create an OPAM switch called ``liquidity``, with version 4.06.1 of OCaml::
-     
-    opam switch create liquidity 4.06.1
-
-  This command should take some time to compile the OCaml distribution.
-  Everytime you want to use this switch in a terminal, you should use
-  the following command::
-
-    eval `opam env --switch liquidity`
-    
-2. Checkout the Github repository::
+1. Checkout the Github repository::
      
     git clone https://github.com/OCamlPro/liquidity
     cd liquidity
     
   This command should create a ``liquidity`` directory with the ``next`` branch.
 
-3. Within the ``liquidity`` directory, the Dune Network sources in branch
+2. Within the ``liquidity`` directory, the Dune Network sources in branch
    ``mainnet`` should be in a subdirectory ``dune-network``. This can be
    achieved either with a symbolic link, or by checkouting the sources::
 
      make clone-dune-network
 
-4. Install Liquidity dependencies::
+3. Install Liquidity dependencies::
 
      make build-deps
 
-5. Build and install::
+4. Build and install::
 
      make
      make install
@@ -46,11 +36,11 @@ As of Oct 4, 2019, the following process should work:
   The last command should install the command ``liquidity`` in the
   OPAM switch ``liquidity``.
 
-6. Do a simple test::
+5. Run a simple test::
 
      (cd tests && liquidity test0.liq)
 
-7. Optionally, you can build some local documentation with sphinx
+6. Optionally, you can build some local documentation with sphinx
    and the Read-The-Docs theme (``pip3 install sphinx-rtd-theme``)::
 
      make doc

--- a/opam
+++ b/opam
@@ -28,7 +28,7 @@ depends: [
      "lwt_log"
      "menhir"
      "ocamlfind"
-     "ocaml-migrate-parsetree"
+     "ocaml-migrate-parsetree" { < "2.0.0" }
      "ocp-build"
      "ocplib-endian"
      "ocurl"


### PR DESCRIPTION
Fixes #254 